### PR TITLE
feat: add configurable editor chrome modes with theme-driven styling

### DIFF
--- a/editor-chrome.ts
+++ b/editor-chrome.ts
@@ -1,0 +1,190 @@
+import { visibleWidth } from "@mariozechner/pi-tui";
+
+import { ansi } from "./colors.js";
+import type { EditorChromeKind } from "./types.js";
+
+interface RenderEditorChromeArgs {
+  width: number;
+  kind: EditorChromeKind;
+  topContent: string | null;
+  bashModeActive: boolean;
+  originalRender: (contentWidth: number) => string[];
+  borderAnsi: (text: string) => string;
+  promptAnsi: (text: string) => string;
+  openBarAnsi: string;
+  openBgAnsi: string;
+  openTextAnsi: string;
+}
+
+interface RenderChromeSharedArgs {
+  width: number;
+  topContent: string;
+  lines: string[];
+  promptGlyph: string;
+  borderAnsi: (text: string) => string;
+  promptAnsi: (text: string) => string;
+  openBarAnsi: string;
+  openBgAnsi: string;
+  openTextAnsi: string;
+}
+
+export function renderEditorChrome(args: RenderEditorChromeArgs): string[] {
+  const contentWidth = args.kind === "rounded"
+    ? Math.max(1, args.width - 5)
+    : args.kind === "ohmy"
+      ? Math.max(1, args.width - 6)
+      : Math.max(1, args.width - 4);
+  const lines = args.originalRender(contentWidth);
+
+  if (lines.length === 0 || args.topContent === null) {
+    return lines;
+  }
+
+  const sharedArgs: RenderChromeSharedArgs = {
+    width: args.width,
+    topContent: args.topContent,
+    lines,
+    promptGlyph: args.bashModeActive ? "$" : ">",
+    borderAnsi: args.borderAnsi,
+    promptAnsi: args.promptAnsi,
+    openBarAnsi: args.openBarAnsi,
+    openBgAnsi: args.openBgAnsi,
+    openTextAnsi: args.openTextAnsi,
+  };
+
+  if (args.kind === "rounded") {
+    return renderRoundedChrome(sharedArgs);
+  }
+
+  if (args.kind === "ohmy") {
+    return renderOhMyChrome(sharedArgs);
+  }
+
+  return renderOpenChrome(sharedArgs);
+}
+
+function renderOpenChrome(args: RenderChromeSharedArgs): string[] {
+  const { width, topContent, lines, openBarAnsi, openBgAnsi, openTextAnsi } = args;
+  const promptPrefix = "   ";
+  const contPrefix = "   ";
+  const contentWidth = Math.max(1, width - 4);
+  const bottomBorderIndex = findBottomBorderIndex(lines);
+  const blueBar = `${openBarAnsi}│${ansi.reset}`;
+  const openChromeAnsi = `${openBgAnsi}${openTextAnsi}`;
+  const reset = ansi.reset;
+
+  const wrap = (body: string): string => {
+    return `${blueBar}${openChromeAnsi}${body.replace(/\x1b\[0m/g, `${reset}${openChromeAnsi}`)}${reset}`;
+  };
+
+  const blankPad = wrap(" ".repeat(3 + contentWidth));
+  const result: string[] = [];
+  result.push(topContent);
+  result.push(blankPad);
+
+  for (let i = 1; i < bottomBorderIndex; i++) {
+    const prefix = i === 1 ? promptPrefix : contPrefix;
+    const content = padToVisibleWidth(lines[i] || "", contentWidth);
+    result.push(wrap(`${prefix}${content}`));
+  }
+
+  if (bottomBorderIndex === 1) {
+    result.push(wrap(`${promptPrefix}${" ".repeat(contentWidth)}`));
+  }
+
+  result.push(blankPad);
+
+  for (let i = bottomBorderIndex + 1; i < lines.length; i++) {
+    result.push(lines[i] || "");
+  }
+
+  return result;
+}
+
+function renderRoundedChrome(args: RenderChromeSharedArgs): string[] {
+  const { width, topContent, lines, promptGlyph, borderAnsi, promptAnsi } = args;
+  const prompt = promptAnsi(promptGlyph);
+  const promptPrefix = ` ${prompt} `;
+  const contPrefix = "   ";
+  const bottomBorderIndex = findBottomBorderIndex(lines);
+
+  const result: string[] = [];
+  result.push(topContent);
+  result.push(borderAnsi(`╭${"─".repeat(width - 2)}╮`));
+
+  for (let i = 1; i < bottomBorderIndex; i++) {
+    const prefix = i === 1 ? promptPrefix : contPrefix;
+    const content = padToVisibleWidth(lines[i] || "", Math.max(0, width - 2 - visibleWidth(prefix)));
+    result.push(`${borderAnsi("│")}${prefix}${content}${borderAnsi("│")}`);
+  }
+
+  if (bottomBorderIndex === 1) {
+    result.push(`${borderAnsi("│")}${promptPrefix}${" ".repeat(Math.max(0, width - 2 - visibleWidth(promptPrefix)))}${borderAnsi("│")}`);
+  }
+
+  result.push(borderAnsi(`╰${"─".repeat(width - 2)}╯`));
+
+  for (let i = bottomBorderIndex + 1; i < lines.length; i++) {
+    result.push(lines[i] || "");
+  }
+
+  return result;
+}
+
+function renderOhMyChrome(args: RenderChromeSharedArgs): string[] {
+  const { width, topContent, lines, borderAnsi } = args;
+  const bottomBorderIndex = findBottomBorderIndex(lines, true);
+  const topLeft = borderAnsi("╭─");
+  const topRight = borderAnsi("─╮");
+  const bottomLeft = borderAnsi("╰─");
+  const bottomRight = borderAnsi("─╯");
+  const vertical = borderAnsi("│");
+  const contentWidth = Math.max(1, width - 6);
+
+  const result: string[] = [];
+  const statusWidth = visibleWidth(topContent);
+  const topFillWidth = width - 4;
+  const fillWidth = Math.max(0, topFillWidth - statusWidth);
+
+  result.push(topLeft + topContent + borderAnsi("─".repeat(fillWidth)) + topRight);
+
+  for (let i = 1; i < bottomBorderIndex; i++) {
+    const content = padToVisibleWidth(lines[i] || "", contentWidth);
+    const isLastContent = i === bottomBorderIndex - 1;
+
+    if (isLastContent) {
+      result.push(`${bottomLeft} ${content} ${bottomRight}`);
+    } else {
+      result.push(`${vertical}  ${content}  ${vertical}`);
+    }
+  }
+
+  if (bottomBorderIndex === 1) {
+    result.push(`${bottomLeft} ${" ".repeat(contentWidth)} ${bottomRight}`);
+  }
+
+  for (let i = bottomBorderIndex + 1; i < lines.length; i++) {
+    result.push(lines[i] || "");
+  }
+
+  return result;
+}
+
+function findBottomBorderIndex(lines: string[], strict = false): number {
+  let bottomBorderIndex = lines.length - 1;
+  for (let i = lines.length - 1; i >= 1; i--) {
+    const stripped = lines[i]?.replace(/\x1b\[[0-9;]*m/g, "") || "";
+    if (stripped.length > 0 && (strict ? /^─+$/.test(stripped) : /^─{3,}/.test(stripped))) {
+      bottomBorderIndex = i;
+      break;
+    }
+  }
+
+  return bottomBorderIndex;
+}
+
+function padToVisibleWidth(text: string, targetWidth: number): string {
+  const width = visibleWidth(text);
+  if (width >= targetWidth) return text;
+  return text + " ".repeat(targetWidth - width);
+}

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 
-import type { ColorScheme, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.js";
+import type { ColorScheme, EditorChromeKind, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.js";
 import { BashTranscriptStore } from "./bash-mode/transcript.ts";
 import {
   BashCompletionEngine,
@@ -29,7 +29,8 @@ import { renderSegment } from "./segments.js";
 import { getGitStatus, invalidateGitStatus, invalidateGitBranch } from "./git-status.js";
 import { ansi, getFgAnsiCode } from "./colors.js";
 import { WelcomeComponent, WelcomeHeader, discoverLoadedCounts, getRecentSessions } from "./welcome.js";
-import { getDefaultColors } from "./theme.js";
+import { fg, getDefaultColors, getSemanticAnsi } from "./theme.js";
+import { renderEditorChrome } from "./editor-chrome.js";
 import { 
   initVibeManager, 
   onVibeBeforeAgentStart, 
@@ -53,10 +54,12 @@ import {
 
 interface PowerlineConfig {
   preset: StatusLinePreset;
+  editorChrome: EditorChromeKind;
 }
 
 let config: PowerlineConfig = {
   preset: "default",
+  editorChrome: "open",
 };
 
 const CUSTOM_COMPACTION_STATUS_KEY = "compact-policy";
@@ -451,6 +454,23 @@ function normalizePreset(value: unknown): StatusLinePreset | null {
 
   const preset = value.trim().toLowerCase();
   return isValidPreset(preset) ? preset : null;
+}
+
+function normalizeEditorChrome(value: unknown): EditorChromeKind | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const chrome = value.trim().toLowerCase();
+  if (chrome === "open" || chrome === "rounded" || chrome === "ohmy") {
+    return chrome;
+  }
+
+  if (chrome === "ohmypi") {
+    return "ohmy";
+  }
+
+  return null;
 }
 
 function hasNonWhitespaceText(text: string): boolean {
@@ -891,6 +911,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     bashModeSettings = parseBashModeSettings(settings);
     showLastPrompt = settings.showLastPrompt !== false;
     config.preset = normalizePreset(settings.powerline) ?? "default";
+    config.editorChrome = normalizeEditorChrome(settings.powerlineEditorChrome) ?? "open";
     stashedPromptHistory = readPersistedStashHistory();
     bashModeActive = false;
     bashTranscript = new BashTranscriptStore(bashModeSettings);
@@ -1709,46 +1730,22 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           return originalRender(width);
         }
 
-        const bc = (s: string) => `${getFgAnsiCode("sep")}${s}${ansi.reset}`;
-        const promptGlyph = bashModeActive ? "$" : ">";
-        const prompt = `${ansi.getFgAnsi(200, 200, 200)}${promptGlyph}${ansi.reset}`;
-        const promptPrefix = ` ${prompt} `;
-        const contPrefix = "   ";
-        const contentWidth = Math.max(1, width - 3);
-        const lines = originalRender(contentWidth);
+        const bc = (s: string) => fg(ctx.ui.theme, "border", s);
+        const pc = (s: string) => fg(ctx.ui.theme, "chromePrompt", s);
+        const topContent = currentCtx ? getResponsiveLayout(width, ctx.ui.theme).topContent : null;
 
-        if (lines.length === 0 || !currentCtx) return lines;
-
-        let bottomBorderIndex = lines.length - 1;
-        for (let i = lines.length - 1; i >= 1; i--) {
-          const stripped = lines[i]?.replace(/\x1b\[[0-9;]*m/g, "") || "";
-          if (stripped.length > 0 && /^─{3,}/.test(stripped)) {
-            bottomBorderIndex = i;
-            break;
-          }
-        }
-
-        const result: string[] = [];
-        const layout = getResponsiveLayout(width, ctx.ui.theme);
-        result.push(layout.topContent);
-        result.push(" " + bc("─".repeat(width - 2)));
-
-        for (let i = 1; i < bottomBorderIndex; i++) {
-          const prefix = i === 1 ? promptPrefix : contPrefix;
-          result.push(`${prefix}${lines[i] || ""}`);
-        }
-
-        if (bottomBorderIndex === 1) {
-          result.push(`${promptPrefix}${" ".repeat(contentWidth)}`);
-        }
-
-        result.push(" " + bc("─".repeat(width - 2)));
-
-        for (let i = bottomBorderIndex + 1; i < lines.length; i++) {
-          result.push(lines[i] || "");
-        }
-
-        return result;
+        return renderEditorChrome({
+          width,
+          kind: config.editorChrome,
+          topContent,
+          bashModeActive,
+          originalRender,
+          borderAnsi: bc,
+          promptAnsi: pc,
+          openBarAnsi: getSemanticAnsi(ctx.ui.theme, "chromeBar", "fg"),
+          openBgAnsi: getSemanticAnsi(ctx.ui.theme, "chromeBg", "bg"),
+          openTextAnsi: getSemanticAnsi(ctx.ui.theme, "chromeText", "fg"),
+        });
       };
 
       return editor;

--- a/theme.example.json
+++ b/theme.example.json
@@ -13,6 +13,10 @@
     "cost": "text",
     "tokens": "muted",
     "separator": "dim",
-    "border": "borderMuted"
+    "border": "borderMuted",
+    "chromeBar": "accent",
+    "chromeBg": "borderMuted",
+    "chromeText": "text",
+    "chromePrompt": "text"
   }
 }

--- a/theme.ts
+++ b/theme.ts
@@ -28,7 +28,11 @@ const DEFAULT_COLORS: Required<ColorScheme> = {
   cost: "text",
   tokens: "muted",
   separator: "dim",
-  border: "borderMuted",
+  border: "#808080", // Matches prior chrome separator gray closely
+  chromeBar: "#5f87ff", // Bright blue left accent for open chrome
+  chromeBg: "#303030", // Dark gray open chrome background
+  chromeText: "#ffffff", // White text inside open chrome
+  chromePrompt: "#c8c8c8", // Matches prior prompt glyph color
 };
 
 // Rainbow colors for high thinking levels
@@ -141,20 +145,32 @@ function hexToAnsi(hex: string): string {
   return `\x1b[38;2;${r};${g};${b}m`;
 }
 
-/**
- * Apply a color to text using the pi theme or custom hex
- */
-export function applyColor(
+function hexToBgAnsi(hex: string): string {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `\x1b[48;2;${r};${g};${b}m`;
+}
+
+function fgAnsiToBgAnsi(code: string): string {
+  return code
+    .replace("\x1b[38;2;", "\x1b[48;2;")
+    .replace("\x1b[38;5;", "\x1b[48;5;");
+}
+
+function getAnsiForColor(
   theme: Theme,
   color: ColorValue,
-  text: string
+  mode: "fg" | "bg",
 ): string {
   if (isHexColor(color)) {
-    return `${hexToAnsi(color)}${text}\x1b[0m`;
+    return mode === "fg" ? hexToAnsi(color) : hexToBgAnsi(color);
   }
 
   try {
-    return theme.fg(color as ThemeColor, text);
+    const fgAnsi = theme.getFgAnsi(color as ThemeColor);
+    return mode === "fg" ? fgAnsi : fgAnsiToBgAnsi(fgAnsi);
   } catch (error) {
     const key = String(color);
     if (!warnedInvalidThemeColors.has(key)) {
@@ -164,8 +180,21 @@ export function applyColor(
       }
       console.debug(`[powerline-theme] Invalid theme color "${key}"; falling back to "text".`, error);
     }
-    return theme.fg("text", text);
+
+    const fallback = theme.getFgAnsi("text");
+    return mode === "fg" ? fallback : fgAnsiToBgAnsi(fallback);
   }
+}
+
+/**
+ * Apply a color to text using the pi theme or custom hex
+ */
+export function applyColor(
+  theme: Theme,
+  color: ColorValue,
+  text: string
+): string {
+  return `${getAnsiForColor(theme, color, "fg")}${text}\x1b[0m`;
 }
 
 /**
@@ -179,6 +208,16 @@ export function fg(
 ): string {
   const color = resolveColor(semantic, presetColors);
   return applyColor(theme, color, text);
+}
+
+export function getSemanticAnsi(
+  theme: Theme,
+  semantic: SemanticColor,
+  mode: "fg" | "bg",
+  presetColors?: ColorScheme,
+): string {
+  const color = resolveColor(semantic, presetColors);
+  return getAnsiForColor(theme, color, mode);
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -18,7 +18,11 @@ export type SemanticColor =
   | "cost"
   | "tokens"
   | "separator"
-  | "border";
+  | "border"
+  | "chromeBar"
+  | "chromeBg"
+  | "chromeText"
+  | "chromePrompt";
 
 // Color scheme mapping semantic names to actual colors
 export type ColorScheme = Partial<Record<SemanticColor, ColorValue>>;
@@ -68,6 +72,8 @@ export type StatusLinePreset =
   | "nerd"
   | "ascii"
   | "custom";
+
+export type EditorChromeKind = "open" | "rounded" | "ohmy";
 
 // Per-segment options
 export interface StatusLineSegmentOptions {


### PR DESCRIPTION
## Summary
This PR makes the input/editor chrome configurable instead of hardcoded.

It extracts editor chrome rendering into a dedicated module, adds multiple chrome modes, and wires chrome styling into the package theme system so users can control the input box appearance without patching the renderer directly.

## What changed
- extracted editor chrome rendering into `editor-chrome.ts`
- added `powerlineEditorChrome` config support
- added chrome modes:
  - `open`
  - `rounded`
  - `ohmy`
- kept backward compatibility by mapping legacy `ohmypi` -> `ohmy`
- moved chrome styling into the theme pipeline
- added theme keys for chrome-specific styling:
  - `border`
  - `chromeBar`
  - `chromeBg`
  - `chromeText`
  - `chromePrompt`
- added sensible fallback defaults in `theme.ts`
- updated `theme.example.json` to document the new theme surface

## Configuration
### Settings
```json
{
  "powerlineEditorChrome": "rounded"
}
```

Valid values:
- `open`
- `rounded`
- `ohmy`

Legacy:
- `ohmypi` is still accepted and normalized to `ohmy`

### Theme keys
```json
{
  "colors": {
    "border": "borderMuted",
    "chromeBar": "accent",
    "chromeBg": "borderMuted",
    "chromeText": "text",
    "chromePrompt": "text"
  }
}
```

## Why
The input box is a big part of the extension's visual identity, but it was previously a single hardcoded design.

This change makes the chrome:
- configurable for users with different layout preferences
- themeable without touching renderer code
- easier to maintain and extend in the future

It also creates a cleaner separation between:
- footer/editor orchestration
- editor chrome rendering
- theme/color resolution

## Notes
- `rounded` and `ohmy` use theme-driven border/prompt styling
- `open` also uses theme-driven chrome styling for its left bar, background, text, and prompt-related colors
- the current `open` mode intentionally has more vertical breathing room and no visible prompt glyph
- this PR is focused on editor/input chrome only
- `npm test` currently fails in this environment due existing symlink/faux-provider setup in unrelated bash-mode and working-vibes tests; the chrome/input-box files in this PR are isolated to `index.ts`, `editor-chrome.ts`, `theme.ts`, `theme.example.json`, and `types.ts`
