### PR TITLE
Show named Pi sessions in the powerline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Session name segment** — The `session` segment now prefers Pi's `/name` display name, uses a comments icon in Nerd Font mode, the default preset shows named sessions without exposing unnamed session ids, and the full preset includes the session segment.
+
 ## [0.5.1] - 2026-05-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ Use `"fixedEditor": true` to enable it again. Add `"mouseScroll": false` if you 
 
 | Preset | Description |
 |--------|-------------|
-| `default` | Model, thinking, path (basename), git, context, tokens, cost |
+| `default` | Model, thinking, path (basename), git, named session, context, tokens, cost |
 | `minimal` | Just path (basename), git, context |
 | `compact` | Model, git, cost, context |
-| `full` | Everything including hostname, time, abbreviated path |
+| `full` | Everything including hostname, session, time, abbreviated path |
 | `nerd` | Maximum detail for Nerd Font users |
 | `ascii` | Safe for any terminal |
 
@@ -322,6 +322,8 @@ Configure via preset options: `path: { mode: "full" }`
 ## Segments
 
 `model` · `thinking` · `shell_mode` · `path` · `git` · `subagents` · `token_in` · `token_out` · `token_total` · `cost` · `context_pct` · `context_total` · `time_spent` · `time` · `session` · `hostname` · `cache_read` · `cache_write`
+
+The `session` segment shows the session display name when one is set with `/name`; otherwise it falls back to the short session id unless the preset disables unnamed ids. Nerd Font mode uses a comments icon; ASCII mode shows the session text without an extra marker. The default preset shows named sessions only.
 
 ## Separators
 

--- a/icons.ts
+++ b/icons.ts
@@ -65,7 +65,7 @@ export const NERD_ICONS: IconSet = {
   input: "\uF090",      // nf-fa-sign_in (input arrow)
   output: "\uF08B",     // nf-fa-sign_out (output arrow)
   host: "\uF109",       // nf-fa-laptop (host)
-  session: "\uF550",    // nf-md-identifier (session id)
+  session: "\uF086",    // nf-fa-comments (session display name/id)
   auto: "\u{F0068}",    // nf-md-lightning_bolt (auto-compact)
   warning: "\uF071",    // nf-fa-warning
 };
@@ -86,7 +86,7 @@ export const ASCII_ICONS: IconSet = {
   input: "in:",
   output: "out:",
   host: "host",
-  session: "id",
+  session: "",
   auto: "AC",
   warning: "!",
 };

--- a/index.ts
+++ b/index.ts
@@ -991,6 +991,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   let layoutDirty = true;
   let forceNextLayoutRecompute = false;
   let lastEditorInputAt = 0;
+  let lastSessionName: string | undefined;
 
   const getShellPath = () => process.env.SHELL || "/bin/sh";
   const getShellCwd = () => shellSession?.state.cwd ?? currentCtx?.cwd ?? process.cwd();
@@ -1030,6 +1031,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     forceNextLayoutRecompute = true;
     statusRenderScheduler.cancel();
     statusRenderScheduler.schedule(0);
+  };
+
+  const getSessionDisplayName = (ctx: any): string | undefined => {
+    const value = ctx?.sessionManager?.getSessionName?.();
+    return typeof value === "string" && value.trim() ? value : undefined;
   };
 
   const installFooterStatusRepaintHook = (footerData: ReadonlyFooterDataProvider) => {
@@ -1270,6 +1276,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     footerDataRef = null;
     getThinkingLevelFn = null;
     currentThinkingLevel = null;
+    lastSessionName = undefined;
     liveAssistantUsage = null;
     tuiRef = null;
     currentEditor = null;
@@ -2109,6 +2116,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       model: ctx.model,
       thinkingLevel,
       sessionId: ctx.sessionManager?.getSessionId?.(),
+      sessionName: getSessionDisplayName(ctx),
       usageStats: { input, output, cacheRead, cacheWrite, cost },
       contextPercent,
       contextWindow,
@@ -2137,6 +2145,12 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   function getResponsiveLayout(width: number, theme: Theme): { topContent: string; secondaryContent: string } {
     const now = Date.now();
     const cacheTtl = isStreaming ? STREAMING_LAYOUT_CACHE_TTL_MS : LAYOUT_CACHE_TTL_MS;
+    const currentSessionName = getSessionDisplayName(currentCtx);
+    if (currentSessionName !== lastSessionName) {
+      lastSessionName = currentSessionName;
+      resetLayoutCache();
+      forceNextLayoutRecompute = true;
+    }
 
     if (lastLayoutResult && lastLayoutWidth === width) {
       const msSinceInput = now - lastEditorInputAt;

--- a/presets.ts
+++ b/presets.ts
@@ -23,7 +23,7 @@ const NERD_COLORS: ColorScheme = {
 
 export const PRESETS: Record<StatusLinePreset, PresetDef> = {
   default: {
-    leftSegments: ["model", "thinking", "shell_mode", "path", "git", "context_pct", "cache_read", "cost"],
+    leftSegments: ["model", "thinking", "shell_mode", "path", "git", "session", "context_pct", "cache_read", "cost"],
     rightSegments: [],
     secondarySegments: ["extension_statuses"],
     separator: "powerline-thin",
@@ -32,6 +32,7 @@ export const PRESETS: Record<StatusLinePreset, PresetDef> = {
       model: { showThinkingLevel: false },
       path: { mode: "basename" },
       git: { showBranch: true, showStaged: true, showUnstaged: true, showUntracked: true },
+      session: { showIdWhenUnnamed: false, maxLength: 32 },
     },
   },
 
@@ -58,7 +59,7 @@ export const PRESETS: Record<StatusLinePreset, PresetDef> = {
   },
 
   full: {
-    leftSegments: ["hostname", "model", "thinking", "shell_mode", "path", "git", "subagents"],
+    leftSegments: ["hostname", "model", "thinking", "shell_mode", "path", "git", "session", "subagents"],
     rightSegments: ["token_in", "token_out", "cache_read", "cost", "context_pct", "time_spent", "time", "extension_statuses"],
     separator: "powerline",
     colors: DEFAULT_COLORS,

--- a/segments.ts
+++ b/segments.ts
@@ -1,6 +1,6 @@
 import { hostname as osHostname } from "node:os";
 import { basename } from "node:path";
-import { visibleWidth } from "@mariozechner/pi-tui";
+import { truncateToWidth } from "@mariozechner/pi-tui";
 import type { BuiltinStatusLineSegmentId, RenderedSegment, SegmentContext, SemanticColor, StatusLineSegment, StatusLineSegmentId } from "./types.ts";
 import { normalizeCompactExtensionStatus, normalizeExtensionStatusValue } from "./powerline-config.ts";
 import { fg, rainbow, applyColor } from "./theme.ts";
@@ -34,6 +34,24 @@ function formatDuration(ms: number): string {
   if (hours > 0) return `${hours}h${minutes % 60}m`;
   if (minutes > 0) return `${minutes}m${seconds % 60}s`;
   return `${seconds}s`;
+}
+
+function sanitizeSegmentText(text: string): string {
+  return text
+    .replace(/[\r\n\t]/g, " ")
+    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .replace(/ +/g, " ")
+    .trim();
+}
+
+function clampDisplayWidth(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(1, Math.floor(value))
+    : fallback;
+}
+
+function stripAnsiSgr(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -355,8 +373,14 @@ const sessionSegment: StatusLineSegment = {
   id: "session",
   render(ctx) {
     const icons = getIcons();
-    const sessionId = ctx.sessionId;
-    const display = sessionId?.slice(0, 8) || "new";
+    const opts = ctx.options.session ?? {};
+    const sessionName = ctx.sessionName ? sanitizeSegmentText(ctx.sessionName) : "";
+    const maxLength = clampDisplayWidth(opts.maxLength, sessionName ? 32 : 8);
+    const displayName = sessionName ? stripAnsiSgr(truncateToWidth(sessionName, maxLength, "…")) : "";
+    const displayId = opts.showIdWhenUnnamed === false ? "" : (ctx.sessionId?.slice(0, 8) || "new");
+    const display = displayName || displayId;
+
+    if (!display) return { content: "", visible: false };
 
     return { content: withIcon(icons.session, display), visible: true };
   },

--- a/tests/session-segment.test.ts
+++ b/tests/session-segment.test.ts
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renderSegment } from "../segments.ts";
+import type { SegmentContext } from "../types.ts";
+
+function createSegmentContext(overrides: Partial<SegmentContext> = {}): SegmentContext {
+  return {
+    model: undefined,
+    thinkingLevel: "off",
+    sessionId: "12345678-90ab-cdef-1234-567890abcdef",
+    sessionName: undefined,
+    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+    contextPercent: 0,
+    contextWindow: 0,
+    autoCompactEnabled: true,
+    customCompactionEnabled: false,
+    usingSubscription: false,
+    sessionStartTime: Date.now(),
+    shellModeActive: false,
+    shellRunning: false,
+    shellName: null,
+    shellCwd: null,
+    git: { branch: null, staged: 0, unstaged: 0, untracked: 0 },
+    extensionStatuses: new Map(),
+    hiddenExtensionStatusKeys: new Set(),
+    customItemsById: new Map(),
+    options: {},
+    theme: {
+      fg(_color, text) {
+        return text;
+      },
+    },
+    colors: {},
+    ...overrides,
+  };
+}
+
+function renderSessionWithFontMode(ctx: SegmentContext, nerdFonts: "0" | "1") {
+  const previous = process.env.POWERLINE_NERD_FONTS;
+  process.env.POWERLINE_NERD_FONTS = nerdFonts;
+  try {
+    return renderSegment("session", ctx);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.POWERLINE_NERD_FONTS;
+    } else {
+      process.env.POWERLINE_NERD_FONTS = previous;
+    }
+  }
+}
+
+function renderAsciiSession(ctx: SegmentContext) {
+  return renderSessionWithFontMode(ctx, "0");
+}
+
+function renderNerdSession(ctx: SegmentContext) {
+  return renderSessionWithFontMode(ctx, "1");
+}
+
+test("session segment prefers the display name over the session id", () => {
+  const rendered = renderAsciiSession(createSegmentContext({ sessionName: "Refactor auth module" }));
+
+  assert.equal(rendered.visible, true);
+  assert.equal(rendered.content, "Refactor auth module");
+});
+
+test("session segment uses the comments icon in Nerd Font mode", () => {
+  const rendered = renderNerdSession(createSegmentContext({ sessionName: "Refactor auth module" }));
+
+  assert.equal(rendered.visible, true);
+  assert.equal(rendered.content, "\uF086 Refactor auth module");
+});
+
+test("session segment hides unnamed sessions when id fallback is disabled", () => {
+  const rendered = renderAsciiSession(
+    createSegmentContext({ options: { session: { showIdWhenUnnamed: false } } }),
+  );
+
+  assert.equal(rendered.visible, false);
+  assert.equal(rendered.content, "");
+});
+
+test("session segment still shows names when unnamed id fallback is disabled", () => {
+  const rendered = renderAsciiSession(
+    createSegmentContext({
+      sessionName: "Named session",
+      options: { session: { showIdWhenUnnamed: false } },
+    }),
+  );
+
+  assert.equal(rendered.visible, true);
+  assert.equal(rendered.content, "Named session");
+});
+
+test("session segment keeps short-id fallback for presets that show unnamed sessions", () => {
+  const rendered = renderAsciiSession(createSegmentContext());
+
+  assert.equal(rendered.visible, true);
+  assert.equal(rendered.content, "12345678");
+});
+
+test("session segment sanitizes and truncates display names", () => {
+  const rendered = renderAsciiSession(
+    createSegmentContext({
+      sessionName: "Feature\nbranch\twith a very long name",
+      options: { session: { maxLength: 14 } },
+    }),
+  );
+
+  assert.equal(rendered.visible, true);
+  assert.equal(rendered.content, "Feature branc…");
+});

--- a/tests/thinking-segment.test.ts
+++ b/tests/thinking-segment.test.ts
@@ -16,6 +16,7 @@ function createSegmentContext(thinkingLevel: string, colors: ColorScheme): Segme
     model: undefined,
     thinkingLevel,
     sessionId: undefined,
+    sessionName: undefined,
     usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
     contextPercent: 0,
     contextWindow: 0,

--- a/types.ts
+++ b/types.ts
@@ -83,6 +83,7 @@ export interface StatusLineSegmentOptions {
   };
   git?: { showBranch?: boolean; showStaged?: boolean; showUnstaged?: boolean; showUntracked?: boolean };
   time?: { format?: "12h" | "24h"; showSeconds?: boolean };
+  session?: { showIdWhenUnnamed?: boolean; maxLength?: number };
 }
 
 export type CustomItemPosition = "left" | "right" | "secondary";
@@ -143,6 +144,7 @@ export interface SegmentContext {
   model: { id: string; name?: string; reasoning?: boolean; contextWindow?: number } | undefined;
   thinkingLevel: string;
   sessionId: string | undefined;
+  sessionName: string | undefined;
   
   // Computed
   usageStats: UsageStats;


### PR DESCRIPTION
## Summary
- Show Pi session display names in the `session` segment when `/name` is set.
- Keep the default preset quiet for unnamed sessions while preserving short-id fallback for presets that opt in.
- Use the Nerd Font comments icon (`` / `\uF086`) for session names so the tag glyph remains available for tag/label semantics.
- Document the behavior and add targeted session segment coverage.

## Tests
- `node --experimental-strip-types --test tests/session-segment.test.ts tests/thinking-segment.test.ts`

## Notes
- Full `npm test` was not run successfully in this Linux checkout because existing tests assume `/opt/homebrew` module paths before this diff's assertions run.
