### PR TITLE
feat: add icon overrides via theme.json

### DIFF
--- a/icons.ts
+++ b/icons.ts
@@ -18,6 +18,72 @@ export interface IconSet {
   warning: string;
 }
 
+// User icon overrides from theme.json
+type PartialIconSet = Partial<IconSet>;
+
+// Cache for user icon overrides
+let userIconCache: PartialIconSet | null = null;
+let userIconCacheTime = 0;
+const ICON_CACHE_TTL = 5000; // 5 seconds
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sanitizeUserIconOverrides(value: unknown): PartialIconSet {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const sanitized: PartialIconSet = {};
+  const validKeys = Object.keys(NERD_ICONS) as Array<keyof IconSet>;
+
+  for (const key of validKeys) {
+    const rawIcon = value[key];
+    if (typeof rawIcon === "string" && rawIcon.length > 0) {
+      sanitized[key] = rawIcon;
+    }
+  }
+
+  return sanitized;
+}
+
+function loadUserIconOverrides(): PartialIconSet {
+  const now = Date.now();
+  if (userIconCache && now - userIconCacheTime < ICON_CACHE_TTL) {
+    return userIconCache;
+  }
+
+  try {
+    // Inline require for synchronous loading
+    const { fileURLToPath } = require("node:url");
+    const { dirname, join } = require("node:path");
+    const { existsSync, readFileSync } = require("node:fs");
+    
+    const themePath = join(dirname(fileURLToPath(import.meta.url)), "theme.json");
+
+    if (existsSync(themePath)) {
+      const content = readFileSync(themePath, "utf-8");
+      const parsed = JSON.parse(content);
+      const icons = isRecord(parsed) ? parsed.icons : undefined;
+      userIconCache = sanitizeUserIconOverrides(icons);
+      userIconCacheTime = now;
+      return userIconCache;
+    }
+  } catch {
+    // Silently fail - no icon overrides
+  }
+
+  userIconCache = {};
+  userIconCacheTime = now;
+  return userIconCache;
+}
+
+// Merge icon sets with user overrides
+function mergeIcons(base: IconSet, overrides: PartialIconSet): IconSet {
+  return { ...base, ...overrides };
+}
+
 // Separator characters
 export const SEP_DOT = " · ";
 
@@ -148,7 +214,9 @@ export function hasNerdFonts(): boolean {
 }
 
 export function getIcons(): IconSet {
-  return hasNerdFonts() ? NERD_ICONS : ASCII_ICONS;
+  const baseIcons = hasNerdFonts() ? NERD_ICONS : ASCII_ICONS;
+  const userOverrides = loadUserIconOverrides();
+  return mergeIcons(baseIcons, userOverrides);
 }
 
 export function getSeparatorChars(): SeparatorChars {


### PR DESCRIPTION
Closes #13

Allow users to customize icons via theme.json alongside colors:



Uses the same caching and merging pattern as color overrides.

Changes:
- Added icon loading from theme.json (same pattern as colors)
- Added merge logic to combine defaults with user overrides
- Works for both Nerd Font and ASCII modes
- 5-second cache TTL to avoid repeated disk reads

Tested with Hack Nerd Font and Maple Mono NF.

<img width="961" height="80" alt="image" src="https://github.com/user-attachments/assets/0fb53b4a-3fe3-4237-bc7c-86dde3b95c0f" />
