### PR TITLE
fix: Restore cursor position after quitting

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2266,12 +2266,16 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     if (fixedEditorCompositor || !tuiRef?.terminal || config.fixedEditor) return;
 
     const rows = Math.max(1, Number(tuiRef.terminal.rows) || 1);
+    const cursorRow = typeof tuiRef.cursorRow === "number" ? tuiRef.cursorRow : rows - 1;
+    const viewportTop = typeof tuiRef.previousViewportTop === "number" ? tuiRef.previousViewportTop : 0;
+    const screenRow = Math.max(1, Math.min(rows, cursorRow - viewportTop + 1));
     try {
-      process.stdout.write(`\x1b[0m\x1b[r\x1b[${rows};1H\n`);
+      process.stdout.write(`\x1b[0m\x1b[r\x1b[${screenRow};1H\n`);
     } catch {
       // Shutdown cleanup cannot surface useful terminal write failures.
     }
   }
+
   
   function findContainerWithChild(tui: any, child: any): { container: any; index: number } | null {
     const children = Array.isArray(tui?.children) ? tui.children : [];

--- a/index.ts
+++ b/index.ts
@@ -1261,6 +1261,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     restoreFooterStatusRepaintHook?.();
     restoreFooterStatusRepaintHook = null;
     teardownFixedEditorCompositor({ resetExtendedKeyboardModes: true });
+    restoreCursorBelowInlineEditor();
     stashShortcutInputUnsubscribe?.();
     stashShortcutInputUnsubscribe = null;
     shellSession?.dispose();
@@ -2260,7 +2261,18 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     fixedWidgetContainerAbove = null;
     fixedWidgetContainerBelow = null;
   }
+  
+  function restoreCursorBelowInlineEditor(): void {
+    if (fixedEditorCompositor || !tuiRef?.terminal || config.fixedEditor) return;
 
+    const rows = Math.max(1, Number(tuiRef.terminal.rows) || 1);
+    try {
+      process.stdout.write(`\x1b[0m\x1b[r\x1b[${rows};1H\n`);
+    } catch {
+      // Shutdown cleanup cannot surface useful terminal write failures.
+    }
+  }
+  
   function findContainerWithChild(tui: any, child: any): { container: any; index: number } | null {
     const children = Array.isArray(tui?.children) ? tui.children : [];
     const index = children.findIndex((candidate: any) => Array.isArray(candidate?.children) && candidate.children.includes(child));


### PR DESCRIPTION
Place terminal cursor to the bottom of the screen after quitting.

With fixedEditor set to false the terminal cursor jumps back to its position when Pi was started. This is usually somewhere in between some previous output text. The fix in this PR places the cursor right after where Pi quits.