### PR TITLE
Fix IME composition visibility in fixed-editor mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ You can also set it in `~/.pi/agent/settings.json` or project-local `.pi/setting
 
 Use `"fixedEditor": true` to enable it again. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling.
 
+When fixed editor is enabled, pi-powerline-footer temporarily enables Pi's hardware cursor so IME preedit text for Korean, Japanese, Chinese, and other composition-based input methods appears at the editor cursor. The previous hardware cursor setting is restored when fixed editor is disabled or the extension shuts down.
+
 | Preset | Description |
 |--------|-------------|
 | `default` | Model, thinking, path (basename), git, context, tokens, cost |

--- a/index.ts
+++ b/index.ts
@@ -966,6 +966,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   let tuiRef: any = null;
   let restoreFooterStatusRepaintHook: (() => void) | null = null;
   let fixedEditorCompositor: TerminalSplitCompositor | null = null;
+  let fixedEditorPreviousHardwareCursor: boolean | null = null;
   let fixedStatusContainer: any = null;
   let fixedEditorContainer: any = null;
   let fixedWidgetContainerAbove: any = null;
@@ -2254,6 +2255,10 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         // Shutdown cleanup cannot surface useful terminal write failures.
       }
     }
+    if (fixedEditorPreviousHardwareCursor !== null && typeof tuiRef?.setShowHardwareCursor === "function") {
+      tuiRef.setShowHardwareCursor(fixedEditorPreviousHardwareCursor);
+    }
+    fixedEditorPreviousHardwareCursor = null;
     fixedEditorCompositor = null;
     fixedStatusContainer = null;
     fixedEditorContainer = null;
@@ -2283,6 +2288,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const editorContainerMatch = findContainerWithChild(tui, currentEditor);
     if (!editorContainerMatch) {
       throw new Error("[powerline-footer] Fixed editor compositor could not find the editor container in TUI children");
+    }
+
+    if (typeof tui.getShowHardwareCursor === "function" && typeof tui.setShowHardwareCursor === "function") {
+      const hardwareCursorEnabled = Boolean(tui.getShowHardwareCursor());
+      if (!hardwareCursorEnabled) {
+        fixedEditorPreviousHardwareCursor = hardwareCursorEnabled;
+        tui.setShowHardwareCursor(true);
+      }
     }
 
     const tuiChildren = Array.isArray(tui.children) ? tui.children : [];

--- a/tests/jump-shortcuts.test.ts
+++ b/tests/jump-shortcuts.test.ts
@@ -147,6 +147,12 @@ test("extension status changes invalidate powerline status rendering", () => {
   assert.match(source, /restoreFooterStatusRepaintHook\?\.\(\);\n\s+restoreFooterStatusRepaintHook = null;/);
 });
 
+test("fixed editor enables the hardware cursor while installed for IME composition", () => {
+  assert.match(source, /let fixedEditorPreviousHardwareCursor: boolean \| null = null/);
+  assert.match(source, /const hardwareCursorEnabled = Boolean\(tui\.getShowHardwareCursor\(\)\);\n\s+if \(!hardwareCursorEnabled\) \{\n\s+fixedEditorPreviousHardwareCursor = hardwareCursorEnabled;\n\s+tui\.setShowHardwareCursor\(true\);\n\s+\}/);
+  assert.match(source, /if \(fixedEditorPreviousHardwareCursor !== null && typeof tuiRef\?\.setShowHardwareCursor === "function"\) \{\n\s+tuiRef\.setShowHardwareCursor\(fixedEditorPreviousHardwareCursor\);\n\s+\}\n\s+fixedEditorPreviousHardwareCursor = null;/);
+});
+
 test("fixed editor captures Pi status messages with the editor cluster", () => {
   assert.match(source, /let fixedStatusContainer: any = null/);
   assert.match(source, /const statusContainerCandidate = tuiChildren\[editorContainerMatch\.index - 2\] \?\? null/);


### PR DESCRIPTION
## Summary

Fix IME composition/preedit visibility in fixed-editor mode by temporarily enabling Pi's hardware cursor while the fixed editor compositor is installed.

## Problem

In fixed-editor mode, Korean IME composition characters such as `ㄱ` or `ㅏ` were not rendered immediately. They became visible only after pressing another key such as Space or Arrow.

This did not happen with Pi's regular editor layout or when running `/powerline fixed-editor off`.

## Cause

Fixed-editor mode hides the normal editor renderable and repaints it inside the fixed cluster. IME-based input methods such as Korean, Japanese, and Chinese depend on the terminal hardware cursor position to display preedit/composition text correctly.

When the hardware cursor is disabled, the IME preedit text has no visible cursor anchor in the fixed editor cluster.

## Fix

- Save the previous hardware cursor state when fixed-editor mode is installed.
- Enable the hardware cursor while fixed-editor mode is active.
- Restore the previous hardware cursor state when fixed-editor mode is disabled or the extension shuts down.
- Document the behavior in the README.

## Testing

- `npm test`
- Manual: verified Korean 2-set IME composition now displays immediately in fixed-editor mode without setting `showHardwareCursor` globally.
