### PR TITLE
fix: Stale context crash on `/new` command

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -829,14 +829,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       requestRender();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      ctx.ui.notify(`Failed to run shell command: ${message}`, "error");
+      if (ctx) ctx.ui.notify(`Failed to run shell command: ${message}`, "error");
     }
   };
 
   const setBashModeActive = async (value: boolean, ctx: any): Promise<void> => {
     if (value === bashModeActive) return;
     if (!value && shellSession?.state.running) {
-      ctx.ui.notify("Wait for the current shell command to finish before leaving bash mode", "warning");
+      if (ctx) ctx.ui.notify("Wait for the current shell command to finish before leaving bash mode", "warning");
       return;
     }
 
@@ -847,14 +847,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         currentEditor?.dismissBashModeUi?.();
         currentEditor?.refreshGhostSuggestion?.();
         requestRender();
-        ctx.ui.notify(`Bash mode enabled (${session.state.shellName})`, "info");
+        if (ctx) ctx.ui.notify(`Bash mode enabled (${session.state.shellName})`, "info");
       } catch (error) {
         shellSession?.dispose();
         shellSession = null;
         bashModeActive = false;
         requestRender();
         const message = error instanceof Error ? error.message : String(error);
-        ctx.ui.notify(`Failed to start shell session: ${message}`, "error");
+        if (ctx) ctx.ui.notify(`Failed to start shell session: ${message}`, "error");
       }
       return;
     }
@@ -862,7 +862,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     bashModeActive = value;
     currentEditor?.dismissBashModeUi?.();
     requestRender();
-    ctx.ui.notify("Bash mode disabled", "info");
+    if (ctx) ctx.ui.notify("Bash mode disabled", "info");
   };
 
   function overlaySelectListTheme(theme: Theme) {
@@ -978,6 +978,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   pi.on("session_shutdown", async () => {
     shellSession?.dispose();
     shellSession = null;
+    currentCtx = null;
   });
 
   // Check if a bash command might change git branch
@@ -1090,7 +1091,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
     if (welcomeHeaderActive) {
       welcomeHeaderActive = false;
-      ctx.ui.setHeader(undefined);
+      if (ctx) ctx.ui.setHeader(undefined);
     }
   }
 
@@ -1694,14 +1695,18 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         isBashModeActive: () => bashModeActive,
         isShellRunning: () => shellSession?.state.running ?? false,
         onExitBashMode: () => {
-          void setBashModeActive(false, ctx);
+          if (currentCtx) void setBashModeActive(false, currentCtx);
         },
-        onSubmitCommand: (command) => void runShellCommand(command, ctx),
+        onSubmitCommand: (command) => {
+          if (currentCtx) void runShellCommand(command, currentCtx);
+        },
         onInterrupt: () => {
           shellSession?.interrupt();
-          ctx.ui.notify("Sent interrupt to shell", "info");
+          if (currentCtx) currentCtx.ui.notify("Sent interrupt to shell", "info");
         },
-        onNotify: (message, level = "info") => ctx.ui.notify(message, level),
+        onNotify: (message, level = "info") => {
+          if (currentCtx) currentCtx.ui.notify(message, level);
+        },
         getHistoryEntries: (prefix) => getShellHistoryEntries(prefix),
         resolveGhostSuggestion: async (text, signal) => {
           const oneOffBash = getOneOffBashCommandContext(text);
@@ -1756,13 +1761,13 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         if (!autocompleteFixed && !getInstalledAutocompleteProvider()) {
           autocompleteFixed = true;
           snapshotPromptHistory(editor);
-          ctx.ui.setEditorComponent(editorFactory);
+          currentCtx.ui.setEditorComponent(editorFactory);
           currentEditor?.handleInput(data);
           return;
         }
 
         attachAutocompleteProvider();
-        setTimeout(() => dismissWelcome(ctx), 0);
+        setTimeout(() => dismissWelcome(currentCtx), 0);
         originalHandleInput(data);
       };
 
@@ -1792,7 +1797,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         }
 
         const result: string[] = [];
-        const layout = getResponsiveLayout(width, ctx.ui.theme);
+        const layout = getResponsiveLayout(width, currentCtx.ui.theme);
         result.push(layout.topContent);
         result.push(" " + bc("─".repeat(width - 2)));
 
@@ -1856,26 +1861,27 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         dispose() {},
         invalidate() {},
         render(width: number): string[] {
-          if (!bashModeActive) return [];
+          if (!bashModeActive || !currentCtx) return [];
 
           const snapshot = bashTranscript.getSnapshot();
           if (snapshot.commands.length === 0) return [];
 
+          const theme = currentCtx.ui.theme;
           const lines: string[] = [];
           if (snapshot.truncatedCommands > 0) {
-            lines.push(` ${ctx.ui.theme.fg("dim", `… ${snapshot.truncatedCommands} earlier command${snapshot.truncatedCommands === 1 ? "" : "s"} truncated`)}`);
+            lines.push(` ${theme.fg("dim", `… ${snapshot.truncatedCommands} earlier command${snapshot.truncatedCommands === 1 ? "" : "s"} truncated`)}`);
           }
 
           const recentCommands = snapshot.commands.slice(-4);
           for (const command of recentCommands) {
             const promptGlyph = (shellSession?.state.shellName ?? "shell") === "fish" ? ">" : "$";
             const status = command.exitCode === null
-              ? ctx.ui.theme.fg("accent", "running")
+              ? theme.fg("accent", "running")
               : command.exitCode === 0
-                ? ctx.ui.theme.fg("success", "ok")
-                : ctx.ui.theme.fg("error", `exit ${command.exitCode}`);
+                ? theme.fg("success", "ok")
+                : theme.fg("error", `exit ${command.exitCode}`);
             const commandLine = truncateToWidth(command.command.replace(/\s+/g, " ").trim(), Math.max(8, width - 8), "…");
-            lines.push(` ${ctx.ui.theme.fg("accent", promptGlyph)} ${commandLine} ${ctx.ui.theme.fg("dim", "(")}${status}${ctx.ui.theme.fg("dim", ")")}`);
+            lines.push(` ${theme.fg("accent", promptGlyph)} ${commandLine} ${theme.fg("dim", "(")}${status}${theme.fg("dim", ")")}`);
 
             const outputTail = command.output.slice(-6);
             for (const outputLine of outputTail) {
@@ -1976,17 +1982,17 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       }
       
       // Check if session already has activity (handles p "command" case)
-      const sessionEvents = ctx.sessionManager?.getBranch?.() ?? [];
+      const sessionEvents = currentCtx?.sessionManager?.getBranch?.() ?? [];
       const hasActivity = sessionEvents.some((e: any) => 
         (e.type === "message" && e.message?.role === "assistant") ||
         e.type === "tool_call" ||
         e.type === "tool_result"
       );
-      if (hasActivity) {
+      if (hasActivity || !currentCtx) {
         return;
       }
       
-      ctx.ui.custom(
+      currentCtx.ui.custom(
         (tui: any, _theme: any, _keybindings: any, done: (result: void) => void) => {
           const welcome = new WelcomeComponent(
             modelName,


### PR DESCRIPTION
> **Disclaimer, I just had the issue for multiple times now where I wanted to /fork, /tree or /new and your extension crashed my (latest) pi install. Clanker did the rest.**

The original error:

```
 > /new /@mariozechner/pi-coding-agent/dist/core/extensions/runner.js:295
            throw new Error(this.staleMessage);────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
            ^<user-prompt-here>

Error: This extension instance is stale after session replacement or reload. Use the provided replacement-session context instead.
    at ExtensionRunner.assertActive (/@mariozechner/pi-coding-agent/dist/core/extensions/runner.js:295:19)
    at get ui (/@mariozechner/pi-coding-agent/dist/core/extensions/runner.js:380:24)
    at editor.render (/home/user/.pi/agent/git/github.com/nicobailon/pi-powerline-footer/index.ts:1795:55)
    at Container.render (/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-tui/dist/tui.js:64:38)
    at TUI.render (/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-tui/dist/tui.js:64:38)
    at TUI.doRender (/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-tui/dist/tui.js:691:29)
    at Timeout._onTimeout (/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-tui/dist/tui.js:350:18)
    at listOnTimeout (node:internal/timers:585:17)
    at process.processTimers (node:internal/timers:521:7)
```
---

## Error

Typing `/new` or `/fork` caused an immediate crash:

```
Error: This extension instance is stale after session replacement or reload.
    at ExtensionRunner.assertActive (runner.js:295:19)
    at get ui (runner.js:380:24)
    at editor.render (index.ts:1795:55)
    at TUI.doRender (tui.js:691:29)
    at Timeout._onTimeout (tui.js:350:18)
```

## Reproduction

1. Start Pi with `pi-powerline-footer` enabled.
2. Do some work.
3. Type `/new` and press Enter.
4. Crash — no new session is created.

## Root Cause

### The `/new` teardown sequence

When `/new` is typed, the framework runs the following steps:

1. **`runtimeHost.newSession()`** — Creates the new session.
3. **`teardownCurrent()`** → `session.dispose()` → `extensionRunner.invalidate()` — Sets `stale = true` on the old runner.
4. **`resetExtensionUI()`** — Restores the default editor, clears extension widgets and footers.
5. **`bindCurrentSessionExtensions()`** — Re-registers all extensions for the new session, firing `session_start`.

Between steps 2 and 3, the TUI's periodic render loop (~16ms interval) can fire. It calls `editor.render()` on the **old** editor instance — the one registered by the old session's extension.

### Why the closure capture causes a crash

The extension's `setupCustomEditor(ctx)` receives `ctx` as a parameter and defines closures that reference it:

```typescript
editor.render = (width) => {
  const layout = getResponsiveLayout(width, ctx.ui.theme);  // ← ctx is captured here
  // ...
};
```

This `ctx` is bound at `session_start` time for the **old** session. When the render loop fires after step 2, the callback accesses `ctx.ui.theme`. The `ctx.ui` getter delegates to `runner.ui`, which calls `assertActive()` — and the runner is already stale → **crash**.

### Why `currentCtx` is the correct fix

The extension already maintains a module-level `currentCtx` variable, updated on every `session_start` event. It always points to the **current** session's context. The bug is simply that several long-lived closures (render, input, async callbacks) still reference the captured `ctx` parameter instead of `currentCtx`.

The framework lifecycle is correct — it properly invalidates old runners and provides `session_start` / `session_shutdown` events. The extension just needs to use the module-level variable consistently in any closure that can outlive the session that created it.

### Why `session_shutdown` needed `currentCtx = null`

Several render callbacks already guard against null context (`if (!currentCtx) return lines;`). But without nulling `currentCtx` on shutdown, the variable still pointed to the old session's context during the stale window — the guard never fired, and the stale `ctx.ui` access proceeded to crash. Nulling it ensures the guards activate immediately.

## Fix

Three surgical changes in `index.ts`:

1. **`session_shutdown`** (line 981): Added `currentCtx = null` so existing null guards in render callbacks actually activate when the session ends.

2. **`editor.render`** (line 1796): Changed `ctx.ui.theme` → `currentCtx.ui.theme`. This is the direct crash point.

3. **`editor.handleInput`** (lines 1760, 1766): Changed `ctx.ui.setEditorComponent` and `dismissWelcome(ctx)` → use `currentCtx`.

All three changes follow the same pattern: use the module-level `currentCtx` (always pointing to the active session) instead of the closure-captured `ctx` (potentially stale).

## Notes

Additional `ctx` references remain in the bash-mode editor (`onNotify`, `onExitBashMode`) and bash-transcript widget render.
