### PR TITLE
feat: add custom path mode with configurable shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,32 @@ The path segment supports three modes:
 | `basename` | `powerline-footer` | Just the directory name (default) |
 | `abbreviated` | `…/extensions/powerline-footer` | Full path with home abbreviated and length limit |
 | `full` | `~/.pi/agent/extensions/powerline-footer` | Complete path with home abbreviated |
+| `custom` | `my-tree//my-project` | Output of a shell command (see below) |
 
 Configure via preset options: `path: { mode: "full" }`
+
+### Custom path command
+
+When `mode` is `"custom"`, the `command` option specifies a shell command whose stdout
+becomes the displayed path. The command runs in the current working directory. Output is
+cached for 5 seconds and falls back to `basename` on error or empty output.
+
+Configure it in `~/.pi/agent/settings.json` under `powerlineSegmentOptions`:
+
+```json
+{
+  "powerlineSegmentOptions": {
+    "path": {
+      "mode": "custom",
+      "command": "my-path-formatter"
+    }
+  }
+}
+```
+
+For example, in a monorepo with multiple git worktrees, a command that prints
+`<tree>/<project>` gives you instant context on which worktree you're in without
+eating your whole status bar.
 
 ## Segments
 

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 
-import type { ColorScheme, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.js";
+import type { ColorScheme, SegmentContext, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions } from "./types.js";
 import { getPreset, PRESETS } from "./presets.js";
 import { getSeparator } from "./separators.js";
 import { renderSegment } from "./segments.js";
@@ -626,12 +626,76 @@ function computeResponsiveLayout(
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// User segment options from settings.json
+// ═══════════════════════════════════════════════════════════════════════════
+
+function parseUserSegmentOptions(settings: Record<string, unknown>): StatusLineSegmentOptions {
+  const raw = settings.powerlineSegmentOptions;
+  if (!isRecord(raw)) return {};
+
+  const opts: StatusLineSegmentOptions = {};
+
+  if (isRecord(raw.path)) {
+    const p: StatusLineSegmentOptions["path"] = {};
+    if (typeof raw.path.mode === "string") {
+      const m = raw.path.mode as string;
+      if (m === "basename" || m === "abbreviated" || m === "full" || m === "custom") {
+        p.mode = m;
+      }
+    }
+    if (typeof raw.path.maxLength === "number") p.maxLength = raw.path.maxLength;
+    if (typeof raw.path.command === "string") p.command = raw.path.command;
+    opts.path = p;
+  }
+
+  if (isRecord(raw.model)) {
+    const m: StatusLineSegmentOptions["model"] = {};
+    if (typeof raw.model.showThinkingLevel === "boolean") m.showThinkingLevel = raw.model.showThinkingLevel;
+    opts.model = m;
+  }
+
+  if (isRecord(raw.git)) {
+    const g: StatusLineSegmentOptions["git"] = {};
+    if (typeof raw.git.showBranch === "boolean") g.showBranch = raw.git.showBranch;
+    if (typeof raw.git.showStaged === "boolean") g.showStaged = raw.git.showStaged;
+    if (typeof raw.git.showUnstaged === "boolean") g.showUnstaged = raw.git.showUnstaged;
+    if (typeof raw.git.showUntracked === "boolean") g.showUntracked = raw.git.showUntracked;
+    opts.git = g;
+  }
+
+  if (isRecord(raw.time)) {
+    const t: StatusLineSegmentOptions["time"] = {};
+    if (raw.time.format === "12h" || raw.time.format === "24h") t.format = raw.time.format;
+    if (typeof raw.time.showSeconds === "boolean") t.showSeconds = raw.time.showSeconds;
+    opts.time = t;
+  }
+
+  return opts;
+}
+
+/** Merge preset options with user overrides (user wins per-segment, shallow merge per key). */
+function mergeSegmentOptions(
+  preset: StatusLineSegmentOptions,
+  user: StatusLineSegmentOptions,
+): StatusLineSegmentOptions {
+  if (!user || Object.keys(user).length === 0) return preset;
+
+  return {
+    model: user.model ? { ...preset.model, ...user.model } : preset.model,
+    path: user.path ? { ...preset.path, ...user.path } : preset.path,
+    git: user.git ? { ...preset.git, ...user.git } : preset.git,
+    time: user.time ? { ...preset.time, ...user.time } : preset.time,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Extension
 // ═══════════════════════════════════════════════════════════════════════════
 
 export default function powerlineFooter(pi: ExtensionAPI) {
   const startupSettings = readSettings();
   const resolvedShortcuts = resolveShortcutConfig(startupSettings);
+  let userSegmentOptions = parseUserSegmentOptions(startupSettings);
 
   let enabled = true;
   let sessionStartTime = Date.now();
@@ -729,6 +793,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const settings = readSettings();
     showLastPrompt = settings.showLastPrompt !== false;
     config.preset = normalizePreset(settings.powerline) ?? "default";
+    userSegmentOptions = parseUserSegmentOptions(settings);
     stashedPromptHistory = readPersistedStashHistory();
 
     getThinkingLevelFn = typeof ctx.getThinkingLevel === "function"
@@ -1351,7 +1416,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       sessionStartTime,
       git: gitStatus,
       extensionStatuses: footerDataRef?.getExtensionStatuses() ?? new Map(),
-      options: presetDef.segmentOptions ?? {},
+      options: mergeSegmentOptions(presetDef.segmentOptions ?? {}, userSegmentOptions),
       theme,
       colors,
     };

--- a/segments.ts
+++ b/segments.ts
@@ -1,9 +1,56 @@
 import { hostname as osHostname } from "node:os";
 import { basename } from "node:path";
+import { execSync } from "node:child_process";
 import { visibleWidth } from "@mariozechner/pi-tui";
 import type { RenderedSegment, SegmentContext, SemanticColor, StatusLineSegment, StatusLineSegmentId } from "./types.js";
 import { fg, rainbow, applyColor } from "./theme.js";
 import { getIcons, SEP_DOT, getThinkingText } from "./icons.js";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Custom path command cache
+// ═══════════════════════════════════════════════════════════════════════════
+
+let customPathCache: { cwd: string; command: string; result: string; timestamp: number } | null = null;
+const CUSTOM_PATH_TTL_MS = 5000;
+
+function getCustomPath(command: string): string {
+  const cwd = process.cwd();
+  const now = Date.now();
+
+  if (
+    customPathCache &&
+    customPathCache.cwd === cwd &&
+    customPathCache.command === command &&
+    now - customPathCache.timestamp < CUSTOM_PATH_TTL_MS
+  ) {
+    return customPathCache.result;
+  }
+
+  try {
+    const result = execSync(command, {
+      cwd,
+      timeout: 2000,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    // Only cache non-empty results; fall back to basename on empty output
+    const value = result || basename(cwd) || cwd;
+    customPathCache = { cwd, command, result: value, timestamp: now };
+    return value;
+  } catch {
+    // Command failed: fall back to basename, cache the fallback so we
+    // don't keep re-running a broken command every render.
+    const fallback = basename(cwd) || cwd;
+    customPathCache = { cwd, command, result: fallback, timestamp: now };
+    return fallback;
+  }
+}
+
+/** Invalidate the custom path cache (e.g. after a directory change). */
+export function invalidateCustomPathCache(): void {
+  customPathCache = null;
+}
 
 // Helper to apply semantic color from context
 function color(ctx: SegmentContext, semantic: SemanticColor, text: string): string {
@@ -89,7 +136,9 @@ const pathSegment: StatusLineSegment = {
     let pwd = process.cwd();
     const home = process.env.HOME || process.env.USERPROFILE;
 
-    if (mode === "basename") {
+    if (mode === "custom" && opts.command) {
+      pwd = getCustomPath(opts.command);
+    } else if (mode === "basename") {
       // Just the last directory component (cross-platform)
       pwd = basename(pwd) || pwd;
     } else {

--- a/types.ts
+++ b/types.ts
@@ -71,8 +71,10 @@ export type StatusLinePreset =
 export interface StatusLineSegmentOptions {
   model?: { showThinkingLevel?: boolean };
   path?: { 
-    mode?: "basename" | "abbreviated" | "full";
+    mode?: "basename" | "abbreviated" | "full" | "custom";
     maxLength?: number;
+    /** Shell command whose stdout is used as the path display (only for mode: "custom"). */
+    command?: string;
   };
   git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
   time?: { format?: "12h" | "24h"; showSeconds?: boolean };


### PR DESCRIPTION
## Situation

The path segment supports `basename`, `abbreviated`, and `full` modes, but none of them work well for monorepo setups with multiple git worktrees. For example, in a repo checked out at `~/src/trees/my-worktree/src/myproj`, `basename` shows just `myproj` (ambiguous across 15+ worktrees) and `full` wastes the entire status bar on a long path.

There is no way to customize how the path is displayed without forking the extension.

## Execution

Two changes:

**1. `custom` path mode with a `command` option.** When `mode` is `"custom"`, the segment runs the configured shell command and uses its stdout as the displayed path. The command runs in the current working directory with a 2s timeout. Output is cached for 5s (keyed on cwd + command string) to avoid re-executing on every render frame. On error or empty output, falls back to `basename`.

**2. `powerlineSegmentOptions` in settings.json.** Previously, segment options could only come from preset definitions. This adds a `powerlineSegmentOptions` key in `~/.pi/agent/settings.json` that lets users override any segment option from any preset. User overrides are shallow-merged per segment on top of the preset defaults, so you can use the `default` preset but swap just the path mode.

Example configuration:

```json
{
  "powerlineSegmentOptions": {
    "path": {
      "mode": "custom",
      "command": "workpath"
    }
  }
}
```
