### PR TITLE
fix: use grapheme segmentation to prevent emoji width overflow crash

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -450,6 +450,11 @@ function buildContentFromParts(
   return " " + parts.join(` ${sepAnsi}${sep}${ansi.reset} `) + ansi.reset + " ";
 }
 
+// Shared grapheme segmenter instance — used to iterate by visual character
+// instead of by code point, so emoji sequences like ⚠️ (U+26A0 + U+FE0F)
+// are measured as a single unit with correct terminal width.
+const graphemeSegmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+
 function truncateWithEllipsisByWidth(text: string, maxWidth: number): string {
   if (maxWidth <= 0) return "";
   if (visibleWidth(text) <= maxWidth) return text;
@@ -459,11 +464,14 @@ function truncateWithEllipsisByWidth(text: string, maxWidth: number): string {
   let truncated = "";
   let truncatedWidth = 0;
 
-  for (const char of text) {
-    const charWidth = visibleWidth(char);
-    if (truncatedWidth + charWidth > targetWidth) break;
-    truncated += char;
-    truncatedWidth += charWidth;
+  // Iterate by grapheme cluster, not by code point.
+  // This ensures multi-codepoint emoji (e.g. ⚠️, 🇺🇸, 👨‍👩‍👧‍👦) are
+  // measured as a single unit with their correct terminal column width.
+  for (const { segment } of graphemeSegmenter.segment(text)) {
+    const segmentWidth = visibleWidth(segment);
+    if (truncatedWidth + segmentWidth > targetWidth) break;
+    truncated += segment;
+    truncatedWidth += segmentWidth;
   }
 
   return truncated.trimEnd() + "…";


### PR DESCRIPTION
## Problem

`truncateWithEllipsisByWidth` iterates over text using `for...of`, which splits by **code point** rather than by **grapheme cluster**. Multi-codepoint emoji sequences get their width miscalculated:

| Emoji | Code Points | Old Width (sum of parts) | Actual Terminal Width |
|-------|------------|--------------------------|----------------------|
| ⚠️ | U+26A0 + U+FE0F | 1 (1 + 0) | **2** |
| 🇺🇸 | U+1F1FA + U+1F1F8 | 4 (2 + 2) | **2** |
| 👨‍👩‍👧‍👦 | 7 code points | 8 | **2** |

This causes the truncated output to be wider than `maxWidth`, resulting in a pi-tui crash:

```
Error: Rendered line 138 exceeds terminal width (95 > 94).

This is likely caused by a custom TUI component not truncating its output.
Use visibleWidth() to measure and truncateToWidth() to truncate lines.
```

The crash is triggered by the "last prompt reminder" widget when the user's prompt contains emoji characters.

## Root Cause

`visibleWidth()` from pi-tui correctly measures the **whole string** width, but when `truncateWithEllipsisByWidth` calls `visibleWidth()` on individual code points and sums them, the result diverges from the actual rendered width:

```ts
// ⚠️ = U+26A0 (WARNING SIGN) + U+FE0F (VARIATION SELECTOR-16)
visibleWidth("⚠️")   // → 2 ✅ (correct)

// But for...of splits it into two code points:
visibleWidth("⚠")    // → 1
visibleWidth("\uFE0F") // → 0
// Sum = 1 ❌ (wrong — terminal renders 2 columns)
```

## Fix

Replace `for (const char of text)` with `Intl.Segmenter` (grapheme granularity), which correctly groups multi-codepoint emoji into single segments:

```ts
const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
for (const { segment } of segmenter.segment(text)) {
  const segmentWidth = visibleWidth(segment);
  // Now ⚠️ is one segment → visibleWidth("⚠️") = 2 ✅
}
```

`Intl.Segmenter` is available in Node.js 16+ and all modern browsers.

## Verification

```
"Mixed: hello ⚠️ 🔥 world" (max=18):
  OLD: visibleWidth = 19 ❌ (exceeds limit)
  NEW: visibleWidth = 16 ✅

"Family: 👨‍👩‍👧‍👦 emoji" (max=15):
  OLD: visibleWidth = 11 (over-truncated)
  NEW: visibleWidth = 15 ✅ (correctly fills available space)
```

Affects all callers: last-prompt reminder widget and stash preview.