### PR TITLE
Add configurable Powerline layout and custom status transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,34 @@ You can promote any extension status key into its own dedicated powerline item. 
 - `hideWhenMissing` (optional): hide item when no status is present (default `true`)
 - `excludeFromExtensionStatuses` (optional): omit this key from the aggregate `extension_statuses` segment (default `true`)
 
+### Custom layout from settings
+
+You can override the preset segment arrays while still reusing the preset's separator, colors, and per-segment options. Segment ids are the built-in names listed in [Segments](#segments), plus `custom:<id>` for items from `customItems`.
+
+```json
+{
+  "powerline": {
+    "preset": "default",
+    "layout": {
+      "left": ["model", "thinking", "shell_mode", "git"],
+      "right": ["context_pct", "cost"],
+      "secondary": ["custom:quotas"]
+    },
+    "customItems": [
+      {
+        "id": "quotas",
+        "statusKey": "pi-quotas-usage",
+        "position": "secondary",
+        "hideWhenMissing": true,
+        "excludeFromExtensionStatuses": true
+      }
+    ]
+  }
+}
+```
+
+`layout.left`, `layout.right`, and `layout.secondary` each replace that preset row when present. Omit a row to keep the preset row and its normal `customItems` appends. `leftSegments`, `rightSegments`, and `secondarySegments` aliases are also accepted.
+
 If you still prefer the old style, `"powerline": "default"` continues to work.
 
 ## Bash mode
@@ -320,7 +348,7 @@ Configure via preset options: `path: { mode: "full" }`
 
 ## Segments
 
-`model` · `thinking` · `shell_mode` · `path` · `git` · `subagents` · `token_in` · `token_out` · `token_total` · `cost` · `context_pct` · `context_total` · `time_spent` · `time` · `session` · `hostname` · `cache_read` · `cache_write`
+`model` · `thinking` · `shell_mode` · `path` · `git` · `subagents` · `token_in` · `token_out` · `token_total` · `cost` · `context_pct` · `context_total` · `time_spent` · `time` · `session` · `hostname` · `cache_read` · `cache_write` · `extension_statuses`
 
 ## Separators
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ You can promote any extension status key into its own dedicated powerline item. 
 - `position` (optional): `left`, `right`, or `secondary` (default `right`)
 - `prefix` (optional): text shown before the live status value
 - `color` (optional): any Pi theme color (`warning`, `accent`, etc.) or hex (`#RRGGBB`)
+- `transforms` (optional): ordered regex replacements scoped to this custom item. Each rule supports `replace`, `with`, and optional `flags` (`g` by default). Use `with: ""` to remove matched text.
 - `hideWhenMissing` (optional): hide item when no status is present (default `true`)
 - `excludeFromExtensionStatuses` (optional): omit this key from the aggregate `extension_statuses` segment (default `true`)
 
@@ -146,6 +147,53 @@ You can override the preset segment arrays while still reusing the preset's sepa
 ```
 
 `layout.left`, `layout.right`, and `layout.secondary` each replace that preset row when present. Omit a row to keep the preset row and its normal `customItems` appends. `leftSegments`, `rightSegments`, and `secondarySegments` aliases are also accepted.
+
+For an exact minimal footer with model, thinking, context, subscription/cost, and formatted quotas only:
+
+```json
+{
+  "powerline": {
+    "preset": "default",
+    "layout": {
+      "left": ["model", "thinking"],
+      "right": ["context_pct", "cost"],
+      "secondary": ["custom:quotas"]
+    },
+    "customItems": [
+      {
+        "id": "quotas",
+        "statusKey": "pi-quotas-usage",
+        "position": "secondary",
+        "transforms": [
+          {
+            "replace": "\\s*(?:\\x1b\\[[0-9;]*m)*left(?:\\x1b\\[[0-9;]*m)*\\s+",
+            "with": " "
+          },
+          {
+            "replace": "↺\\s*(?:\\x1b\\[[0-9;]*m)*in(?:\\x1b\\[[0-9;]*m)*\\s*",
+            "with": "↺ "
+          },
+          {
+            "replace": "\\)((?:(?:\\x1b\\[[0-9;]*m)|\\s)+)((?:\\x1b\\[[0-9;]*m)*\\d+[hd]:)",
+            "with": ")$1· $2"
+          },
+          {
+            "replace": "\\s*cap:(?:\\x1b\\[[0-9;]*m)*OK(?:\\x1b\\[[0-9;]*m)*\\s*",
+            "with": "",
+            "flags": "gi"
+          },
+          {
+            "replace": "\\s{2,}",
+            "with": " "
+          }
+        ],
+        "hideWhenMissing": true,
+        "excludeFromExtensionStatuses": true
+      }
+    ]
+  }
+}
+```
 
 If you still prefer the old style, `"powerline": "default"` continues to work.
 

--- a/index.ts
+++ b/index.ts
@@ -67,6 +67,7 @@ import {
 let config: PowerlineConfig = {
   preset: "default",
   customItems: [],
+  layout: null,
   mouseScroll: true,
   fixedEditor: true,
 };
@@ -885,7 +886,7 @@ function computeResponsiveLayout(
   const sepWidth = visibleWidth(separatorDef.left) + 2; // separator + spaces around it
   
   // Get all segments: primary first, then secondary
-  const mergedSegments = mergeSegmentsWithCustomItems(presetDef, config.customItems);
+  const mergedSegments = mergeSegmentsWithCustomItems(presetDef, config.customItems, config.layout);
   const primaryIds = [...mergedSegments.leftSegments, ...mergedSegments.rightSegments];
   const secondaryIds = mergedSegments.secondarySegments;
   const allSegmentIds = [...primaryIds, ...secondaryIds];

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,5 +1,5 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
-import type { BuiltinStatusLineSegmentId, ColorValue, CustomItemPosition, CustomStatusItem, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
+import type { BuiltinStatusLineSegmentId, ColorValue, CustomItemPosition, CustomStatusItem, CustomStatusTransform, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
 
 export interface PowerlineConfig {
   preset: StatusLinePreset;
@@ -108,6 +108,30 @@ function normalizeCustomPrefix(value: unknown): string | undefined {
   return normalized ? normalized : undefined;
 }
 
+function normalizeCustomStatusTransform(raw: unknown): CustomStatusTransform | null {
+  if (!isRecord(raw)) return null;
+  const replace = typeof raw.replace === "string" ? raw.replace : null;
+  if (!replace) return null;
+
+  const flags = typeof raw.flags === "string" ? raw.flags : "g";
+  try {
+    new RegExp(replace, flags);
+  } catch {
+    return null;
+  }
+
+  const withValue = typeof raw.with === "string" ? raw.with : "";
+  return { replace, with: withValue, flags };
+}
+
+function normalizeCustomStatusTransforms(raw: unknown): CustomStatusTransform[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    const transform = normalizeCustomStatusTransform(entry);
+    return transform ? [transform] : [];
+  });
+}
+
 function normalizeCustomStatusItem(raw: unknown, idOverride?: string): CustomStatusItem | null {
   if (!isRecord(raw)) return null;
   const id = normalizeCustomItemId(idOverride ?? raw.id);
@@ -121,6 +145,7 @@ function normalizeCustomStatusItem(raw: unknown, idOverride?: string): CustomSta
     position: normalizeCustomItemPosition(raw.position),
     color: normalizeCustomColor(raw.color),
     prefix: normalizeCustomPrefix(raw.prefix),
+    transforms: normalizeCustomStatusTransforms(raw.transforms),
     hideWhenMissing: raw.hideWhenMissing !== false,
     excludeFromExtensionStatuses: raw.excludeFromExtensionStatuses !== false,
   };
@@ -262,6 +287,25 @@ export function normalizeExtensionStatusValue(value: string): string | null {
 
   const stripped = value.replace(/(\x1b\[[0-9;]*m|\s|·|[|])+$/, "");
   return visibleWidth(stripped) > 0 ? stripped : null;
+}
+
+export function applyCustomStatusTransforms(value: string, transforms: readonly CustomStatusTransform[] = []): string {
+  let transformed = value;
+  for (const transform of transforms) {
+    try {
+      transformed = transformed.replace(new RegExp(transform.replace, transform.flags), transform.with);
+    } catch {
+      continue;
+    }
+  }
+  return transformed;
+}
+
+export function normalizeCustomStatusValue(value: string, transforms: readonly CustomStatusTransform[] = []): string | null {
+  const normalized = normalizeExtensionStatusValue(value);
+  if (!normalized) return null;
+
+  return normalizeExtensionStatusValue(applyCustomStatusTransforms(normalized, transforms));
 }
 
 export function normalizeCompactExtensionStatus(value: string): string | null {

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,9 +1,10 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
-import type { ColorValue, CustomItemPosition, CustomStatusItem, PresetDef, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
+import type { BuiltinStatusLineSegmentId, ColorValue, CustomItemPosition, CustomStatusItem, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
 
 export interface PowerlineConfig {
   preset: StatusLinePreset;
   customItems: CustomStatusItem[];
+  layout: StatusLineLayout | null;
   mouseScroll: boolean;
   fixedEditor: boolean;
 }
@@ -23,6 +24,71 @@ function normalizeCustomItemId(value: unknown): string | null {
   const normalized = value.trim();
   if (!normalized) return null;
   return /^[a-zA-Z0-9_-]+$/.test(normalized) ? normalized : null;
+}
+
+const BUILTIN_SEGMENT_IDS = new Set<BuiltinStatusLineSegmentId>([
+  "model",
+  "shell_mode",
+  "path",
+  "git",
+  "subagents",
+  "token_in",
+  "token_out",
+  "token_total",
+  "cost",
+  "context_pct",
+  "context_total",
+  "time_spent",
+  "time",
+  "session",
+  "hostname",
+  "cache_read",
+  "cache_write",
+  "thinking",
+  "extension_statuses",
+]);
+
+function normalizeLayoutSegmentId(value: unknown): StatusLineSegmentId | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  if (BUILTIN_SEGMENT_IDS.has(normalized as BuiltinStatusLineSegmentId)) {
+    return normalized as BuiltinStatusLineSegmentId;
+  }
+
+  if (!normalized.startsWith("custom:")) return null;
+  const customId = normalizeCustomItemId(normalized.slice("custom:".length));
+  return customId ? `custom:${customId}` : null;
+}
+
+function normalizeLayoutSegments(raw: unknown): StatusLineSegmentId[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+
+  const segments: StatusLineSegmentId[] = [];
+  const seen = new Set<string>();
+  for (const entry of raw) {
+    const segmentId = normalizeLayoutSegmentId(entry);
+    if (!segmentId || seen.has(segmentId)) continue;
+    seen.add(segmentId);
+    segments.push(segmentId);
+  }
+
+  return segments;
+}
+
+function normalizeLayout(raw: unknown): StatusLineLayout | null {
+  if (!isRecord(raw)) return null;
+
+  const layout: StatusLineLayout = {};
+  const left = normalizeLayoutSegments(raw.left ?? raw.leftSegments);
+  const right = normalizeLayoutSegments(raw.right ?? raw.rightSegments);
+  const secondary = normalizeLayoutSegments(raw.secondary ?? raw.secondarySegments);
+
+  if (left) layout.leftSegments = left;
+  if (right) layout.rightSegments = right;
+  if (secondary) layout.secondarySegments = secondary;
+
+  return layout.leftSegments || layout.rightSegments || layout.secondarySegments ? layout : null;
 }
 
 function normalizeCustomItemPosition(value: unknown): CustomItemPosition {
@@ -84,7 +150,13 @@ function normalizeCustomItems(raw: unknown): CustomStatusItem[] {
 }
 
 export function parsePowerlineConfig(value: unknown, presets: readonly StatusLinePreset[]): PowerlineConfig {
-  const defaultConfig: PowerlineConfig = { preset: "default", customItems: [], mouseScroll: true, fixedEditor: true };
+  const defaultConfig: PowerlineConfig = {
+    preset: "default",
+    customItems: [],
+    layout: null,
+    mouseScroll: true,
+    fixedEditor: true,
+  };
 
   const directPreset = normalizePreset(value, presets);
   if (directPreset) return { ...defaultConfig, preset: directPreset };
@@ -94,26 +166,47 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
   return {
     preset: normalizePreset(value.preset, presets) ?? defaultConfig.preset,
     customItems: normalizeCustomItems(value.customItems),
+    layout: normalizeLayout(value.layout),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,
   };
 }
 
-export function mergeSegmentsWithCustomItems(presetDef: PresetDef, customItems: readonly CustomStatusItem[]): {
+function appendCustomItems(
+  segments: StatusLineSegmentId[],
+  customItems: readonly CustomStatusItem[],
+  position: CustomItemPosition,
+): StatusLineSegmentId[] {
+  const merged = [...segments];
+  const seen = new Set(merged);
+
+  for (const item of customItems) {
+    if (item.position !== position) continue;
+    const segmentId: StatusLineSegmentId = `custom:${item.id}`;
+    if (seen.has(segmentId)) continue;
+    seen.add(segmentId);
+    merged.push(segmentId);
+  }
+
+  return merged;
+}
+
+export function mergeSegmentsWithCustomItems(
+  presetDef: PresetDef,
+  customItems: readonly CustomStatusItem[],
+  layout: StatusLineLayout | null = null,
+): {
   leftSegments: StatusLineSegmentId[];
   rightSegments: StatusLineSegmentId[];
   secondarySegments: StatusLineSegmentId[];
 } {
-  const left: StatusLineSegmentId[] = [...presetDef.leftSegments];
-  const right: StatusLineSegmentId[] = [...presetDef.rightSegments];
-  const secondary: StatusLineSegmentId[] = [...(presetDef.secondarySegments ?? [])];
+  const leftBase: StatusLineSegmentId[] = layout?.leftSegments ?? presetDef.leftSegments;
+  const rightBase: StatusLineSegmentId[] = layout?.rightSegments ?? presetDef.rightSegments;
+  const secondaryBase: StatusLineSegmentId[] = layout?.secondarySegments ?? (presetDef.secondarySegments ?? []);
 
-  for (const item of customItems) {
-    const segmentId: StatusLineSegmentId = `custom:${item.id}`;
-    if (item.position === "left") left.push(segmentId);
-    else if (item.position === "secondary") secondary.push(segmentId);
-    else right.push(segmentId);
-  }
+  const left = layout?.leftSegments ? [...leftBase] : appendCustomItems(leftBase, customItems, "left");
+  const right = layout?.rightSegments ? [...rightBase] : appendCustomItems(rightBase, customItems, "right");
+  const secondary = layout?.secondarySegments ? [...secondaryBase] : appendCustomItems(secondaryBase, customItems, "secondary");
 
   return { leftSegments: left, rightSegments: right, secondarySegments: secondary };
 }

--- a/segments.ts
+++ b/segments.ts
@@ -2,7 +2,7 @@ import { hostname as osHostname } from "node:os";
 import { basename } from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import type { BuiltinStatusLineSegmentId, RenderedSegment, SegmentContext, SemanticColor, StatusLineSegment, StatusLineSegmentId } from "./types.ts";
-import { normalizeCompactExtensionStatus, normalizeExtensionStatusValue } from "./powerline-config.ts";
+import { normalizeCompactExtensionStatus, normalizeCustomStatusValue } from "./powerline-config.ts";
 import { fg, rainbow, applyColor } from "./theme.ts";
 import { getIcons, SEP_DOT, getThinkingText } from "./icons.ts";
 
@@ -456,7 +456,7 @@ function renderCustomSegment(id: `custom:${string}`, ctx: SegmentContext): Rende
   if (!custom) return { content: "", visible: false };
 
   const rawStatus = ctx.extensionStatuses.get(custom.statusKey);
-  const normalizedStatus = rawStatus ? normalizeExtensionStatusValue(rawStatus) : null;
+  const normalizedStatus = rawStatus ? normalizeCustomStatusValue(rawStatus, custom.transforms) : null;
   if (!normalizedStatus) {
     return custom.hideWhenMissing ? { content: "", visible: false } : { content: custom.prefix ?? custom.id, visible: true };
   }

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -44,6 +44,26 @@ test("parsePowerlineConfig supports disabling fixed editor", () => {
   assert.equal(config.fixedEditor, false);
 });
 
+test("parsePowerlineConfig supports explicit layout arrays", () => {
+  const config = parsePowerlineConfig(
+    {
+      preset: "default",
+      layout: {
+        left: ["model", "thinking", "custom:quotas", "unknown", "model"],
+        rightSegments: ["context_pct", "cost"],
+        secondary: ["extension_statuses"],
+      },
+    },
+    ["default", "compact"],
+  );
+
+  assert.deepEqual(config.layout, {
+    leftSegments: ["model", "thinking", "custom:quotas"],
+    rightSegments: ["context_pct", "cost"],
+    secondarySegments: ["extension_statuses"],
+  });
+});
+
 test("mergeSegmentsWithCustomItems appends custom segment ids by position", () => {
   const merged = mergeSegmentsWithCustomItems(
     {
@@ -62,6 +82,51 @@ test("mergeSegmentsWithCustomItems appends custom segment ids by position", () =
   assert.deepEqual(merged.leftSegments, ["path", "custom:ci"]);
   assert.deepEqual(merged.rightSegments, ["git", "custom:timer"]);
   assert.deepEqual(merged.secondarySegments, ["extension_statuses", "custom:review"]);
+});
+
+test("mergeSegmentsWithCustomItems uses explicit layout arrays without appending custom items to configured rows", () => {
+  const merged = mergeSegmentsWithCustomItems(
+    {
+      leftSegments: ["path"],
+      rightSegments: ["git"],
+      secondarySegments: ["extension_statuses"],
+      separator: "powerline",
+    },
+    [
+      { id: "ci", statusKey: "ci", position: "left", hideWhenMissing: true, excludeFromExtensionStatuses: true },
+      { id: "timer", statusKey: "timer", position: "right", hideWhenMissing: true, excludeFromExtensionStatuses: true },
+      { id: "review", statusKey: "review", position: "secondary", hideWhenMissing: true, excludeFromExtensionStatuses: true },
+    ],
+    {
+      leftSegments: ["model", "custom:ci"],
+      rightSegments: ["context_pct", "cost"],
+      secondarySegments: [],
+    },
+  );
+
+  assert.deepEqual(merged.leftSegments, ["model", "custom:ci"]);
+  assert.deepEqual(merged.rightSegments, ["context_pct", "cost"]);
+  assert.deepEqual(merged.secondarySegments, []);
+});
+
+test("mergeSegmentsWithCustomItems preserves custom append behavior for rows not configured by layout", () => {
+  const merged = mergeSegmentsWithCustomItems(
+    {
+      leftSegments: ["path"],
+      rightSegments: ["git"],
+      secondarySegments: ["extension_statuses"],
+      separator: "powerline",
+    },
+    [
+      { id: "ci", statusKey: "ci", position: "left", hideWhenMissing: true, excludeFromExtensionStatuses: true },
+      { id: "timer", statusKey: "timer", position: "right", hideWhenMissing: true, excludeFromExtensionStatuses: true },
+    ],
+    { leftSegments: ["model"] },
+  );
+
+  assert.deepEqual(merged.leftSegments, ["model"]);
+  assert.deepEqual(merged.rightSegments, ["git", "custom:timer"]);
+  assert.deepEqual(merged.secondarySegments, ["extension_statuses"]);
 });
 
 test("nextPowerlineSettingWithPreset preserves object settings", () => {

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, normalizeExtensionStatusValue, parsePowerlineConfig, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, normalizeCompactExtensionStatus } from "../powerline-config.ts";
+import { applyCustomStatusTransforms, collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, normalizeCustomStatusValue, normalizeExtensionStatusValue, parsePowerlineConfig, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, normalizeCompactExtensionStatus } from "../powerline-config.ts";
 
 test("parsePowerlineConfig supports object config with custom items", () => {
   const config = parsePowerlineConfig(
@@ -19,9 +19,34 @@ test("parsePowerlineConfig supports object config with custom items", () => {
   assert.equal(config.customItems[0].id, "ci");
   assert.equal(config.customItems[0].statusKey, "ci-status");
   assert.equal(config.customItems[1].statusKey, "review");
+  assert.deepEqual(config.customItems[1].transforms, []);
   assert.equal(config.customItems[1].hideWhenMissing, false);
   assert.equal(config.mouseScroll, true);
   assert.equal(config.fixedEditor, true);
+});
+
+test("parsePowerlineConfig supports per-custom-item status transforms", () => {
+  const config = parsePowerlineConfig(
+    {
+      customItems: [
+        {
+          id: "quotas",
+          statusKey: "pi-quotas-usage",
+          transforms: [
+            { replace: "\\s+left\\s+\\(↺\\s*in\\s*", with: " (↺ " },
+            { replace: "(?:^|\\s*(?:·|\\|)\\s*)cap:OK(?=\\s*(?:·|\\|)|$)", with: "", flags: "gi" },
+            { replace: "[", with: "ignored" },
+          ],
+        },
+      ],
+    },
+    ["default"],
+  );
+
+  assert.deepEqual(config.customItems[0].transforms, [
+    { replace: "\\s+left\\s+\\(↺\\s*in\\s*", with: " (↺ ", flags: "g" },
+    { replace: "(?:^|\\s*(?:·|\\|)\\s*)cap:OK(?=\\s*(?:·|\\|)|$)", with: "", flags: "gi" },
+  ]);
 });
 
 test("parsePowerlineConfig supports disabling mouse scroll", () => {
@@ -186,6 +211,31 @@ test("normalizeCompactExtensionStatus strips baked-in trailing separators", () =
 
 test("normalizeExtensionStatusValue keeps notification-style statuses renderable for custom items", () => {
   assert.equal(normalizeExtensionStatusValue("[review] queued · "), "[review] queued");
+});
+
+test("applyCustomStatusTransforms applies ordered regex replacements", () => {
+  const transforms = [
+    { replace: "\\s+left\\s+\\(↺\\s*in\\s*", with: " (↺ ", flags: "g" },
+    { replace: "(?:^|\\s*(?:·|\\|)\\s*)cap:OK(?=\\s*(?:·|\\|)|$)", with: "", flags: "gi" },
+  ];
+
+  assert.equal(
+    applyCustomStatusTransforms("5h:93% left (↺in 2h8m) · 7d:83% left (↺in 73h47m) · cap:OK", transforms),
+    "5h:93% (↺ 2h8m) · 7d:83% (↺ 73h47m)",
+  );
+});
+
+test("normalizeCustomStatusValue scopes transforms to the custom item", () => {
+  const quotaTransforms = [
+    { replace: "\\s+left\\s+\\(↺\\s*in\\s*", with: " (↺ ", flags: "g" },
+    { replace: "(?:^|\\s*(?:·|\\|)\\s*)cap:OK(?=\\s*(?:·|\\|)|$)", with: "", flags: "gi" },
+  ];
+
+  assert.equal(
+    normalizeCustomStatusValue("5h:93% left (↺in 2h8m) | cap:OK", quotaTransforms),
+    "5h:93% (↺ 2h8m)",
+  );
+  assert.equal(normalizeCustomStatusValue("plain · ", []), "plain");
 });
 
 test("getNotificationExtensionStatuses skips promoted hidden status keys", () => {

--- a/types.ts
+++ b/types.ts
@@ -87,12 +87,19 @@ export interface StatusLineSegmentOptions {
 
 export type CustomItemPosition = "left" | "right" | "secondary";
 
+export interface CustomStatusTransform {
+  replace: string;
+  with: string;
+  flags?: string;
+}
+
 export interface CustomStatusItem {
   id: string;
   statusKey: string;
   position: CustomItemPosition;
   color?: ColorValue;
   prefix?: string;
+  transforms?: CustomStatusTransform[];
   hideWhenMissing: boolean;
   excludeFromExtensionStatuses: boolean;
 }

--- a/types.ts
+++ b/types.ts
@@ -97,6 +97,14 @@ export interface CustomStatusItem {
   excludeFromExtensionStatuses: boolean;
 }
 
+// Segment layout override from settings
+export interface StatusLineLayout {
+  leftSegments?: StatusLineSegmentId[];
+  rightSegments?: StatusLineSegmentId[];
+  /** Secondary row segments (shown in footer, above sub bar) */
+  secondarySegments?: StatusLineSegmentId[];
+}
+
 // Preset definition
 export interface PresetDef {
   leftSegments: BuiltinStatusLineSegmentId[];


### PR DESCRIPTION
## Summary

This PR adds two settings-driven Powerline footer customization features:

1. `powerline.layout`, a JSON-configurable way to control which footer segments are shown on each row.
2. `customItems[].transforms`, ordered regex replacements scoped to a promoted custom status item.

Together, these let users compose an exact footer from settings without creating a new preset, modifying source code, or patching the extension that originally publishes a status.

## Motivation

Today, `pi-powerline-footer` supports presets and `customItems`, but presets define fixed segment arrays in source. This makes it hard to compose a footer that is “mostly default” while removing specific noisy segments.

For example, a user may want to:

- keep `model`
- keep `thinking`
- keep `context_pct`
- keep `cost`
- remove `path`
- remove `cache_read`
- hide aggregate `extension_statuses`
- promote one extension status into a dedicated footer item
- clean up the promoted status text for compact display

Before this PR, the closest option was often `compact`, but that could also remove useful segments like `thinking`.

This change makes that kind of footer possible from settings alone.

`transforms` are included because extension statuses are published as display strings through `ctx.ui.setStatus(...)`. When a user promotes one status into its own custom item, they may want display-layer cleanup without changing the publishing extension. The transform rules are scoped per custom item/status key so rules for one extension cannot affect other status entries.

Closes https://github.com/nicobailon/pi-powerline-footer/issues/37

## Usage

Example `.pi/settings.json` or `~/.pi/agent/settings.json`:

```json
{
  "powerline": {
    "preset": "default",
    "layout": {
      "left": ["model", "thinking", "shell_mode", "git"],
      "right": ["context_pct", "cost"],
      "secondary": ["custom:quotas"]
    },
    "customItems": [
      {
        "id": "quotas",
        "statusKey": "pi-quotas-usage",
        "position": "secondary",
        "transforms": [
          {
            "replace": "\\s*(?:\\x1b\\[[0-9;]*m)*left(?:\\x1b\\[[0-9;]*m)*\\s+",
            "with": " "
          },
          {
            "replace": "↺\\s*(?:\\x1b\\[[0-9;]*m)*in(?:\\x1b\\[[0-9;]*m)*\\s*",
            "with": "↺ "
          },
          {
            "replace": "\\)((?:(?:\\x1b\\[[0-9;]*m)|\\s)+)((?:\\x1b\\[[0-9;]*m)*\\d+[hd]:)",
            "with": ")$1· $2"
          },
          {
            "replace": "\\s*cap:(?:\\x1b\\[[0-9;]*m)*OK(?:\\x1b\\[[0-9;]*m)*\\s*",
            "with": "",
            "flags": "gi"
          },
          {
            "replace": "\\s{2,}",
            "with": " "
          }
        ],
        "hideWhenMissing": true,
        "excludeFromExtensionStatuses": true
      }
    ]
  }
}
```

### Supported row keys

- `layout.left`
- `layout.right`
- `layout.secondary`

Aliases are also supported:

- `layout.leftSegments`
- `layout.rightSegments`
- `layout.secondarySegments`

### Custom item transforms

Each `customItems[].transforms` entry supports:

- `replace`: regex pattern string
- `with`: replacement string
- `flags`: optional regex flags, defaulting to `g`

Transforms run in order and only apply to that custom item’s `statusKey` value.

## Behavior

- Preset still controls separator, colors, and per-segment options.
- If a layout row is present, it replaces that preset row exactly.
- If a layout row is omitted, the preset row is used as before.
- `customItems` still append to omitted rows by their configured position.
- Explicit layout rows can include custom items using `custom:<id>`.
- Unknown segment ids are ignored.
- Duplicate segment ids in a row are deduplicated.
- Invalid transform regexes are ignored during config parsing.
- Existing string-style config such as `"powerline": "default"` continues to work.

## Example use case

This config keeps useful status information while removing path/cache/status noise and promoting only one extension status:

```json
{
  "powerline": {
    "preset": "default",
    "layout": {
      "left": ["model", "thinking"],
      "right": ["context_pct", "cost"],
      "secondary": ["custom:quotas"]
    },
    "customItems": [
      {
        "id": "quotas",
        "statusKey": "pi-quotas-usage",
        "position": "secondary",
        "hideWhenMissing": true,
        "excludeFromExtensionStatuses": true
      }
    ]
  }
}
```

This can produce a cleaner footer with model, thinking level, context, and cost/subscription status, while avoiding the workspace path, cache counters, and aggregate extension status segment.

When transforms are added to the `quotas` item, the promoted status can also be display-cleaned without changing the `pi-quotas` extension.

## Implementation details

This PR adds:

- `StatusLineLayout` type
- layout parsing in `parsePowerlineConfig()`
- built-in segment id validation
- `custom:<id>` validation using the existing custom item id rules
- layout-aware segment merging
- `CustomStatusTransform` type
- per-custom-item transform parsing and validation
- transform application in custom segment rendering
- README documentation
- changelog entry
- test coverage for:
  - parsing layout arrays
  - exact row replacement
  - empty row override behavior
  - partial layout compatibility with existing `customItems` append behavior
  - transform parsing and invalid regex rejection
  - ordered transform application
  - transform scoping to a custom item

## Backward compatibility

This should be backward compatible.

Existing configs continue to behave the same when `powerline.layout` is absent.

Existing `customItems` behavior is preserved unless the user explicitly configures the row where those custom items would normally be appended.

Transforms are optional. Existing custom items without transforms render as before.

## Validation

Smoke-tested in a Pi agent project with a local package install.

Confirmed:

- custom layout loaded successfully
- footer segments appeared according to the configured layout
- `custom:quotas` rendered the `pi-quotas-usage` status
- `transforms` applied only to the promoted quotas item
- transforms handled ANSI-colored status fragments
- cleaned quota output rendered as expected, e.g.:

```text
5h:98% (↺ 4h23m) · 7d:81% (↺ 65h31m)
```