### PR TITLE
Localize powerline status command copy

### DIFF
--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,135 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Params = Record<string, string | number>;
+type Translate = (key: string, fallback: string, params?: Params) => string;
+
+let translate: Translate = (_key, fallback, params) => format(fallback, params);
+
+function format(text: string, params?: Params): string {
+  if (!params) return text;
+  return text.replace(/\{(\w+)\}/g, (_match, key: string) => String(params[key] ?? `{${key}}`));
+}
+
+export function t(key: string, fallback: string, params?: Params): string {
+  return translate(key, fallback, params);
+}
+
+const bundles = [
+  {
+    locale: "ja",
+    namespace: "pi-powerline-footer",
+    messages: {
+      "bash.alreadyRunning": "シェルコマンドはすでに実行中です",
+      "bash.noHistoryMatches": "一致するシェル履歴がありません",
+      "bash.failedRun": "シェルコマンドの実行に失敗しました: {message}",
+      "bash.waitBeforeExit": "bash mode を終了する前に、現在のシェルコマンドの完了を待ってください",
+      "bash.enabled": "Bash mode が有効です ({shell})",
+      "bash.failedStart": "シェルセッションの開始に失敗しました: {message}",
+      "bash.disabled": "Bash mode が無効です",
+      "bash.usage": "使用方法: /bash-mode [on|off|toggle]",
+      "bash.failedRestart": "シェルセッションの再起動に失敗しました: {message}",
+      "bash.reset": "Bash セッションをリセットしました",
+      "powerline.description": "powerline ステータスを設定 (toggle, preset)",
+      "powerline.enabled": "Powerline が有効です",
+      "powerline.disabled": "Powerline が無効です",
+      "powerline.preset": "プリセットを設定しました: {preset}",
+      "powerline.presetNotPersisted": "プリセットを設定しました: {preset} (保存されていません。settings.json を確認してください)",
+      "powerline.availablePresets": "利用可能なプリセット: {presets}",
+      "powerline.disabledStatus": "Powerline は無効です",
+      "stash.editorEmpty": "エディタは空です",
+      "stash.inserted": "プロンプトを挿入しました",
+      "stash.replaced": "エディタをプロンプトで置き換えました",
+      "stash.appended": "プロンプトを追加しました",
+      "stash.nothing": "stash する内容がありません",
+      "stash.restored": "Stash を復元しました",
+      "stash.updated": "Stash を更新しました",
+      "stash.textStashed": "テキストを stash しました",
+      "stash.failedLoadPrompts": "プロジェクトプロンプトの読み込みに失敗しました: {message}",
+      "stash.noHistory": "プロンプト履歴はまだありません",
+      "stash.preserved": "Stash を保持しました — エディタを空にしてから Alt+S で復元してください",
+      "editor.cut": "エディタテキストを切り取りました"
+    }
+  },
+  {
+    locale: "zh-CN",
+    namespace: "pi-powerline-footer",
+    messages: {
+      "bash.alreadyRunning": "Shell 命令已在运行",
+      "bash.noHistoryMatches": "没有匹配的 shell 历史",
+      "bash.failedRun": "运行 shell 命令失败: {message}",
+      "bash.waitBeforeExit": "离开 bash mode 前，请等待当前 shell 命令完成",
+      "bash.enabled": "Bash mode 已启用 ({shell})",
+      "bash.failedStart": "启动 shell 会话失败: {message}",
+      "bash.disabled": "Bash mode 已关闭",
+      "bash.usage": "用法: /bash-mode [on|off|toggle]",
+      "bash.failedRestart": "重启 shell 会话失败: {message}",
+      "bash.reset": "Bash 会话已重置",
+      "powerline.description": "配置 powerline 状态栏 (toggle, preset)",
+      "powerline.enabled": "Powerline 已启用",
+      "powerline.disabled": "Powerline 已关闭",
+      "powerline.preset": "Preset 已设置为: {preset}",
+      "powerline.presetNotPersisted": "Preset 已设置为: {preset}（未持久化；请检查 settings.json）",
+      "powerline.availablePresets": "可用 preset: {presets}",
+      "powerline.disabledStatus": "Powerline 已关闭",
+      "stash.editorEmpty": "编辑器为空",
+      "stash.inserted": "已插入 prompt",
+      "stash.replaced": "已用 prompt 替换编辑器内容",
+      "stash.appended": "已追加 prompt",
+      "stash.nothing": "没有可 stash 的内容",
+      "stash.restored": "Stash 已恢复",
+      "stash.updated": "Stash 已更新",
+      "stash.textStashed": "文本已 stash",
+      "stash.failedLoadPrompts": "加载项目 prompts 失败: {message}",
+      "stash.noHistory": "还没有 prompt 历史",
+      "stash.preserved": "Stash 已保留 — 清空编辑器后按 Alt+S 恢复",
+      "editor.cut": "已剪切编辑器文本"
+    }
+  },
+  {
+    locale: "de",
+    namespace: "pi-powerline-footer",
+    messages: {
+      "bash.alreadyRunning": "Shell-Befehl läuft bereits",
+      "bash.noHistoryMatches": "Keine passenden Shell-Verläufe",
+      "bash.failedRun": "Shell-Befehl fehlgeschlagen: {message}",
+      "bash.waitBeforeExit": "Warte, bis der aktuelle Shell-Befehl fertig ist, bevor du bash mode verlässt",
+      "bash.enabled": "Bash mode aktiviert ({shell})",
+      "bash.failedStart": "Shell-Sitzung konnte nicht gestartet werden: {message}",
+      "bash.disabled": "Bash mode deaktiviert",
+      "bash.usage": "Verwendung: /bash-mode [on|off|toggle]",
+      "bash.failedRestart": "Shell-Sitzung konnte nicht neu gestartet werden: {message}",
+      "bash.reset": "Bash-Sitzung zurückgesetzt",
+      "powerline.description": "Powerline-Status konfigurieren (toggle, preset)",
+      "powerline.enabled": "Powerline aktiviert",
+      "powerline.disabled": "Powerline deaktiviert",
+      "powerline.preset": "Preset gesetzt auf: {preset}",
+      "powerline.presetNotPersisted": "Preset gesetzt auf: {preset} (nicht gespeichert; settings.json prüfen)",
+      "powerline.availablePresets": "Verfügbare Presets: {presets}",
+      "powerline.disabledStatus": "Powerline ist deaktiviert",
+      "stash.editorEmpty": "Editor ist leer",
+      "stash.inserted": "Prompt eingefügt",
+      "stash.replaced": "Editor durch Prompt ersetzt",
+      "stash.appended": "Prompt angehängt",
+      "stash.nothing": "Nichts zu stashen",
+      "stash.restored": "Stash wiederhergestellt",
+      "stash.updated": "Stash aktualisiert",
+      "stash.textStashed": "Text gestasht",
+      "stash.failedLoadPrompts": "Projekt-Prompts konnten nicht geladen werden: {message}",
+      "stash.noHistory": "Noch kein Prompt-Verlauf",
+      "stash.preserved": "Stash behalten — Editor leeren, dann Alt+S zum Wiederherstellen",
+      "editor.cut": "Editor-Text ausgeschnitten"
+    }
+  }
+];
+
+export function initI18n(pi: ExtensionAPI): void {
+  const events = pi.events;
+  if (!events) return;
+  for (const bundle of bundles) events.emit("pi-core/i18n/registerBundle", bundle);
+  events.emit("pi-core/i18n/requestApi", {
+    namespace: "pi-powerline-footer",
+    callback(api: { t?: Translate } | undefined) {
+      if (typeof api?.t === "function") translate = api.t;
+    }
+  });
+}

--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,7 @@ import { getPreset, PRESETS } from "./presets.js";
 import { collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, mergeSegmentsWithCustomItems, nextPowerlineSettingWithPreset, parsePowerlineConfig } from "./powerline-config.js";
 import { getSeparator } from "./separators.js";
 import { renderSegment } from "./segments.js";
+import { initI18n, t } from "./i18n.js";
 import { getGitStatus, invalidateGitStatus, invalidateGitBranch } from "./git-status.js";
 import { ansi, getFgAnsiCode } from "./colors.js";
 import { WelcomeComponent, WelcomeHeader, discoverLoadedCounts, getRecentSessions } from "./welcome.js";
@@ -766,6 +767,7 @@ function computeResponsiveLayout(
 // ═══════════════════════════════════════════════════════════════════════════
 
 export default function powerlineFooter(pi: ExtensionAPI) {
+  initI18n(pi);
   const startupSettings = readSettings();
   config = parsePowerlineConfig(startupSettings.powerline, PRESET_NAMES);
   const resolvedShortcuts = resolveShortcutConfig(startupSettings);
@@ -858,14 +860,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       requestStatusRender();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      ctx.ui.notify(`Failed to run shell command: ${message}`, "error");
+      ctx.ui.notify(t("bash.failedRun", "Failed to run shell command: {message}", { message }), "error");
     }
   };
 
   const setBashModeActive = async (value: boolean, ctx: any): Promise<void> => {
     if (value === bashModeActive) return;
     if (!value && shellSession?.state.running) {
-      ctx.ui.notify("Wait for the current shell command to finish before leaving bash mode", "warning");
+      ctx.ui.notify(t("bash.waitBeforeExit", "Wait for the current shell command to finish before leaving bash mode"), "warning");
       return;
     }
 
@@ -876,14 +878,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         currentEditor?.dismissBashModeUi?.();
         currentEditor?.refreshGhostSuggestion?.();
         requestStatusRender();
-        ctx.ui.notify(`Bash mode enabled (${session.state.shellName})`, "info");
+        ctx.ui.notify(t("bash.enabled", "Bash mode enabled ({shell})", { shell: session.state.shellName }), "info");
       } catch (error) {
         shellSession?.dispose();
         shellSession = null;
         bashModeActive = false;
         requestStatusRender();
         const message = error instanceof Error ? error.message : String(error);
-        ctx.ui.notify(`Failed to start shell session: ${message}`, "error");
+        ctx.ui.notify(t("bash.failedStart", "Failed to start shell session: {message}", { message }), "error");
       }
       return;
     }
@@ -891,7 +893,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     bashModeActive = value;
     currentEditor?.dismissBashModeUi?.();
     requestStatusRender();
-    ctx.ui.notify("Bash mode disabled", "info");
+    ctx.ui.notify(t("bash.disabled", "Bash mode disabled"), "info");
   };
 
   function overlaySelectListTheme(theme: Theme) {
@@ -1166,7 +1168,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       return text;
     }
 
-    ctx.ui.notify("Editor is empty", "info");
+    ctx.ui.notify(t("stash.editorEmpty", "Editor is empty"), "info");
     return null;
   }
 
@@ -1244,7 +1246,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const currentText = getCurrentEditorText(ctx, currentEditor);
     if (!hasNonWhitespaceText(currentText)) {
       ctx.ui.setEditorText(selected);
-      ctx.ui.notify("Inserted prompt", "info");
+      ctx.ui.notify(t("stash.inserted", "Inserted prompt"), "info");
       return;
     }
 
@@ -1252,14 +1254,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
     if (action === "Replace") {
       ctx.ui.setEditorText(selected);
-      ctx.ui.notify("Replaced editor with prompt", "info");
+      ctx.ui.notify(t("stash.replaced", "Replaced editor with prompt"), "info");
       return;
     }
 
     if (action === "Append") {
       const separator = currentText.endsWith("\n") || selected.startsWith("\n") ? "" : "\n";
       ctx.ui.setEditorText(`${currentText}${separator}${selected}`);
-      ctx.ui.notify("Appended prompt", "info");
+      ctx.ui.notify(t("stash.appended", "Appended prompt"), "info");
     }
   }
 
@@ -1269,14 +1271,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
     if (!hasNonWhitespaceText(rawText)) {
       if (!hasStash) {
-        ctx.ui.notify("Nothing to stash", "info");
+        ctx.ui.notify(t("stash.nothing", "Nothing to stash"), "info");
         return;
       }
 
       ctx.ui.setEditorText(stashedEditorText);
       stashedEditorText = null;
       ctx.ui.setStatus("stash", undefined);
-      ctx.ui.notify("Stash restored", "info");
+      ctx.ui.notify(t("stash.restored", "Stash restored"), "info");
       return;
     }
 
@@ -1284,7 +1286,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     addStashHistoryEntry(rawText);
     ctx.ui.setEditorText("");
     ctx.ui.setStatus("stash", "stash");
-    ctx.ui.notify(hasStash ? "Stash updated" : "Text stashed", "info");
+    ctx.ui.notify(hasStash ? t("stash.updated", "Stash updated") : t("stash.textStashed", "Text stashed"), "info");
   }
 
   async function openStashHistory(ctx: any): Promise<void> {
@@ -1294,11 +1296,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       projectPrompts = readRecentProjectPrompts(ctx.cwd, PROJECT_PROMPT_HISTORY_LIMIT);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      ctx.ui.notify(`Failed to load project prompts: ${message}`, "warning");
+      ctx.ui.notify(t("stash.failedLoadPrompts", "Failed to load project prompts: {message}", { message }), "warning");
     }
 
     if (stashedPromptHistory.length === 0 && projectPrompts.length === 0) {
-      ctx.ui.notify("No prompt history yet", "info");
+      ctx.ui.notify(t("stash.noHistory", "No prompt history yet"), "info");
       return;
     }
 
@@ -1325,9 +1327,9 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           ctx.ui.setEditorText(stashedEditorText);
           stashedEditorText = null;
           ctx.ui.setStatus("stash", undefined);
-          ctx.ui.notify("Stash restored", "info");
+          ctx.ui.notify(t("stash.restored", "Stash restored"), "info");
         } else {
-          ctx.ui.notify("Stash preserved — clear editor then Alt+S to restore", "info");
+          ctx.ui.notify(t("stash.preserved", "Stash preserved — clear editor then Alt+S to restore"), "info");
         }
       }
     }
@@ -1336,7 +1338,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   // Command to toggle/configure
   pi.registerCommand("powerline", {
-    description: "Configure powerline status (toggle, preset)",
+    description: t("powerline.description", "Configure powerline status (toggle, preset)"),
     handler: async (args, ctx) => {
       // Update context reference (command ctx may have more methods)
       currentCtx = ctx;
@@ -1346,7 +1348,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         enabled = !enabled;
         if (enabled) {
           setupCustomEditor(ctx);
-          ctx.ui.notify("Powerline enabled", "info");
+          ctx.ui.notify(t("powerline.enabled", "Powerline enabled"), "info");
         } else {
           shellSession?.dispose();
           shellSession = null;
@@ -1374,7 +1376,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           currentEditor = null;
           statusRenderScheduler.cancel();
           resetLayoutCache();
-          ctx.ui.notify("Powerline disabled", "info");
+          ctx.ui.notify(t("powerline.disabled", "Powerline disabled"), "info");
         }
         return;
       }
@@ -1388,16 +1390,16 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         }
 
         if (writePowerlinePresetSetting(preset, ctx.cwd)) {
-          ctx.ui.notify(`Preset set to: ${preset}`, "info");
+          ctx.ui.notify(t("powerline.preset", "Preset set to: {preset}", { preset }), "info");
         } else {
-          ctx.ui.notify(`Preset set to: ${preset} (not persisted; check settings.json)`, "warning");
+          ctx.ui.notify(t("powerline.presetNotPersisted", "Preset set to: {preset} (not persisted; check settings.json)", { preset }), "warning");
         }
         return;
       }
 
       // Show available presets
       const presetList = Object.keys(PRESETS).join(", ");
-      ctx.ui.notify(`Available presets: ${presetList}`, "info");
+      ctx.ui.notify(t("powerline.availablePresets", "Available presets: {presets}", { presets: presetList }), "info");
     },
   });
 
@@ -1406,7 +1408,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     handler: async (_args, ctx) => {
       if (!ctx.hasUI) return;
       if (!enabled) {
-        ctx.ui.notify("Powerline is disabled", "info");
+        ctx.ui.notify(t("powerline.disabledStatus", "Powerline is disabled"), "info");
         return;
       }
 
@@ -1430,7 +1432,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         await setBashModeActive(!bashModeActive, ctx);
         return;
       }
-      ctx.ui.notify("Usage: /bash-mode [on|off|toggle]", "warning");
+      ctx.ui.notify(t("bash.usage", "Usage: /bash-mode [on|off|toggle]"), "warning");
     },
   });
 
@@ -1446,13 +1448,13 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         } catch (error) {
           bashModeActive = false;
           const message = error instanceof Error ? error.message : String(error);
-          ctx.ui.notify(`Failed to restart shell session: ${message}`, "error");
+          ctx.ui.notify(t("bash.failedRestart", "Failed to restart shell session: {message}", { message }), "error");
           requestStatusRender();
           return;
         }
       }
       requestStatusRender();
-      ctx.ui.notify("Bash session reset", "info");
+      ctx.ui.notify(t("bash.reset", "Bash session reset"), "info");
     },
   });
 
@@ -1502,7 +1504,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
       copyTextToClipboard(ctx, text);
       ctx.ui.setEditorText("");
-      ctx.ui.notify("Cut editor text", "info");
+      ctx.ui.notify(t("editor.cut", "Cut editor text"), "info");
     },
   });
 


### PR DESCRIPTION
I found a small UX issue in the command/status path: this extension is always visible, but the setup/status messages around powerline, bash mode, and stash history are English-only. Those are exactly the messages users see when they are deciding whether the footer is enabled, why bash mode did not start, or where their stashed prompt went.

This PR makes that command/status copy optionally localizable while preserving the current English strings as fallbacks.

- No new dependency
- No behavior change without an i18n provider
- English remains the default/fallback
- Locales: ja, zh-CN, de — common developer locales for status/config UI
- Covers powerline enable/disable/preset, bash mode lifecycle/errors, and stash-history notifications

Validation:
- npm pack --dry-run

Note: npm test needs Node 22 for --experimental-strip-types. With npx node@22, local Windows test failures are environment-related: missing /bin/zsh or /bin/bash, symlink EEXIST in test setup, and missing local @mariozechner packages. I did not change those paths.