### PR TITLE
fix: scroll images with chat history in fixed-editor mode

### DIFF
--- a/fixed-editor/terminal-split.ts
+++ b/fixed-editor/terminal-split.ts
@@ -1,4 +1,4 @@
-import { isKeyRelease, matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { deleteAllKittyImages, isKeyRelease, matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { matchesConfiguredShortcut } from "../shortcuts.ts";
 import type { FixedEditorClusterRender } from "./cluster.ts";
 
@@ -352,6 +352,7 @@ export class TerminalSplitCompositor {
   private selectionDragging = false;
   private preserveSelectionFocusOnRelease = false;
   private lastLeftPress: { area: SelectionArea; line: number; at: number } | null = null;
+  private pendingImageCleanup = false;
 
   constructor(options: TerminalSplitCompositorOptions) {
     this.tui = options.tui;
@@ -461,6 +462,7 @@ export class TerminalSplitCompositor {
     this.clearSelection();
     this.lastLeftPress = null;
     this.scrollOffset = 0;
+    this.pendingImageCleanup = true;
     this.requestRender();
     return true;
   }
@@ -483,6 +485,7 @@ export class TerminalSplitCompositor {
       this.clearSelection();
       this.lastLeftPress = null;
       this.scrollOffset = nextOffset;
+      this.pendingImageCleanup = true;
       this.requestRender();
       return true;
     }
@@ -583,8 +586,13 @@ export class TerminalSplitCompositor {
         this.scrollOffset += lines.length - this.lastRootLineCount;
       }
       this.lastRootLineCount = lines.length;
+      const prevMaxScroll = this.maxScrollOffset;
       this.maxScrollOffset = Math.max(0, lines.length - scrollableRows);
-      this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, this.maxScrollOffset));
+      const clampedOffset = Math.max(0, Math.min(this.scrollOffset, this.maxScrollOffset));
+      if (clampedOffset !== this.scrollOffset || this.maxScrollOffset !== prevMaxScroll) {
+        this.pendingImageCleanup = true;
+      }
+      this.scrollOffset = clampedOffset;
 
       const start = this.updateVisibleRootWindow(scrollableRows);
       return this.visibleRootLines.map((line, index) => this.renderSelectionHighlight(line, start + index, "root"));
@@ -753,6 +761,7 @@ export class TerminalSplitCompositor {
     this.lastLeftPress = null;
     this.preserveSelectionFocusOnRelease = true;
     this.scrollOffset = nextOffset;
+    this.pendingImageCleanup = true;
     const start = this.updateVisibleRootWindow();
     const edgeLine = delta > 0 ? start : start + Math.max(0, this.visibleScrollableRows - 1);
     this.selectionFocus = {
@@ -848,6 +857,7 @@ export class TerminalSplitCompositor {
     this.clearSelection();
     this.lastLeftPress = null;
     this.scrollOffset = nextOffset;
+    this.pendingImageCleanup = true;
     this.requestRender();
   }
 
@@ -974,7 +984,10 @@ export class TerminalSplitCompositor {
           : 0;
       const viewportTop = typeof this.tui.previousViewportTop === "number" ? this.tui.previousViewportTop : 0;
       const screenRow = Math.max(1, Math.min(scrollBottom, hardwareCursorRow - viewportTop + 1));
+      const imageCleanup = this.pendingImageCleanup ? deleteAllKittyImages() : "";
+      this.pendingImageCleanup = false;
       const buffer = beginSynchronizedOutput()
+        + imageCleanup
         + setScrollRegion(1, scrollBottom)
         + moveCursor(screenRow, 1)
         + data


### PR DESCRIPTION
## Problem
When images are displayed in chat and the user scrolls (mouse wheel, keyboard, or message jumps), the images stay fixed at their screen position while text scrolls around them. Closes #47.

## Root Cause
Pi TUI's `encodeKitty()` uses `a=T` (static placement) for Kitty graphics protocol images. When the `TerminalSplitCompositor` sets a DECSTBM scroll region via `setScrollRegion()` and the TUI's differential renderer produces terminal-level scroll operations, text scrolls but static Kitty images remain at their absolute screen positions.

## Fix
Added a `pendingImageCleanup` flag to `TerminalSplitCompositor`:

1. The flag is set to `true` in all scroll-offset mutation paths:
   - `scrollBy()` (mouse wheel / keyboard)
   - `jumpToRootTarget()` (message jump shortcuts)
   - `jumpToRootBottom()` (jump to bottom shortcut)
   - `scrollSelectionAtViewportEdge()` (drag-scroll at viewport edge)
   - `renderScrollableRoot()` (content-growth clamping)

2. In `write()`, if the flag is set, `deleteAllKittyImages()` (from `@mariozechner/pi-tui`) is emitted inside the synchronized output block — between `beginSynchronizedOutput()` and `setScrollRegion()` — ensuring atomic delete+re-place with no visible flicker.

3. After computing the cleanup, the flag is immediately cleared so it fires exactly once per scroll event.

## Scope
- 1 file changed: `fixed-editor/terminal-split.ts`
- 15 insertions, 2 deletions
- No changes to public API or configuration

## Notes
- iTerm2 images are unaffected (use `inline=1` which scrolls natively)
- Terminals without Kitty protocol silently ignore the APC delete command
- Long-term, changing Pi TUI's `a=T` to `a=t` would be a more fundamental fix, but this workaround is self-contained