### PR TITLE
fix/feat: accurate context tracking after compaction

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1582,6 +1582,94 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     },
   });
 
+  /**
+   * Estimate token count for a single message using chars/4 heuristic.
+   * Mirrors the core's estimateTokens() from compaction.ts.
+   */
+  function estimateMessageTokens(msg: any): number {
+    let chars = 0;
+
+    switch (msg.role) {
+      case "user": {
+        const content = msg.content;
+        if (typeof content === "string") {
+          chars = content.length;
+        } else if (Array.isArray(content)) {
+          for (const block of content) {
+            if (block?.type === "text" && block.text) {
+              chars += block.text.length;
+            }
+          }
+        }
+        return Math.ceil(chars / 4);
+      }
+      case "assistant": {
+        const content = msg.content;
+        if (Array.isArray(content)) {
+          for (const block of content) {
+            if (block?.type === "text") {
+              chars += block.text?.length ?? 0;
+            } else if (block?.type === "thinking") {
+              chars += block.thinking?.length ?? 0;
+            } else if (block?.type === "toolCall") {
+              chars += block.name?.length ?? 0;
+              chars += JSON.stringify(block.arguments ?? {}).length;
+            }
+          }
+        }
+        return Math.ceil(chars / 4);
+      }
+      case "toolResult": {
+        // Tool result messages have content (string) or result (string)
+        chars = (msg.content ?? msg.result ?? "").length;
+        return Math.ceil(chars / 4);
+      }
+      case "compactionSummary": {
+        // Compaction summary messages have a summary string
+        chars = msg.summary?.length ?? 0;
+        return Math.ceil(chars / 4);
+      }
+      case "branchSummary": {
+        // Branch summary messages have a summary string
+        chars = msg.summary?.length ?? 0;
+        return Math.ceil(chars / 4);
+      }
+      case "bashExecution": {
+        // Bash execution: command + output
+        chars = msg.command?.length ?? 0;
+        chars += msg.output?.length ?? 0;
+        return Math.ceil(chars / 4);
+      }
+      case "custom": {
+        const content = msg.content;
+        if (typeof content === "string") {
+          chars = content.length;
+        } else if (Array.isArray(content)) {
+          for (const block of content) {
+            if (block?.type === "text" && block.text) {
+              chars += block.text.length;
+            }
+          }
+        }
+        return Math.ceil(chars / 4);
+      }
+      default:
+        return 0;
+    }
+  }
+
+  /**
+   * Estimate total tokens from a messages array using chars/4 heuristic.
+   * Used as fallback when getContextUsage() returns null tokens (post-compaction gap).
+   */
+  function estimateTokensFromMessages(messages: any[]): number {
+    let total = 0;
+    for (const msg of messages) {
+      total += estimateMessageTokens(msg);
+    }
+    return total;
+  }
+
   function buildSegmentContext(ctx: any, theme: Theme): SegmentContext {
     const presetDef = getPreset(config.preset);
     const colors: ColorScheme = presetDef.colors ?? getDefaultColors();
@@ -1628,17 +1716,40 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const contextWindow = contextUsage
       ? contextUsage.contextWindow
       : (ctx.model?.contextWindow ?? 0);
-    const tokensInContext = contextUsage?.tokens ?? null;
-    const contextPercent = contextUsage
-      ? contextUsage.percent
-      : (lastAssistant && contextWindow > 0
-          ? ((lastAssistant.usage.input + lastAssistant.usage.output +
-              lastAssistant.usage.cacheRead + lastAssistant.usage.cacheWrite) / contextWindow) * 100
-          : 0);
-    // Note: ternary (not ??) for contextPercent — when contextUsage exists but
-    // percent is null (post-compaction gap), we must preserve null to show "?"
-    // in the segment. The fallback only applies when contextUsage is null
-    // (older Pi versions lacking getContextUsage).
+
+    // Determine tokens in context: prefer getContextUsage() result, then estimate
+    // from buildSessionContext() on post-compaction gap, then fall back to
+    // last-assistant calculation for older Pi versions.
+    let tokensInContext: number | null;
+    let contextPercent: number | null;
+
+    if (contextUsage?.tokens !== null) {
+      // Normal case: use getContextUsage() result directly
+      tokensInContext = contextUsage.tokens;
+      contextPercent = contextUsage.percent;
+    } else if (contextUsage) {
+      // Post-compaction gap: getContextUsage() exists but tokens are null.
+      // Try to estimate from the current session context messages.
+      const sessionCtx = ctx.sessionManager?.buildSessionContext?.();
+      if (sessionCtx && Array.isArray(sessionCtx.messages)) {
+        tokensInContext = estimateTokensFromMessages(sessionCtx.messages);
+        contextPercent = contextWindow > 0
+          ? (tokensInContext / contextWindow) * 100
+          : null;
+      } else {
+        // buildSessionContext unavailable — show unknown
+        tokensInContext = null;
+        contextPercent = null;
+      }
+    } else {
+      // Older Pi version lacking getContextUsage(): fall back to
+      // last-assistant calculation.
+      tokensInContext = null;
+      contextPercent = lastAssistant && contextWindow > 0
+        ? ((lastAssistant.usage.input + lastAssistant.usage.output +
+            lastAssistant.usage.cacheRead + lastAssistant.usage.cacheWrite) / contextWindow) * 100
+        : 0;
+    }
 
     // Get git status (cached)
     const gitBranch = footerDataRef?.getGitBranch() ?? null;

--- a/index.ts
+++ b/index.ts
@@ -1631,7 +1631,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const tokensInContext = contextUsage?.tokens ?? null;
     const contextPercent = contextUsage
       ? contextUsage.percent
-      : (lastAssistant
+      : (lastAssistant && contextWindow > 0
           ? ((lastAssistant.usage.input + lastAssistant.usage.output +
               lastAssistant.usage.cacheRead + lastAssistant.usage.cacheWrite) / contextWindow) * 100
           : 0);

--- a/index.ts
+++ b/index.ts
@@ -1260,6 +1260,12 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     requestRender();
   });
 
+  // Force re-render after compaction so the footer shows accurate context usage
+  pi.on("session_compact", async (_event, ctx) => {
+    currentCtx = ctx;
+    requestRender();
+  });
+
   // Command to toggle/configure
   pi.registerCommand("powerline", {
     description: "Configure powerline status (toggle, preset)",
@@ -1612,13 +1618,27 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       lastAssistant = m;
     }
 
-    // Calculate context percentage (total tokens used in last turn)
-    const contextTokens = lastAssistant
-      ? lastAssistant.usage.input + lastAssistant.usage.output +
-        lastAssistant.usage.cacheRead + lastAssistant.usage.cacheWrite
-      : 0;
-    const contextWindow = ctx.model?.contextWindow || 0;
-    const contextPercent = contextWindow > 0 ? (contextTokens / contextWindow) * 100 : 0;
+    // Calculate context usage using the core's getContextUsage() which handles
+    // compaction boundaries correctly. Falls back to last-assistant calculation
+    // if getContextUsage is unavailable (older Pi versions).
+    const contextUsage = typeof ctx.getContextUsage === "function"
+      ? (ctx.getContextUsage() ?? null)
+      : null;
+
+    const contextWindow = contextUsage
+      ? contextUsage.contextWindow
+      : (ctx.model?.contextWindow ?? 0);
+    const tokensInContext = contextUsage?.tokens ?? null;
+    const contextPercent = contextUsage
+      ? contextUsage.percent
+      : (lastAssistant
+          ? ((lastAssistant.usage.input + lastAssistant.usage.output +
+              lastAssistant.usage.cacheRead + lastAssistant.usage.cacheWrite) / contextWindow) * 100
+          : 0);
+    // Note: ternary (not ??) for contextPercent — when contextUsage exists but
+    // percent is null (post-compaction gap), we must preserve null to show "?"
+    // in the segment. The fallback only applies when contextUsage is null
+    // (older Pi versions lacking getContextUsage).
 
     // Get git status (cached)
     const gitBranch = footerDataRef?.getGitBranch() ?? null;
@@ -1640,6 +1660,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       sessionId: ctx.sessionManager?.getSessionId?.(),
       usageStats: { input, output, cacheRead, cacheWrite, cost },
       contextPercent,
+      tokensInContext,
       contextWindow,
       autoCompactEnabled: ctx.settingsManager?.getCompactionSettings?.()?.enabled ?? true,
       customCompactionEnabled: customCompactionEnabled || extensionStatuses.has(CUSTOM_COMPACTION_STATUS_KEY),

--- a/segments.ts
+++ b/segments.ts
@@ -287,6 +287,7 @@ const contextPctSegment: StatusLineSegment = {
   id: "context_pct",
   render(ctx) {
     if (ctx.customCompactionEnabled) return { content: "", visible: false };
+    if (!ctx.contextWindow) return { content: "", visible: false };
 
     const icons = getIcons();
     const pct = ctx.contextPercent;

--- a/segments.ts
+++ b/segments.ts
@@ -290,16 +290,26 @@ const contextPctSegment: StatusLineSegment = {
 
     const icons = getIcons();
     const pct = ctx.contextPercent;
+    const tokens = ctx.tokensInContext;
     const window = ctx.contextWindow;
 
     const autoIcon = ctx.autoCompactEnabled && icons.auto ? ` ${icons.auto}` : "";
-    const text = `${pct.toFixed(1)}%/${formatTokens(window)}${autoIcon}`;
+
+    // Show: pct - currentTokens/window (e.g. "19.1% - 12.6k/66k")
+    // During post-compaction gap, pct and tokens are null -> show "? - ?/66k"
+    const pctStr = pct !== null
+      ? `${pct.toFixed(1)}%`
+      : "?";
+    const tokensStr = tokens !== null
+      ? ` - ${formatTokens(tokens)}`
+      : " - ?";
+    const text = `${pctStr}${tokensStr}/${formatTokens(window)}${autoIcon}`;
 
     // Icon outside color, text inside - use semantic colors for thresholds
     let content: string;
-    if (pct > 90) {
+    if (pct !== null && pct > 90) {
       content = withIcon(icons.context, color(ctx, "contextError", text));
-    } else if (pct > 70) {
+    } else if (pct !== null && pct > 70) {
       content = withIcon(icons.context, color(ctx, "contextWarn", text));
     } else {
       content = withIcon(icons.context, color(ctx, "context", text));

--- a/types.ts
+++ b/types.ts
@@ -148,7 +148,8 @@ export interface SegmentContext {
   
   // Computed
   usageStats: UsageStats;
-  contextPercent: number;
+  contextPercent: number | null;
+  tokensInContext: number | null;
   contextWindow: number;
   autoCompactEnabled: boolean;
   customCompactionEnabled: boolean;


### PR DESCRIPTION
In my opinion the footer didn't really represent well the token count, it didn't show the amount of tokens that will be injected in the next turn to the model, and the "in: " section just keeps accumulating (which is fine for tracking)

My approach:

Initial state

1. dir /mnt/e/pi-mono >  **in: 221k** > out: 33k > cache in: 3.9M > ◫ **46.0%/66k AC** 

/reload

2. dir /mnt/e/pi-mono >  in: 221k > out: 33k > cache in: 3.9M > ◫ **46.0% - 30k/66k AC** 

_(shows the same percentage, but now shows the token count/context size)_

/compact

4. dir /mnt/e/pi-mono >  in: 236k > out: 34k > cache in: 4.0M > **◫ 24.7% - 16k/66k AC**

after compaction it accurately represents the token count that will be injected with the next turn. (safely adds an estimate mirrored from pi-mono)

---

> Disclaimer:
> I just prompted, clanker did the rest, but for me it works fine (in combination with #32 , otherwise /reload wouldn't work, but I made separate PR-s, but should be mergeable).
> Everything below is written by the model.

## Problem

The `context_pct` segment showed stale or misleading values after compaction. Three underlying issues caused this:

1. **Percentage derived from last-turn usage, not actual context size.** The extension computed `contextPercent` from the last assistant message's `usage.input + output + cacheRead + cacheWrite`. This represents a single LLM call's token consumption, not the total context being sent. After compaction, the last assistant message was pre-compaction — so the percentage reflected the old, inflated context.

2. **No compaction event handling.** The extension never subscribed to `session_compact`, so it had no mechanism to re-render the footer immediately after compaction.

3. **No current context token display.** The `context_pct` segment showed `19.1%/66k` — a percentage and window size, but no actual token count.

### Observed Behavior

```
Before compaction:  ◫ 93.1%/66k
After compaction:   ◫ 93.1%/66k    ← stale, context was actually much smaller
After new response: ◫ 19.1%/66k    ← drops, but shows no token count
```

## Approach

Delegate to the Pi core's `ctx.getContextUsage()` API, which handles compaction boundaries correctly: it finds the latest `CompactionEntry`, only trusts usage from assistant messages after the compaction boundary, and returns `{ tokens: null, percent: null }` during the post-compaction gap.

To fill that gap, estimate tokens from `buildSessionContext()` using the core's chars/4 heuristic — same approach used internally by the compaction system.

**Backward compatibility:** `token_in`, `token_out`, and other cumulative segments remain unchanged.

## Changes

### 1. Use `ctx.getContextUsage()` for context tracking

Calls `ctx.getContextUsage()` and reads `percent` and `tokens` directly. Falls back to last-assistant calculation only when `getContextUsage` is unavailable (older Pi versions).

`contextPercent` uses a ternary (not `??`) so that `null` values from the core are preserved — the fallback only applies when `contextUsage` itself is `null`.

### 2. Add `tokensInContext` to segment context

New field `tokensInContext: number | null` on `SegmentContext`, populated from `ctx.getContextUsage().tokens`.

### 3. Estimate post-compaction context from session messages

When `getContextUsage()` returns `null` tokens (post-compaction gap), estimate tokens from `ctx.sessionManager.buildSessionContext()` using the core's chars/4 heuristic.

Added `estimateMessageTokens()` and `estimateTokensFromMessages()` helpers that mirror the core's `estimateTokens()` from `compaction.ts`. Handles all message types: user, assistant, toolResult, compactionSummary, branchSummary, bashExecution, custom.

**Post-compaction gap:** Shows estimated values (e.g., `15.2% - 10.0k/66k`) instead of `?`. If estimation fails, falls back to `?`.

### 4. Extend `context_pct` display format

**Before:** `◫ 19.1%/66k`

**After:** `◫ 19.1% - 12.6k/66k`

Null-safe rendering guards the color thresholds so the segment doesn't mis-color during the gap. Added `if (!ctx.contextWindow)` early return to hide the segment when no context window is available.

### 5. Subscribe to `session_compact` for immediate re-render

Subscribes to `session_compact`, updates the context reference, and forces an immediate re-render.

### 6. Guard against division by zero

Added `contextWindow > 0` guard in the fallback path to prevent `Infinity` rendering.

## Impact

| Segment | Before | After |
|---|---|---|
| `context_pct` | `19.1%/66k` (stale after compaction) | `19.1% - 12.6k/66k` (core-backed, accurate) |
| `context_pct` (gap) | Shows stale pre-compaction value | Estimated from session messages |
| `token_in` | Lifetime cumulative | **Unchanged** |
| `token_out` | Lifetime cumulative | **Unchanged** |
| `cost` | Lifetime cumulative | **Unchanged** |

The extended format adds ~8–12 characters per segment. The responsive layout handles overflow by demoting segments to the secondary line.

## Files Changed

- `types.ts` — Added `tokensInContext: number | null`; changed `contextPercent` to `number | null`
- `index.ts` — Uses `ctx.getContextUsage()` for context tracking; estimates from `buildSessionContext()` during post-compaction gap; subscribes to `session_compact`; guards against division by zero
- `segments.ts` — `context_pct` renders `pct - tokens/window` format with null handling; hides on zero context window
