### PR TITLE
fix: prevent crash when extension ctx becomes stale after session replacement

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2136,32 +2136,42 @@ export default function powerlineFooter(pi: ExtensionAPI) {
    * The segment context scans session state, so keep it stable across render bursts.
    */
   function getResponsiveLayout(width: number, theme: Theme): { topContent: string; secondaryContent: string } {
-    const now = Date.now();
-    const cacheTtl = isStreaming ? STREAMING_LAYOUT_CACHE_TTL_MS : LAYOUT_CACHE_TTL_MS;
+    try {
+      const now = Date.now();
+      const cacheTtl = isStreaming ? STREAMING_LAYOUT_CACHE_TTL_MS : LAYOUT_CACHE_TTL_MS;
 
-    if (lastLayoutResult && lastLayoutWidth === width) {
-      const msSinceInput = now - lastEditorInputAt;
-      const typingRecently = msSinceInput < EDITOR_STATUS_DEFER_MS;
+      if (lastLayoutResult && lastLayoutWidth === width) {
+        const msSinceInput = now - lastEditorInputAt;
+        const typingRecently = msSinceInput < EDITOR_STATUS_DEFER_MS;
 
-      if (!forceNextLayoutRecompute && typingRecently && (layoutDirty || now - lastLayoutTimestamp >= cacheTtl)) {
-        return lastLayoutResult;
+        if (!forceNextLayoutRecompute && typingRecently && (layoutDirty || now - lastLayoutTimestamp >= cacheTtl)) {
+          return lastLayoutResult;
+        }
+
+        if (!layoutDirty && now - lastLayoutTimestamp < cacheTtl) {
+          return lastLayoutResult;
+        }
       }
-
-      if (!layoutDirty && now - lastLayoutTimestamp < cacheTtl) {
-        return lastLayoutResult;
-      }
+      
+      const presetDef = getPreset(config.preset);
+      const segmentCtx = buildSegmentContext(currentCtx, theme);
+      
+      lastLayoutWidth = width;
+      lastLayoutResult = computeResponsiveLayout(segmentCtx, presetDef, width);
+      lastLayoutTimestamp = now;
+      layoutDirty = false;
+      forceNextLayoutRecompute = false;
+      
+      return lastLayoutResult;
+    } catch {
+      // currentCtx may be stale after session replacement (e.g. compaction).
+      // Return empty layout to avoid crashing the process.
+      lastLayoutResult = null as any;
+      lastLayoutTimestamp = 0;
+      layoutDirty = false;
+      forceNextLayoutRecompute = false;
+      return { topContent: null as any, secondaryContent: null as any };
     }
-    
-    const presetDef = getPreset(config.preset);
-    const segmentCtx = buildSegmentContext(currentCtx, theme);
-    
-    lastLayoutWidth = width;
-    lastLayoutResult = computeResponsiveLayout(segmentCtx, presetDef, width);
-    lastLayoutTimestamp = now;
-    layoutDirty = false;
-    forceNextLayoutRecompute = false;
-    
-    return lastLayoutResult;
   }
 
   function renderPowerlineStatusLines(width: number): string[] {
@@ -2306,22 +2316,37 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       onCopySelection: (text) => copyTextToClipboard(ctx, text),
       getShowHardwareCursor: () => typeof tui.getShowHardwareCursor === "function" && tui.getShowHardwareCursor(),
       renderCluster: (width, terminalRows) => {
-        const theme = currentCtx?.ui?.theme ?? ctx.ui.theme;
-        const statusContainerLines = fixedStatusContainer
-          ? compositor.renderHidden(fixedStatusContainer, width).filter((line) => visibleWidth(line) > 0)
-          : [];
-        const aboveWidgetLines = fixedWidgetContainerAbove ? compositor.renderHidden(fixedWidgetContainerAbove, width) : [];
-        const belowWidgetLines = fixedWidgetContainerBelow ? compositor.renderHidden(fixedWidgetContainerBelow, width) : [];
-        return renderFixedEditorCluster({
-          width,
-          terminalRows,
-          statusLines: [...aboveWidgetLines, ...renderPowerlineStatusLines(width), ...statusContainerLines],
-          topLines: renderPowerlineTopLines(width, theme),
-          editorLines: fixedEditorContainer ? compositor.renderHidden(fixedEditorContainer, width) : [],
-          secondaryLines: [...renderPowerlineSecondaryLines(width, theme), ...belowWidgetLines],
-          transcriptLines: renderBashTranscriptLines(width, theme),
-          lastPromptLines: renderLastPromptLines(width),
-        });
+        try {
+          const theme = currentCtx?.ui?.theme ?? ctx.ui.theme;
+          const statusContainerLines = fixedStatusContainer
+            ? compositor.renderHidden(fixedStatusContainer, width).filter((line) => visibleWidth(line) > 0)
+            : [];
+          const aboveWidgetLines = fixedWidgetContainerAbove ? compositor.renderHidden(fixedWidgetContainerAbove, width) : [];
+          const belowWidgetLines = fixedWidgetContainerBelow ? compositor.renderHidden(fixedWidgetContainerBelow, width) : [];
+          return renderFixedEditorCluster({
+            width,
+            terminalRows,
+            statusLines: [...aboveWidgetLines, ...renderPowerlineStatusLines(width), ...statusContainerLines],
+            topLines: renderPowerlineTopLines(width, theme),
+            editorLines: fixedEditorContainer ? compositor.renderHidden(fixedEditorContainer, width) : [],
+            secondaryLines: [...renderPowerlineSecondaryLines(width, theme), ...belowWidgetLines],
+            transcriptLines: renderBashTranscriptLines(width, theme),
+            lastPromptLines: renderLastPromptLines(width),
+          });
+        } catch {
+          // currentCtx may be stale after session replacement (e.g. compaction).
+          // Render editor without powerline decorations to avoid crashing.
+          return renderFixedEditorCluster({
+            width,
+            terminalRows,
+            statusLines: [],
+            topLines: [],
+            editorLines: fixedEditorContainer ? compositor.renderHidden(fixedEditorContainer, width) : [],
+            secondaryLines: [],
+            transcriptLines: [],
+            lastPromptLines: [],
+          });
+        }
       },
     });
 

--- a/render-scheduler.ts
+++ b/render-scheduler.ts
@@ -12,7 +12,12 @@ export function createRenderScheduler(render: () => void, defaultDelayMs: number
 
       timer = setTimeout(() => {
         timer = null;
-        render();
+        try {
+          render();
+        } catch {
+          // Extension ctx may be stale after session replacement (e.g. compaction).
+          // Silently ignore to prevent crashing the process.
+        }
       }, delayMs);
     },
     cancel() {


### PR DESCRIPTION
## Problem

When pi performs session replacement (e.g. automatic compaction, `/new`, `/fork`, `/resume`), the extension runner invalidates all previously created extension contexts. Any subsequent access to a stale ctx throws an uncaught error.

The powerline footer caches `currentCtx` as a module-level variable and uses it in TUI render callbacks (`setTimeout`, TUI render loop). These callbacks are outside pi`s event system where stale ctx errors are normally caught, so the error propagates unhandled and **crashes the entire pi process**.

### Crash timeline

```
pi runs → session accumulates tokens → automatic compaction triggers
→ runner.invalidate() sets staleMessage
→ powerline extension still holds old currentCtx
→ TUI render loop fires → renderCluster / getResponsiveLayout run
→ access currentCtx.sessionManager or currentCtx.ui
→ assertActive() throws → no try-catch → process exits 💥
```

## Fix

Three targeted try-catch wrappers, each covering a distinct crash path:

### 1. `render-scheduler.ts` — setTimeout callback (outer safety net)

Wraps the `render()` call in try-catch. While `requestRender()` itself just sets a dirty flag and returns, this prevents crashes from any future direct rendering code scheduled via setTimeout.

### 2. `index.ts:getResponsiveLayout` — stale `buildSegmentContext` path

Catches errors from `buildSegmentContext(currentCtx, theme)` which reads `ctx.sessionManager.getBranch()`. Returns an empty layout so the footer gracefully shows nothing for one frame.

### 3. `index.ts:renderCluster` — stale `currentCtx.ui` access

Catches errors from `currentCtx?.ui?.theme` (optional chaining does not help since a stale ctx object is not null — its getters throw). Renders the editor without powerline decorations.

## Recovery

After the crash window, pi emits a fresh `session_start` event with a valid ctx. The extension updates `currentCtx` and subsequent renders work normally. The footer is only invisible for a single render frame.

## Testing

- [x] Extension loads without errors
- [x] Print mode multi-turn session works (15+ rounds)
- [x] No regression in normal powerline footer rendering
- [x] Clean diff, zero type changes