### PR TITLE
feat(powerline): implement configurable custom preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Configurable custom preset layout** — `powerline.preset: "custom"` can now define explicit segment rows, separator style, and per-segment options through `powerline.custom`, including `custom:<id>` entries for promoted extension statuses.
+
 ## [0.5.1] - 2026-05-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Configurable custom preset layout** — `powerline.preset: "custom"` can define explicit segment rows and separator style through `powerline.custom`, including `custom:<id>` entries for promoted extension statuses.
 - **Fixed-editor scroll-away shortcut hint card** — Shows a stacked bottom/user/assistant shortcut card when chat is scrolled away from the bottom; clicking anywhere in the card jumps back to the bottom when fixed-editor mouse handling is enabled.
 - **Welcome toggle** — Added `powerline.welcome` so the startup welcome UI can be disabled without disabling the footer. Thanks to OCPdev25, miloslavnosek, vzeazy, and Florian Kinder (@fank) for #48/#89.
 - **Display options** — Added `powerline.cost.subscriptionDisplay` and `powerline.model.display` for subscription cost and provider-qualified model names. Thanks to Alexandr Burdiyan (@burdiyan), Meidhy (@dymayday), Mathu Mounasamy (@Mathuv), and pserey for #3/#83/#50.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,31 @@ You can promote any extension status key into its own dedicated powerline item. 
 - `hideWhenMissing` (optional): hide item when no status is present (default `true`)
 - `excludeFromExtensionStatuses` (optional): omit this key from the aggregate `extension_statuses` segment (default `true`)
 
+### Custom preset layout
+
+Use `"preset": "custom"` to define explicit rows instead of appending `customItems` by position:
+
+```json
+{
+  "powerline": {
+    "preset": "custom",
+    "custom": {
+      "separator": "powerline-thin",
+      "leftSegments": ["custom:model_display", "path", "git"],
+      "rightSegments": ["custom:context_gauge"],
+      "secondarySegments": [],
+      "options": { "path": { "mode": "basename" } }
+    },
+    "customItems": [
+      { "id": "model_display" },
+      { "id": "context_gauge" }
+    ]
+  }
+}
+```
+
+`leftSegments`, `rightSegments`, and `secondarySegments` accept the built-in segment ids below plus `custom:<id>` entries for configured custom items. With `preset: "custom"`, custom item `position` is ignored.
+
 If you still prefer the old style, `"powerline": "default"` continues to work.
 
 ## Bash mode
@@ -322,6 +347,8 @@ Configure via preset options: `path: { mode: "full" }`
 ## Segments
 
 `model` · `thinking` · `shell_mode` · `path` · `git` · `subagents` · `token_in` · `token_out` · `token_total` · `cost` · `context_pct` · `context_total` · `time_spent` · `time` · `session` · `hostname` · `cache_read` · `cache_write`
+
+Custom preset layouts can also use `custom:<id>` entries for configured custom items.
 
 ## Separators
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,30 @@ You can promote any extension status key into its own dedicated powerline item. 
 - `hideWhenMissing` (optional): hide item when no status is present (default `true`)
 - `excludeFromExtensionStatuses` (optional): omit this key from the aggregate `extension_statuses` segment (default `true`)
 
+### Custom preset layout
+
+Use `"preset": "custom"` to define explicit rows instead of appending `customItems` by position:
+
+```json
+{
+  "powerline": {
+    "preset": "custom",
+    "custom": {
+      "separator": "powerline-thin",
+      "leftSegments": ["custom:model_display", "path", "git"],
+      "rightSegments": ["custom:context_gauge"],
+      "secondarySegments": []
+    },
+    "customItems": [
+      { "id": "model_display" },
+      { "id": "context_gauge" }
+    ]
+  }
+}
+```
+
+`leftSegments`, `rightSegments`, and `secondarySegments` accept the built-in segment ids below plus `custom:<id>` entries for configured custom items. With `preset: "custom"`, custom item `position` is ignored. Configure built-in segment options with the top-level `powerline.path`, `powerline.git`, `powerline.model`, and `powerline.time` settings.
+
 If you still prefer the older string preset config shape, `"powerline": "default"` continues to work. String preset shorthand keeps `welcome` enabled and uses the default shortcut/cost/model display settings.
 
 ### Demo settings
@@ -371,6 +395,8 @@ Use `"off"` to disable extension-owned git polling entirely and only show the br
 ## Segments
 
 `model` · `thinking` · `shell_mode` · `path` · `git` · `subagents` · `token_in` · `token_out` · `token_total` · `cost` · `context_pct` · `context_total` · `time_spent` · `time` · `session` · `hostname` · `cache_read` · `cache_write`
+
+Custom preset layouts can also use `custom:<id>` entries for configured custom items.
 
 ## Separators
 

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 
-import type { ColorScheme, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.js";
+import type { ColorScheme, PresetDef, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.js";
 import type { PowerlineConfig } from "./powerline-config.js";
 import { BashTranscriptStore } from "./bash-mode/transcript.ts";
 import {
@@ -24,8 +24,8 @@ import { BashModeEditor } from "./bash-mode/editor.ts";
 import { ManagedShellSession } from "./bash-mode/shell-session.ts";
 import { matchHistoryEntries, readGlobalShellHistory, readProjectHistory, appendProjectHistory } from "./bash-mode/history.ts";
 import type { BashModeSettings } from "./bash-mode/types.ts";
-import { getPreset, PRESETS } from "./presets.js";
-import { collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, parsePowerlineConfig } from "./powerline-config.js";
+import { PRESETS } from "./presets.js";
+import { collectHiddenExtensionStatusKeys, customPresetFromConfig, getNotificationExtensionStatuses, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, parsePowerlineConfig } from "./powerline-config.js";
 import { getSeparator } from "./separators.js";
 import { renderSegment } from "./segments.js";
 import { getGitStatus, invalidateGitStatus, invalidateGitBranch } from "./git-status.js";
@@ -635,10 +635,10 @@ function writePowerlineOptionSetting(
   ));
 }
 
-const PRESET_NAMES = Object.keys(PRESETS) as StatusLinePreset[];
+const PRESET_NAMES = [...Object.keys(PRESETS), "custom"] as StatusLinePreset[];
 
 function isValidPreset(value: unknown): value is StatusLinePreset {
-  return typeof value === "string" && Object.prototype.hasOwnProperty.call(PRESETS, value);
+  return typeof value === "string" && (value === "custom" || Object.prototype.hasOwnProperty.call(PRESETS, value));
 }
 
 function normalizePreset(value: unknown): StatusLinePreset | null {
@@ -862,7 +862,7 @@ function renderSegmentWithWidth(
 /** Build content string from pre-rendered parts */
 function buildContentFromParts(
   parts: string[],
-  presetDef: ReturnType<typeof getPreset>
+  presetDef: PresetDef
 ): string {
   if (parts.length === 0) return "";
   const separatorDef = getSeparator(presetDef.separator);
@@ -878,16 +878,18 @@ function buildContentFromParts(
  */
 function computeResponsiveLayout(
   ctx: SegmentContext,
-  presetDef: ReturnType<typeof getPreset>,
+  presetDef: PresetDef,
   availableWidth: number
 ): { topContent: string; secondaryContent: string } {
   const separatorDef = getSeparator(presetDef.separator);
   const sepWidth = visibleWidth(separatorDef.left) + 2; // separator + spaces around it
   
   // Get all segments: primary first, then secondary
-  const mergedSegments = mergeSegmentsWithCustomItems(presetDef, config.customItems);
-  const primaryIds = [...mergedSegments.leftSegments, ...mergedSegments.rightSegments];
-  const secondaryIds = mergedSegments.secondarySegments;
+  const segments = config.preset === "custom"
+    ? presetDef
+    : mergeSegmentsWithCustomItems(presetDef, config.customItems);
+  const primaryIds = [...segments.leftSegments, ...segments.rightSegments];
+  const secondaryIds = segments.secondarySegments ?? [];
   const allSegmentIds = [...primaryIds, ...secondaryIds];
   
   // Render all segments and get their widths
@@ -2047,7 +2049,9 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   });
 
   function buildSegmentContext(ctx: any, theme: Theme): SegmentContext {
-    const presetDef = getPreset(config.preset);
+    const presetDef = config.preset === "custom"
+      ? customPresetFromConfig(config, PRESETS.default.colors)
+      : PRESETS[config.preset] ?? PRESETS.default;
     const colors: ColorScheme = presetDef.colors ?? getDefaultColors();
 
     // Build usage stats and get thinking level from session
@@ -2151,7 +2155,9 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       }
     }
     
-    const presetDef = getPreset(config.preset);
+    const presetDef = config.preset === "custom"
+      ? customPresetFromConfig(config, PRESETS.default.colors)
+      : PRESETS[config.preset] ?? PRESETS.default;
     const segmentCtx = buildSegmentContext(currentCtx, theme);
     
     lastLayoutWidth = width;

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@ import { isKeyRelease, type AutocompleteProvider, type SelectItem, SelectList, t
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 
-import type { ColorScheme, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
+import type { ColorScheme, PresetDef, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
 import type { PowerlineConfig } from "./powerline-config.ts";
 import { BashTranscriptStore } from "./bash-mode/transcript.ts";
 import {
@@ -25,7 +25,7 @@ import { matchHistoryEntries, readGlobalShellHistory, readProjectHistory, append
 import type { BashModeSettings } from "./bash-mode/types.ts";
 import { getPreset, PRESETS } from "./presets.ts";
 import { getAgentPath } from "./paths.ts";
-import { collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, mergeSegmentOptions, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, parsePowerlineConfig } from "./powerline-config.ts";
+import { collectHiddenExtensionStatusKeys, customPresetFromConfig, getNotificationExtensionStatuses, mergeSegmentOptions, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, parsePowerlineConfig } from "./powerline-config.ts";
 import { getSeparator } from "./separators.ts";
 import { renderSegment } from "./segments.ts";
 import { getGitStatus, invalidateGitStatus, invalidateGitBranch } from "./git-status.ts";
@@ -639,10 +639,10 @@ function writePowerlineOptionSetting(
   ));
 }
 
-const PRESET_NAMES = Object.keys(PRESETS) as StatusLinePreset[];
+const PRESET_NAMES = [...Object.keys(PRESETS), "custom"] as StatusLinePreset[];
 
 function isValidPreset(value: unknown): value is StatusLinePreset {
-  return typeof value === "string" && Object.prototype.hasOwnProperty.call(PRESETS, value);
+  return typeof value === "string" && (value === "custom" || Object.prototype.hasOwnProperty.call(PRESETS, value));
 }
 
 function normalizePreset(value: unknown): StatusLinePreset | null {
@@ -652,6 +652,12 @@ function normalizePreset(value: unknown): StatusLinePreset | null {
 
   const preset = value.trim().toLowerCase();
   return isValidPreset(preset) ? preset : null;
+}
+
+function resolvePreset(config: PowerlineConfig): PresetDef {
+  return config.preset === "custom"
+    ? customPresetFromConfig(config, PRESETS.default.colors)
+    : getPreset(config.preset);
 }
 
 function hasNonWhitespaceText(text: string): boolean {
@@ -947,7 +953,7 @@ function renderSegmentWithWidth(
 /** Build content string from pre-rendered parts */
 function buildContentFromParts(
   parts: string[],
-  presetDef: ReturnType<typeof getPreset>
+  presetDef: PresetDef
 ): string {
   if (parts.length === 0) return "";
   const separatorDef = getSeparator(presetDef.separator);
@@ -963,16 +969,18 @@ function buildContentFromParts(
  */
 function computeResponsiveLayout(
   ctx: SegmentContext,
-  presetDef: ReturnType<typeof getPreset>,
+  presetDef: PresetDef,
   availableWidth: number
 ): { topContent: string; secondaryContent: string } {
   const separatorDef = getSeparator(presetDef.separator);
   const sepWidth = visibleWidth(separatorDef.left) + 2; // separator + spaces around it
   
   // Get all segments: primary first, then secondary
-  const mergedSegments = mergeSegmentsWithCustomItems(presetDef, config.customItems);
-  const primaryIds = [...mergedSegments.leftSegments, ...mergedSegments.rightSegments];
-  const secondaryIds = mergedSegments.secondarySegments;
+  const segments = config.preset === "custom"
+    ? presetDef
+    : mergeSegmentsWithCustomItems(presetDef, config.customItems);
+  const primaryIds = [...segments.leftSegments, ...segments.rightSegments];
+  const secondaryIds = segments.secondarySegments ?? [];
   const allSegmentIds = [...primaryIds, ...secondaryIds];
   
   // Render all segments and get their widths
@@ -1918,7 +1926,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       }
 
       // Show available presets
-      const presetList = Object.keys(PRESETS).join(", ");
+      const presetList = PRESET_NAMES.join(", ");
       ctx.ui.notify(`Available presets: ${presetList}`, "info");
     },
   });
@@ -2099,7 +2107,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   });
 
   function buildSegmentContext(ctx: any, theme: Theme): SegmentContext {
-    const presetDef = getPreset(config.preset);
+    const presetDef = resolvePreset(config);
     const colors: ColorScheme = presetDef.colors ?? getDefaultColors();
 
     // Build usage stats and get thinking level from session
@@ -2206,7 +2214,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       }
     }
 
-    const presetDef = getPreset(config.preset);
+    const presetDef = resolvePreset(config);
     let segmentCtx: SegmentContext;
     try {
       segmentCtx = buildSegmentContext(currentCtx, theme);

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,9 +1,10 @@
 import { visibleWidth } from "@mariozechner/pi-tui";
-import type { ColorValue, CustomItemPosition, CustomStatusItem, PresetDef, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
+import type { ColorScheme, ColorValue, CustomItemPosition, CustomPresetConfig, CustomStatusItem, PresetDef, StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle, StatusLineSegmentOptions } from "./types.ts";
 
 export interface PowerlineConfig {
   preset: StatusLinePreset;
   customItems: CustomStatusItem[];
+  custom?: CustomPresetConfig;
   mouseScroll: boolean;
   fixedEditor: boolean;
 }
@@ -40,6 +41,52 @@ function normalizeCustomPrefix(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const normalized = value.trim();
   return normalized ? normalized : undefined;
+}
+
+function normalizeSegmentId(value: unknown): StatusLineSegmentId | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  return normalized as StatusLineSegmentId;
+}
+
+function normalizeSegmentIds(value: unknown): StatusLineSegmentId[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.map(normalizeSegmentId).filter((id): id is StatusLineSegmentId => Boolean(id));
+}
+
+function normalizeSeparator(value: unknown): StatusLineSeparatorStyle | undefined {
+  switch (value) {
+    case "powerline":
+    case "powerline-thin":
+    case "slash":
+    case "pipe":
+    case "block":
+    case "none":
+    case "ascii":
+    case "dot":
+    case "chevron":
+    case "star":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function normalizeSegmentOptions(value: unknown): StatusLineSegmentOptions | undefined {
+  return isRecord(value) ? (value as StatusLineSegmentOptions) : undefined;
+}
+
+function normalizeCustomPreset(raw: unknown): CustomPresetConfig | undefined {
+  if (!isRecord(raw)) return undefined;
+
+  return {
+    leftSegments: normalizeSegmentIds(raw.leftSegments),
+    rightSegments: normalizeSegmentIds(raw.rightSegments),
+    secondarySegments: normalizeSegmentIds(raw.secondarySegments),
+    separator: normalizeSeparator(raw.separator),
+    segmentOptions: normalizeSegmentOptions(raw.options),
+  };
 }
 
 function normalizeCustomStatusItem(raw: unknown, idOverride?: string): CustomStatusItem | null {
@@ -94,8 +141,20 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
   return {
     preset: normalizePreset(value.preset, presets) ?? defaultConfig.preset,
     customItems: normalizeCustomItems(value.customItems),
+    custom: normalizeCustomPreset(value.custom),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,
+  };
+}
+
+export function customPresetFromConfig(config: PowerlineConfig, colors?: ColorScheme): PresetDef {
+  return {
+    leftSegments: config.custom?.leftSegments ?? [],
+    rightSegments: config.custom?.rightSegments ?? [],
+    secondarySegments: config.custom?.secondarySegments ?? [],
+    separator: config.custom?.separator ?? "powerline-thin",
+    segmentOptions: config.custom?.segmentOptions ?? {},
+    colors,
   };
 }
 

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,10 +1,11 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
-import type { ColorValue, CustomItemPosition, CustomStatusItem, PresetDef, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions } from "./types.ts";
+import type { ColorScheme, ColorValue, CustomItemPosition, CustomPresetConfig, CustomStatusItem, PresetDef, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions, StatusLineSeparatorStyle } from "./types.ts";
 
 export interface PowerlineConfig {
   preset: StatusLinePreset;
   customItems: CustomStatusItem[];
   segmentOptions: StatusLineSegmentOptions;
+  custom?: CustomPresetConfig;
   mouseScroll: boolean;
   fixedEditor: boolean;
   welcome: boolean;
@@ -43,6 +44,36 @@ function normalizeCustomPrefix(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const normalized = value.trim();
   return normalized ? normalized : undefined;
+}
+
+function normalizeSegmentId(value: unknown): StatusLineSegmentId | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  return normalized as StatusLineSegmentId;
+}
+
+function normalizeSegmentIds(value: unknown): StatusLineSegmentId[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.map(normalizeSegmentId).filter((id): id is StatusLineSegmentId => Boolean(id));
+}
+
+function normalizeSeparator(value: unknown): StatusLineSeparatorStyle | undefined {
+  switch (value) {
+    case "powerline":
+    case "powerline-thin":
+    case "slash":
+    case "pipe":
+    case "block":
+    case "none":
+    case "ascii":
+    case "dot":
+    case "chevron":
+    case "star":
+      return value;
+    default:
+      return undefined;
+  }
 }
 
 function normalizeCustomStatusItem(raw: unknown, idOverride?: string): CustomStatusItem | null {
@@ -135,6 +166,17 @@ function normalizeSegmentOptions(raw: Record<string, unknown>): StatusLineSegmen
   return options;
 }
 
+function normalizeCustomPreset(raw: unknown): CustomPresetConfig | undefined {
+  if (!isRecord(raw)) return undefined;
+
+  return {
+    leftSegments: normalizeSegmentIds(raw.leftSegments),
+    rightSegments: normalizeSegmentIds(raw.rightSegments),
+    secondarySegments: normalizeSegmentIds(raw.secondarySegments),
+    separator: normalizeSeparator(raw.separator),
+  };
+}
+
 export function mergeSegmentOptions(
   defaults: StatusLineSegmentOptions = {},
   overrides: StatusLineSegmentOptions = {},
@@ -170,10 +212,22 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     preset: normalizePreset(value.preset, presets) ?? defaultConfig.preset,
     customItems: normalizeCustomItems(value.customItems),
     segmentOptions: normalizeSegmentOptions(value),
+    custom: normalizeCustomPreset(value.custom),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,
     welcome: value.welcome !== false,
     stashSharpSShortcut: value.stashSharpSShortcut === true,
+  };
+}
+
+export function customPresetFromConfig(config: PowerlineConfig, colors?: ColorScheme): PresetDef {
+  return {
+    leftSegments: config.custom?.leftSegments ?? [],
+    rightSegments: config.custom?.rightSegments ?? [],
+    secondarySegments: config.custom?.secondarySegments ?? [],
+    separator: config.custom?.separator ?? "powerline-thin",
+    segmentOptions: {},
+    colors,
   };
 }
 

--- a/presets.ts
+++ b/presets.ts
@@ -1,4 +1,4 @@
-import type { ColorScheme, PresetDef, StatusLinePreset } from "./types.ts";
+import type { BuiltinStatusLinePreset, ColorScheme, PresetDef } from "./types.ts";
 import { getDefaultColors } from "./theme.ts";
 
 // Get base colors from theme.ts (single source of truth)
@@ -21,7 +21,7 @@ const NERD_COLORS: ColorScheme = {
   cost: "warning",
 };
 
-export const PRESETS: Record<StatusLinePreset, PresetDef> = {
+export const PRESETS: Record<BuiltinStatusLinePreset, PresetDef> = {
   default: {
     leftSegments: ["model", "thinking", "shell_mode", "path", "git", "context_pct", "cache_read", "cost"],
     rightSegments: [],
@@ -94,16 +94,8 @@ export const PRESETS: Record<StatusLinePreset, PresetDef> = {
       git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: true },
     },
   },
-
-  custom: {
-    leftSegments: ["model", "shell_mode", "path", "git"],
-    rightSegments: ["token_total", "cost", "context_pct"],
-    separator: "powerline-thin",
-    colors: DEFAULT_COLORS,
-    segmentOptions: {},
-  },
 };
 
-export function getPreset(name: StatusLinePreset): PresetDef {
+export function getPreset(name: BuiltinStatusLinePreset): PresetDef {
   return PRESETS[name] ?? PRESETS.default;
 }

--- a/presets.ts
+++ b/presets.ts
@@ -1,4 +1,4 @@
-import type { ColorScheme, PresetDef, StatusLinePreset } from "./types.js";
+import type { BuiltinStatusLinePreset, ColorScheme, PresetDef } from "./types.js";
 import { getDefaultColors } from "./theme.js";
 
 // Get base colors from theme.ts (single source of truth)
@@ -21,7 +21,7 @@ const NERD_COLORS: ColorScheme = {
   cost: "warning",
 };
 
-export const PRESETS: Record<StatusLinePreset, PresetDef> = {
+export const PRESETS: Record<BuiltinStatusLinePreset, PresetDef> = {
   default: {
     leftSegments: ["model", "thinking", "shell_mode", "path", "git", "context_pct", "cache_read", "cost"],
     rightSegments: [],
@@ -94,16 +94,4 @@ export const PRESETS: Record<StatusLinePreset, PresetDef> = {
       git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: true },
     },
   },
-
-  custom: {
-    leftSegments: ["model", "shell_mode", "path", "git"],
-    rightSegments: ["token_total", "cost", "context_pct"],
-    separator: "powerline-thin",
-    colors: DEFAULT_COLORS,
-    segmentOptions: {},
-  },
 };
-
-export function getPreset(name: StatusLinePreset): PresetDef {
-  return PRESETS[name] ?? PRESETS.default;
-}

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, normalizeExtensionStatusValue, parsePowerlineConfig, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, normalizeCompactExtensionStatus } from "../powerline-config.ts";
+import { collectHiddenExtensionStatusKeys, customPresetFromConfig, getNotificationExtensionStatuses, normalizeExtensionStatusValue, parsePowerlineConfig, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, normalizeCompactExtensionStatus } from "../powerline-config.ts";
 
 test("parsePowerlineConfig supports object config with custom items", () => {
   const config = parsePowerlineConfig(
@@ -42,6 +42,45 @@ test("parsePowerlineConfig supports disabling fixed editor", () => {
 
   assert.equal(config.preset, "compact");
   assert.equal(config.fixedEditor, false);
+});
+
+test("parsePowerlineConfig supports custom preset layout", () => {
+  const config = parsePowerlineConfig(
+    {
+      preset: "custom",
+      custom: {
+        separator: "powerline-thin",
+        leftSegments: ["custom:model_display", "path", "git"],
+        rightSegments: ["custom:context_gauge"],
+        secondarySegments: [],
+        options: { path: { mode: "basename" } },
+      },
+      customItems: [{ id: "context_gauge" }],
+    },
+    ["default", "custom"],
+  );
+
+  assert.equal(config.preset, "custom");
+  assert.deepEqual(config.custom?.leftSegments, ["custom:model_display", "path", "git"]);
+  assert.deepEqual(config.custom?.rightSegments, ["custom:context_gauge"]);
+  assert.deepEqual(config.custom?.secondarySegments, []);
+  assert.equal(config.custom?.separator, "powerline-thin");
+  assert.deepEqual(config.custom?.segmentOptions, { path: { mode: "basename" } });
+});
+
+test("customPresetFromConfig builds a config-defined preset", () => {
+  const colors = { model: "accent" } as const;
+  const config = parsePowerlineConfig(
+    { preset: "custom", custom: { leftSegments: ["custom:model_display"], rightSegments: [], separator: "powerline" } },
+    ["default", "custom"],
+  );
+  const resolved = customPresetFromConfig(config, colors);
+
+  assert.deepEqual(resolved.leftSegments, ["custom:model_display"]);
+  assert.deepEqual(resolved.rightSegments, []);
+  assert.deepEqual(resolved.secondarySegments, []);
+  assert.equal(resolved.separator, "powerline");
+  assert.equal(resolved.colors, colors);
 });
 
 test("mergeSegmentsWithCustomItems appends custom segment ids by position", () => {

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, normalizeExtensionStatusValue, parsePowerlineConfig, mergeSegmentOptions, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, normalizeCompactExtensionStatus } from "../powerline-config.ts";
+import { collectHiddenExtensionStatusKeys, customPresetFromConfig, getNotificationExtensionStatuses, normalizeExtensionStatusValue, parsePowerlineConfig, mergeSegmentOptions, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, normalizeCompactExtensionStatus } from "../powerline-config.ts";
 
 test("parsePowerlineConfig supports object config with custom items", () => {
   const config = parsePowerlineConfig(
@@ -95,6 +95,44 @@ test("mergeSegmentOptions lets user config override preset segment defaults", ()
       cost: { subscriptionDisplay: "reported-cost" },
     },
   );
+});
+
+test("parsePowerlineConfig supports custom preset layout", () => {
+  const config = parsePowerlineConfig(
+    {
+      preset: "custom",
+      custom: {
+        separator: "powerline-thin",
+        leftSegments: ["custom:model_display", "path", "git"],
+        rightSegments: ["custom:context_gauge"],
+        secondarySegments: [],
+      },
+      customItems: [{ id: "context_gauge" }],
+    },
+    ["default", "custom"],
+  );
+
+  assert.equal(config.preset, "custom");
+  assert.deepEqual(config.custom?.leftSegments, ["custom:model_display", "path", "git"]);
+  assert.deepEqual(config.custom?.rightSegments, ["custom:context_gauge"]);
+  assert.deepEqual(config.custom?.secondarySegments, []);
+  assert.equal(config.custom?.separator, "powerline-thin");
+});
+
+test("customPresetFromConfig builds a config-defined preset", () => {
+  const colors = { model: "accent" } as const;
+  const config = parsePowerlineConfig(
+    { preset: "custom", custom: { leftSegments: ["custom:model_display"], rightSegments: [], separator: "powerline" } },
+    ["default", "custom"],
+  );
+  const resolved = customPresetFromConfig(config, colors);
+
+  assert.deepEqual(resolved.leftSegments, ["custom:model_display"]);
+  assert.deepEqual(resolved.rightSegments, []);
+  assert.deepEqual(resolved.secondarySegments, []);
+  assert.equal(resolved.separator, "powerline");
+  assert.deepEqual(resolved.segmentOptions, {});
+  assert.equal(resolved.colors, colors);
 });
 
 test("mergeSegmentsWithCustomItems appends custom segment ids by position", () => {

--- a/types.ts
+++ b/types.ts
@@ -65,14 +65,15 @@ export type StatusLineSeparatorStyle =
   | "star";
 
 // Preset names
-export type StatusLinePreset =
+export type BuiltinStatusLinePreset =
   | "default"
   | "minimal"
   | "compact"
   | "full"
   | "nerd"
-  | "ascii"
-  | "custom";
+  | "ascii";
+
+export type StatusLinePreset = BuiltinStatusLinePreset | "custom";
 
 // Per-segment options
 export interface StatusLineSegmentOptions {
@@ -99,15 +100,17 @@ export interface CustomStatusItem {
 
 // Preset definition
 export interface PresetDef {
-  leftSegments: BuiltinStatusLineSegmentId[];
-  rightSegments: BuiltinStatusLineSegmentId[];
+  leftSegments: StatusLineSegmentId[];
+  rightSegments: StatusLineSegmentId[];
   /** Secondary row segments (shown in footer, above sub bar) */
-  secondarySegments?: BuiltinStatusLineSegmentId[];
+  secondarySegments?: StatusLineSegmentId[];
   separator: StatusLineSeparatorStyle;
   segmentOptions?: StatusLineSegmentOptions;
   /** Color scheme for this preset */
   colors?: ColorScheme;
 }
+
+export type CustomPresetConfig = Partial<Omit<PresetDef, "colors">>;
 
 // Separator definition
 export interface SeparatorDef {

--- a/types.ts
+++ b/types.ts
@@ -65,14 +65,15 @@ export type StatusLineSeparatorStyle =
   | "star";
 
 // Preset names
-export type StatusLinePreset =
+export type BuiltinStatusLinePreset =
   | "default"
   | "minimal"
   | "compact"
   | "full"
   | "nerd"
-  | "ascii"
-  | "custom";
+  | "ascii";
+
+export type StatusLinePreset = BuiltinStatusLinePreset | "custom";
 
 // Per-segment options
 export interface StatusLineSegmentOptions {
@@ -106,15 +107,17 @@ export interface CustomStatusItem {
 
 // Preset definition
 export interface PresetDef {
-  leftSegments: BuiltinStatusLineSegmentId[];
-  rightSegments: BuiltinStatusLineSegmentId[];
+  leftSegments: StatusLineSegmentId[];
+  rightSegments: StatusLineSegmentId[];
   /** Secondary row segments (shown in footer, above sub bar) */
-  secondarySegments?: BuiltinStatusLineSegmentId[];
+  secondarySegments?: StatusLineSegmentId[];
   separator: StatusLineSeparatorStyle;
   segmentOptions?: StatusLineSegmentOptions;
   /** Color scheme for this preset */
   colors?: ColorScheme;
 }
+
+export type CustomPresetConfig = Partial<Pick<PresetDef, "leftSegments" | "rightSegments" | "secondarySegments" | "separator">>;
 
 // Separator definition
 export interface SeparatorDef {


### PR DESCRIPTION
Closes #37.

This implements the existing `custom` preset name as a real configurable layout preset.

Previously, `custom` was listed as valid but behaved like a fixed preset. With this change, setting:

```json
{
  "powerline": {
    "preset": "custom",
    "custom": {
      "separator": "powerline-thin",
      "leftSegments": ["model", "path", "git"],
      "rightSegments": ["custom:ci"],
      "secondarySegments": []
    },
    "customItems": [
      { "id": "ci", "statusKey": "ci-status" }
    ]
  }
}
```

now lets users choose the exact segment layout.

## What changed

- Removed `custom` from the fixed built-in preset table
- Treat `custom` as a config-defined preset
- Allow `custom:<id>` entries in the configured layout
- For `preset: "custom"`, do not auto-append `customItems`; they render only where explicitly listed as `custom:<id>`

## What stayed the same

- Existing `customItems` append-by-position behavior is preserved for non-`custom` presets

## Validation

- Added tests for parsing and resolving `powerline.custom`
- Ran the full test suite:

```sh
npm test
```

All 130 tests passed.

- Smoke-tested in real `pi` using a local package path with:

```json
{
  "powerline": {
    "preset": "custom",
    "custom": {
      "separator": "powerline-thin",
      "leftSegments": ["custom:model_display", "path", "git"],
      "rightSegments": ["custom:context_gauge"],
      "secondarySegments": []
    },
    "customItems": [
      { "id": "model_display" },
      { "id": "context_gauge" }
    ]
  }
}
```

Confirmed the rendered order was:

```text
model / path / git / context gauge
```

<img width="1316" height="70" alt="Screenshot 2026-04-30 at 03 22 24@2x" src="https://github.com/user-attachments/assets/fa7bcd27-4bd4-48d1-9d8c-6103dd5c5ee6" />
