### PR TITLE
feat: add generic custom powerline items from extension statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,48 @@ Activates automatically. Toggle with `/powerline`, switch presets with `/powerli
 Preset selection is saved to `~/.pi/agent/settings.json` under `powerline` and restored on startup.
 Run `/powerline default` to switch back to the default preset.
 
+### Custom items from extension statuses
+
+You can promote any extension status key into its own dedicated powerline item. This gives you a general way to register your own status items without changing this extension.
+
+1. Any extension can publish status text through `ctx.ui.setStatus("my-key", "...value...")`.
+2. Configure `powerline.customItems` to place those keys on the left, right, or secondary row.
+
+```json
+{
+  "powerline": {
+    "preset": "default",
+    "customItems": [
+      {
+        "id": "ci",
+        "statusKey": "ci-status",
+        "position": "right",
+        "prefix": "CI",
+        "color": "warning"
+      },
+      {
+        "id": "review",
+        "position": "secondary",
+        "hideWhenMissing": false,
+        "prefix": "review"
+      }
+    ]
+  }
+}
+```
+
+`customItems` fields:
+
+- `id` (required): unique item id (`a-z`, `A-Z`, `0-9`, `_`, `-`)
+- `statusKey` (optional): extension status key to read, defaults to `id`
+- `position` (optional): `left`, `right`, or `secondary` (default `right`)
+- `prefix` (optional): text shown before the live status value
+- `color` (optional): any Pi theme color (`warning`, `accent`, etc.) or hex (`#RRGGBB`)
+- `hideWhenMissing` (optional): hide item when no status is present (default `true`)
+- `excludeFromExtensionStatuses` (optional): omit this key from the aggregate `extension_statuses` segment (default `true`)
+
+If you still prefer the old style, `"powerline": "default"` continues to work.
+
 ## Bash mode
 
 Toggle bash mode with either:

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 
 import type { ColorScheme, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.js";
+import type { PowerlineConfig } from "./powerline-config.js";
 import { BashTranscriptStore } from "./bash-mode/transcript.ts";
 import {
   BashCompletionEngine,
@@ -24,6 +25,7 @@ import { ManagedShellSession } from "./bash-mode/shell-session.ts";
 import { matchHistoryEntries, readGlobalShellHistory, readProjectHistory, appendProjectHistory } from "./bash-mode/history.ts";
 import type { BashModeSettings } from "./bash-mode/types.ts";
 import { getPreset, PRESETS } from "./presets.js";
+import { collectHiddenExtensionStatusKeys, mergeSegmentsWithCustomItems, nextPowerlineSettingWithPreset, parsePowerlineConfig } from "./powerline-config.js";
 import { getSeparator } from "./separators.js";
 import { renderSegment } from "./segments.js";
 import { getGitStatus, invalidateGitStatus, invalidateGitBranch } from "./git-status.js";
@@ -51,12 +53,9 @@ import {
 // Configuration
 // ═══════════════════════════════════════════════════════════════════════════
 
-interface PowerlineConfig {
-  preset: StatusLinePreset;
-}
-
 let config: PowerlineConfig = {
   preset: "default",
+  customItems: [],
 };
 
 const CUSTOM_COMPACTION_STATUS_KEY = "compact-policy";
@@ -428,7 +427,7 @@ function writePowerlinePresetSetting(preset: StatusLinePreset): boolean {
     }
   }
 
-  settings.powerline = preset;
+  settings.powerline = nextPowerlineSettingWithPreset(settings.powerline, preset);
 
   try {
     mkdirSync(dirname(settingsPath), { recursive: true });
@@ -439,6 +438,8 @@ function writePowerlinePresetSetting(preset: StatusLinePreset): boolean {
     return false;
   }
 }
+
+const PRESET_NAMES = Object.keys(PRESETS) as StatusLinePreset[];
 
 function isValidPreset(value: unknown): value is StatusLinePreset {
   return typeof value === "string" && Object.prototype.hasOwnProperty.call(PRESETS, value);
@@ -645,8 +646,9 @@ function computeResponsiveLayout(
   const sepWidth = visibleWidth(separatorDef.left) + 2; // separator + spaces around it
   
   // Get all segments: primary first, then secondary
-  const primaryIds = [...presetDef.leftSegments, ...presetDef.rightSegments];
-  const secondaryIds = presetDef.secondarySegments ?? [];
+  const mergedSegments = mergeSegmentsWithCustomItems(presetDef, config.customItems);
+  const primaryIds = [...mergedSegments.leftSegments, ...mergedSegments.rightSegments];
+  const secondaryIds = mergedSegments.secondarySegments;
   const allSegmentIds = [...primaryIds, ...secondaryIds];
   
   // Render all segments and get their widths
@@ -709,6 +711,7 @@ function computeResponsiveLayout(
 
 export default function powerlineFooter(pi: ExtensionAPI) {
   const startupSettings = readSettings();
+  config = parsePowerlineConfig(startupSettings.powerline, PRESET_NAMES);
   const resolvedShortcuts = resolveShortcutConfig(startupSettings);
   let bashModeSettings = parseBashModeSettings(startupSettings);
 
@@ -890,7 +893,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const settings = readSettings();
     bashModeSettings = parseBashModeSettings(settings);
     showLastPrompt = settings.showLastPrompt !== false;
-    config.preset = normalizePreset(settings.powerline) ?? "default";
+    config = parsePowerlineConfig(settings.powerline, PRESET_NAMES);
     stashedPromptHistory = readPersistedStashHistory();
     bashModeActive = false;
     bashTranscript = new BashTranscriptStore(bashModeSettings);
@@ -1571,6 +1574,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const gitBranch = footerDataRef?.getGitBranch() ?? null;
     const gitStatus = getGitStatus(gitBranch);
     const extensionStatuses = footerDataRef?.getExtensionStatuses() ?? new Map();
+    const customItemsById = new Map(config.customItems.map((item) => [item.id, item]));
+    const hiddenExtensionStatusKeys = collectHiddenExtensionStatusKeys(config.customItems);
 
     // Check if using OAuth subscription
     const usingSubscription = ctx.model
@@ -1596,6 +1601,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       shellCwd: shellSession?.state.cwd ?? null,
       git: gitStatus,
       extensionStatuses,
+      hiddenExtensionStatusKeys,
+      customItemsById,
       options: presetDef.segmentOptions ?? {},
       theme,
       colors,

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,0 +1,129 @@
+import type { BuiltinStatusLineSegmentId, ColorValue, CustomItemPosition, CustomStatusItem, PresetDef, StatusLinePreset, StatusLineSegmentId } from "./types.js";
+
+export interface PowerlineConfig {
+  preset: StatusLinePreset;
+  customItems: CustomStatusItem[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizePreset(value: unknown, presets: readonly StatusLinePreset[]): StatusLinePreset | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return (presets as readonly string[]).includes(normalized) ? (normalized as StatusLinePreset) : null;
+}
+
+function normalizeCustomItemId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  return /^[a-zA-Z0-9_-]+$/.test(normalized) ? normalized : null;
+}
+
+function normalizeCustomItemPosition(value: unknown): CustomItemPosition {
+  if (value === "left" || value === "right" || value === "secondary") return value;
+  return "right";
+}
+
+function normalizeCustomColor(value: unknown): ColorValue | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  return normalized ? (normalized as ColorValue) : undefined;
+}
+
+function normalizeCustomPrefix(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim();
+  return normalized ? normalized : undefined;
+}
+
+function normalizeCustomStatusItem(raw: unknown, idOverride?: string): CustomStatusItem | null {
+  if (!isRecord(raw)) return null;
+  const id = normalizeCustomItemId(idOverride ?? raw.id);
+  if (!id) return null;
+
+  const statusKey = typeof raw.statusKey === "string" && raw.statusKey.trim() ? raw.statusKey.trim() : id;
+
+  return {
+    id,
+    statusKey,
+    position: normalizeCustomItemPosition(raw.position),
+    color: normalizeCustomColor(raw.color),
+    prefix: normalizeCustomPrefix(raw.prefix),
+    hideWhenMissing: raw.hideWhenMissing !== false,
+    excludeFromExtensionStatuses: raw.excludeFromExtensionStatuses !== false,
+  };
+}
+
+function normalizeCustomItems(raw: unknown): CustomStatusItem[] {
+  const normalized: CustomStatusItem[] = [];
+
+  if (Array.isArray(raw)) {
+    for (const entry of raw) {
+      const item = normalizeCustomStatusItem(entry);
+      if (item) normalized.push(item);
+    }
+  } else if (isRecord(raw)) {
+    for (const [id, entry] of Object.entries(raw)) {
+      const item = normalizeCustomStatusItem(entry, id);
+      if (item) normalized.push(item);
+    }
+  }
+
+  const deduped = new Map<string, CustomStatusItem>();
+  for (const item of normalized) {
+    deduped.set(item.id, item);
+  }
+
+  return [...deduped.values()];
+}
+
+export function parsePowerlineConfig(value: unknown, presets: readonly StatusLinePreset[]): PowerlineConfig {
+  const defaultConfig: PowerlineConfig = { preset: "default", customItems: [] };
+
+  const directPreset = normalizePreset(value, presets);
+  if (directPreset) return { ...defaultConfig, preset: directPreset };
+
+  if (!isRecord(value)) return defaultConfig;
+
+  return {
+    preset: normalizePreset(value.preset, presets) ?? defaultConfig.preset,
+    customItems: normalizeCustomItems(value.customItems),
+  };
+}
+
+export function mergeSegmentsWithCustomItems(presetDef: PresetDef, customItems: readonly CustomStatusItem[]): {
+  leftSegments: StatusLineSegmentId[];
+  rightSegments: StatusLineSegmentId[];
+  secondarySegments: StatusLineSegmentId[];
+} {
+  const left: StatusLineSegmentId[] = [...presetDef.leftSegments];
+  const right: StatusLineSegmentId[] = [...presetDef.rightSegments];
+  const secondary: StatusLineSegmentId[] = [...(presetDef.secondarySegments ?? [])];
+
+  for (const item of customItems) {
+    const segmentId: StatusLineSegmentId = `custom:${item.id}`;
+    if (item.position === "left") left.push(segmentId);
+    else if (item.position === "secondary") secondary.push(segmentId);
+    else right.push(segmentId);
+  }
+
+  return { leftSegments: left, rightSegments: right, secondarySegments: secondary };
+}
+
+export function nextPowerlineSettingWithPreset(existingPowerlineSetting: unknown, preset: StatusLinePreset): unknown {
+  if (!isRecord(existingPowerlineSetting)) {
+    return preset;
+  }
+  return { ...existingPowerlineSetting, preset };
+}
+
+export function collectHiddenExtensionStatusKeys(customItems: readonly CustomStatusItem[]): Set<string> {
+  const hidden = new Set<string>();
+  for (const item of customItems) {
+    if (item.excludeFromExtensionStatuses) hidden.add(item.statusKey);
+  }
+  return hidden;
+}

--- a/segments.ts
+++ b/segments.ts
@@ -1,7 +1,7 @@
 import { hostname as osHostname } from "node:os";
 import { basename } from "node:path";
 import { visibleWidth } from "@mariozechner/pi-tui";
-import type { RenderedSegment, SegmentContext, SemanticColor, StatusLineSegment, StatusLineSegmentId } from "./types.js";
+import type { BuiltinStatusLineSegmentId, RenderedSegment, SegmentContext, SemanticColor, StatusLineSegment, StatusLineSegmentId } from "./types.js";
 import { fg, rainbow, applyColor } from "./theme.js";
 import { getIcons, SEP_DOT, getThinkingText } from "./icons.js";
 
@@ -415,9 +415,11 @@ const extensionStatusesSegment: StatusLineSegment = {
 
     // Join compact statuses with a separator
     // Skip: empty strings, notification-style ("[...") shown above editor,
-    // and strings that are only ANSI codes with no visible text
+    // and strings that are only ANSI codes with no visible text.
+    // Also skip statuses explicitly elevated into dedicated custom segments.
     const parts: string[] = [];
-    for (const value of statuses.values()) {
+    for (const [statusKey, value] of statuses.entries()) {
+      if (ctx.hiddenExtensionStatusKeys.has(statusKey)) continue;
       if (value && !value.trimStart().startsWith('[') && visibleWidth(value) > 0) {
         // Strip trailing separators (· | · etc.) that some extensions bake in,
         // since we add our own SEP_DOT joiner between entries.
@@ -441,7 +443,7 @@ const extensionStatusesSegment: StatusLineSegment = {
 // Segment Registry
 // ═══════════════════════════════════════════════════════════════════════════
 
-export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
+export const SEGMENTS: Record<BuiltinStatusLineSegmentId, StatusLineSegment> = {
   pi: piSegment,
   model: modelSegment,
   shell_mode: shellModeSegment,
@@ -464,7 +466,32 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
   extension_statuses: extensionStatusesSegment,
 };
 
+function renderCustomSegment(id: `custom:${string}`, ctx: SegmentContext): RenderedSegment {
+  const customItemId = id.slice("custom:".length);
+  const custom = ctx.customItemsById.get(customItemId);
+  if (!custom) return { content: "", visible: false };
+
+  const rawStatus = ctx.extensionStatuses.get(custom.statusKey);
+  if (!rawStatus || visibleWidth(rawStatus) <= 0) {
+    return custom.hideWhenMissing ? { content: "", visible: false } : { content: custom.prefix ?? custom.id, visible: true };
+  }
+
+  let content = rawStatus;
+  if (custom.prefix) {
+    content = `${custom.prefix}${SEP_DOT}${content}`;
+  }
+  if (custom.color) {
+    content = applyColor(ctx.theme, custom.color, content);
+  }
+
+  return { content, visible: true };
+}
+
 export function renderSegment(id: StatusLineSegmentId, ctx: SegmentContext): RenderedSegment {
+  if (id.startsWith("custom:")) {
+    return renderCustomSegment(id, ctx);
+  }
+
   const segment = SEGMENTS[id];
   if (!segment) {
     return { content: "", visible: false };

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { collectHiddenExtensionStatusKeys, parsePowerlineConfig, mergeSegmentsWithCustomItems, nextPowerlineSettingWithPreset } from "../powerline-config.ts";
+
+test("parsePowerlineConfig supports object config with custom items", () => {
+  const config = parsePowerlineConfig(
+    {
+      preset: "compact",
+      customItems: [
+        { id: "ci", statusKey: "ci-status", position: "right", prefix: "CI" },
+        { id: "review", position: "secondary", hideWhenMissing: false },
+      ],
+    },
+    ["default", "compact"],
+  );
+
+  assert.equal(config.preset, "compact");
+  assert.equal(config.customItems.length, 2);
+  assert.equal(config.customItems[0].id, "ci");
+  assert.equal(config.customItems[0].statusKey, "ci-status");
+  assert.equal(config.customItems[1].statusKey, "review");
+  assert.equal(config.customItems[1].hideWhenMissing, false);
+});
+
+test("mergeSegmentsWithCustomItems appends custom segment ids by position", () => {
+  const merged = mergeSegmentsWithCustomItems(
+    {
+      leftSegments: ["path"],
+      rightSegments: ["git"],
+      secondarySegments: ["extension_statuses"],
+      separator: "powerline",
+    },
+    [
+      { id: "ci", statusKey: "ci", position: "left", hideWhenMissing: true, excludeFromExtensionStatuses: true },
+      { id: "timer", statusKey: "timer", position: "right", hideWhenMissing: true, excludeFromExtensionStatuses: true },
+      { id: "review", statusKey: "review", position: "secondary", hideWhenMissing: true, excludeFromExtensionStatuses: true },
+    ],
+  );
+
+  assert.deepEqual(merged.leftSegments, ["path", "custom:ci"]);
+  assert.deepEqual(merged.rightSegments, ["git", "custom:timer"]);
+  assert.deepEqual(merged.secondarySegments, ["extension_statuses", "custom:review"]);
+});
+
+test("nextPowerlineSettingWithPreset preserves object settings", () => {
+  const updated = nextPowerlineSettingWithPreset({ preset: "default", customItems: [{ id: "ci" }] }, "compact") as any;
+  assert.equal(updated.preset, "compact");
+  assert.deepEqual(updated.customItems, [{ id: "ci" }]);
+});
+
+test("collectHiddenExtensionStatusKeys includes default custom status keys", () => {
+  const hidden = collectHiddenExtensionStatusKeys([
+    { id: "ci", statusKey: "ci-status", position: "right", hideWhenMissing: true, excludeFromExtensionStatuses: true },
+    { id: "review", statusKey: "review", position: "secondary", hideWhenMissing: true, excludeFromExtensionStatuses: false },
+  ]);
+
+  assert.equal(hidden.has("ci-status"), true);
+  assert.equal(hidden.has("review"), false);
+});

--- a/types.ts
+++ b/types.ts
@@ -23,8 +23,8 @@ export type SemanticColor =
 // Color scheme mapping semantic names to actual colors
 export type ColorScheme = Partial<Record<SemanticColor, ColorValue>>;
 
-// Segment identifiers
-export type StatusLineSegmentId =
+// Built-in segment identifiers
+export type BuiltinStatusLineSegmentId =
   | "pi"
   | "model"
   | "shell_mode"
@@ -45,6 +45,9 @@ export type StatusLineSegmentId =
   | "cache_write"
   | "thinking"
   | "extension_statuses";
+
+// Segment identifiers (built-in + dynamically registered custom items)
+export type StatusLineSegmentId = BuiltinStatusLineSegmentId | `custom:${string}`;
 
 // Separator styles
 export type StatusLineSeparatorStyle =
@@ -80,12 +83,24 @@ export interface StatusLineSegmentOptions {
   time?: { format?: "12h" | "24h"; showSeconds?: boolean };
 }
 
+export type CustomItemPosition = "left" | "right" | "secondary";
+
+export interface CustomStatusItem {
+  id: string;
+  statusKey: string;
+  position: CustomItemPosition;
+  color?: ColorValue;
+  prefix?: string;
+  hideWhenMissing: boolean;
+  excludeFromExtensionStatuses: boolean;
+}
+
 // Preset definition
 export interface PresetDef {
-  leftSegments: StatusLineSegmentId[];
-  rightSegments: StatusLineSegmentId[];
+  leftSegments: BuiltinStatusLineSegmentId[];
+  rightSegments: BuiltinStatusLineSegmentId[];
   /** Secondary row segments (shown in footer, above sub bar) */
-  secondarySegments?: StatusLineSegmentId[];
+  secondarySegments?: BuiltinStatusLineSegmentId[];
   separator: StatusLineSeparatorStyle;
   segmentOptions?: StatusLineSegmentOptions;
   /** Color scheme for this preset */
@@ -145,6 +160,8 @@ export interface SegmentContext {
   
   // Extension statuses
   extensionStatuses: ReadonlyMap<string, string>;
+  hiddenExtensionStatusKeys: ReadonlySet<string>;
+  customItemsById: ReadonlyMap<string, CustomStatusItem>;
   
   // Options
   options: StatusLineSegmentOptions;
@@ -162,6 +179,6 @@ export interface RenderedSegment {
 
 // Segment definition
 export interface StatusLineSegment {
-  id: StatusLineSegmentId;
+  id: BuiltinStatusLineSegmentId;
   render(ctx: SegmentContext): RenderedSegment;
 }


### PR DESCRIPTION
## Summary
- add a generic `powerline.customItems` config block so users can place custom status items in left, right, or secondary rows
- keep `"powerline": "default"` backward-compatible while also supporting object config (`{ preset, customItems }`)
- preserve existing `customItems` settings when `/powerline <preset>` updates the active preset
- hide custom-promoted status keys from aggregate `extension_statuses` by default to avoid duplicate display
- document the custom item contract in README

## Config example
```json
{
  "powerline": {
    "preset": "default",
    "customItems": [
      {
        "id": "ci",
        "statusKey": "ci-status",
        "position": "right",
        "prefix": "CI",
        "color": "warning"
      }
    ]
  }
}
```

## Testing
- `node --experimental-strip-types --test tests/custom-items.test.ts`

I also ran `npm test`; it fails in this local environment because pre-existing test files depend on machine-specific symlink/module assumptions, unrelated to this change.
