### PR TITLE
feat: update segment layout function to support switching styles

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,6 +69,7 @@ let config: PowerlineConfig = {
   customItems: [],
   mouseScroll: true,
   fixedEditor: true,
+  splitLayout: false,
 };
 
 const CUSTOM_COMPACTION_STATUS_KEY = "compact-policy";
@@ -627,7 +628,7 @@ function writePowerlinePresetSetting(preset: StatusLinePreset, cwd: string = pro
 
 function writePowerlineOptionSetting(
   cwd: string,
-  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor">>,
+  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "splitLayout">>,
   currentPreset: StatusLinePreset,
 ): boolean {
   return writePowerlineSetting(cwd, (existingPowerlineSetting) => (
@@ -872,9 +873,13 @@ function buildContentFromParts(
 }
 
 /**
- * Split segment layout - prioritizes primary segments.
- * When terminal is too narrow, primary segments overflow down to secondary row.
- * When secondary row is full, remaining segments are skipped.
+ * Responsive segment fitter - handles multiple cases.
+ * When splitLayout is false: 
+ *   - All segments are candidates for primary row
+ *   - Overflow fills secondary row
+ * When splitLayout is true:
+ *   - Only primary segments are candidates for primary row  
+ *   - Secondary row prioritizes overflow before fitting secondary segments
  */
 function computeResponsiveLayout(
   ctx: SegmentContext,
@@ -907,31 +912,38 @@ function computeResponsiveLayout(
     }
   }
   
+  // Determine primary row candidates based on layout mode
+  const primaryRowCandidates = config.splitLayout 
+    ? renderedPrimarySegments 
+    : [...renderedPrimarySegments, ...renderedSecondarySegments];
+  
   // Calculate how many segments fit in primary row
   // Account for: leading space (1) + trailing space (1) = 2 chars overhead
   const baseOverhead = 2;
   let currentWidth = baseOverhead;
   let topSegments: string[] = [];
-  let overflowPrimarySegments: { content: string; width: number }[] = [];
+  let overflowSegments: { content: string; width: number }[] = [];
+  let overflow = false;
   
-  for (const seg of renderedPrimarySegments) {
+  for (const seg of primaryRowCandidates) {
     const neededWidth = seg.width + (topSegments.length > 0 ? sepWidth : 0);
     
-    if (currentWidth + neededWidth <= availableWidth) {
+    if (!overflow && currentWidth + neededWidth <= availableWidth) {
       topSegments.push(seg.content);
       currentWidth += neededWidth;
     } else {
-      overflowPrimarySegments.push(seg);
+      overflow = true;
+      overflowSegments.push(seg);
     }
   }
   
-  // Fit remaining segments into secondary row (same width constraint)
-  // Stop at first non-fitting segment to preserve ordering
-  const secondaryRowCandidates: { content: string; width: number }[] = [
-    ...overflowPrimarySegments,
-    ...renderedSecondarySegments
-  ];
+  // Determine secondary row candidates based on layout mode
+  const secondaryRowCandidates = config.splitLayout
+    ? [...overflowSegments, ...renderedSecondarySegments]
+    : overflowSegments;
   
+  // Fit eligible candidates into secondary row (same width constraint)
+  // Stop at first non-fitting segment to preserve ordering
   let secondaryWidth = baseOverhead;
   let secondarySegments: string[] = [];
   
@@ -1793,6 +1805,21 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           ctx.ui.notify(`Powerline fixed editor ${config.fixedEditor ? "enabled" : "disabled"}`, "info");
         } else {
           ctx.ui.notify(`Powerline fixed editor ${config.fixedEditor ? "enabled" : "disabled"} (not persisted; check settings.json)`, "warning");
+        }
+        return;
+      }
+
+      // Add split layout toggle command
+      const splitLayoutMatch = /^split-layout(?:\s+(on|off|toggle))?$/.exec(normalizedArgs);
+      if (splitLayoutMatch) {
+        const mode = splitLayoutMatch[1] ?? "toggle";
+        config.splitLayout = mode === "toggle" ? !config.splitLayout : mode === "on";
+        resetLayoutCache();
+        
+        if (writePowerlineOptionSetting(ctx.cwd, { splitLayout: config.splitLayout }, config.preset)) {
+          ctx.ui.notify(`Powerline split layout ${config.splitLayout ? "enabled" : "disabled"}`, "info");
+        } else {
+          ctx.ui.notify(`Powerline split layout ${config.splitLayout ? "enabled" : "disabled"} (not persisted; check settings.json)`, "warning");
         }
         return;
       }

--- a/index.ts
+++ b/index.ts
@@ -872,9 +872,9 @@ function buildContentFromParts(
 }
 
 /**
- * Responsive segment layout - fits segments into top bar, overflows to secondary row.
- * When terminal is wide enough, secondary segments move up to top bar.
- * When narrow, top bar segments overflow down to secondary row.
+ * Split segment layout - prioritizes primary segments.
+ * When terminal is too narrow, primary segments overflow down to secondary row.
+ * When secondary row is full, remaining segments are skipped.
  */
 function computeResponsiveLayout(
   ctx: SegmentContext,
@@ -888,47 +888,54 @@ function computeResponsiveLayout(
   const mergedSegments = mergeSegmentsWithCustomItems(presetDef, config.customItems);
   const primaryIds = [...mergedSegments.leftSegments, ...mergedSegments.rightSegments];
   const secondaryIds = mergedSegments.secondarySegments;
-  const allSegmentIds = [...primaryIds, ...secondaryIds];
   
-  // Render all segments and get their widths
-  const renderedSegments: { content: string; width: number }[] = [];
-  for (const segId of allSegmentIds) {
+  // Render primary segments and get their widths
+  const renderedPrimarySegments: { content: string; width: number }[] = [];
+  for (const segId of primaryIds) {
     const { content, width, visible } = renderSegmentWithWidth(segId, ctx);
     if (visible) {
-      renderedSegments.push({ content, width });
+      renderedPrimarySegments.push({ content, width });
     }
   }
   
-  if (renderedSegments.length === 0) {
-    return { topContent: "", secondaryContent: "" };
+  // Render secondary segments and get their widths
+  const renderedSecondarySegments: { content: string; width: number }[] = [];
+  for (const segId of secondaryIds) {
+    const { content, width, visible } = renderSegmentWithWidth(segId, ctx);
+    if (visible) {
+      renderedSecondarySegments.push({ content, width });
+    }
   }
   
-  // Calculate how many segments fit in top bar
+  // Calculate how many segments fit in primary row
   // Account for: leading space (1) + trailing space (1) = 2 chars overhead
   const baseOverhead = 2;
   let currentWidth = baseOverhead;
   let topSegments: string[] = [];
-  let overflowSegments: { content: string; width: number }[] = [];
-  let overflow = false;
+  let overflowPrimarySegments: { content: string; width: number }[] = [];
   
-  for (const seg of renderedSegments) {
+  for (const seg of renderedPrimarySegments) {
     const neededWidth = seg.width + (topSegments.length > 0 ? sepWidth : 0);
     
-    if (!overflow && currentWidth + neededWidth <= availableWidth) {
+    if (currentWidth + neededWidth <= availableWidth) {
       topSegments.push(seg.content);
       currentWidth += neededWidth;
     } else {
-      overflow = true;
-      overflowSegments.push(seg);
+      overflowPrimarySegments.push(seg);
     }
   }
   
-  // Fit overflow segments into secondary row (same width constraint)
+  // Fit remaining segments into secondary row (same width constraint)
   // Stop at first non-fitting segment to preserve ordering
+  const secondaryRowCandidates: { content: string; width: number }[] = [
+    ...overflowPrimarySegments,
+    ...renderedSecondarySegments
+  ];
+  
   let secondaryWidth = baseOverhead;
   let secondarySegments: string[] = [];
   
-  for (const seg of overflowSegments) {
+  for (const seg of secondaryRowCandidates) {
     const neededWidth = seg.width + (secondarySegments.length > 0 ? sepWidth : 0);
     if (secondaryWidth + neededWidth <= availableWidth) {
       secondarySegments.push(seg.content);

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -97,7 +97,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     customItems: normalizeCustomItems(value.customItems),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,
-    splitLayout: value.splitLayout !== true
+    splitLayout: value.splitLayout === true
   };
 }
 

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -6,6 +6,7 @@ export interface PowerlineConfig {
   customItems: CustomStatusItem[];
   mouseScroll: boolean;
   fixedEditor: boolean;
+  splitLayout: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -84,7 +85,7 @@ function normalizeCustomItems(raw: unknown): CustomStatusItem[] {
 }
 
 export function parsePowerlineConfig(value: unknown, presets: readonly StatusLinePreset[]): PowerlineConfig {
-  const defaultConfig: PowerlineConfig = { preset: "default", customItems: [], mouseScroll: true, fixedEditor: true };
+  const defaultConfig: PowerlineConfig = { preset: "default", customItems: [], mouseScroll: true, fixedEditor: true, splitLayout: false };
 
   const directPreset = normalizePreset(value, presets);
   if (directPreset) return { ...defaultConfig, preset: directPreset };
@@ -96,6 +97,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     customItems: normalizeCustomItems(value.customItems),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,
+    splitLayout: value.splitLayout !== true
   };
 }
 
@@ -127,7 +129,7 @@ export function nextPowerlineSettingWithPreset(existingPowerlineSetting: unknown
 
 export function nextPowerlineSettingWithOptions(
   existingPowerlineSetting: unknown,
-  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor">>,
+  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "splitLayout">>,
   currentPreset: StatusLinePreset,
 ): unknown {
   if (!isRecord(existingPowerlineSetting)) {


### PR DESCRIPTION
# Summary
The following changes have been made:
- conditional logic for row eligibility
- new split layout to pin secondary segments below command line (primary segments are prioritized)
- new `split-layout` slash command to toggle styles

# Configuration
The default config uses the original layout (split-layout disabled).
To use the split layout, add the following to your config:
```json
{
  "powerline": {
    "splitLayout": true
  }
}
```
The layout can be toggled in a session using `/powerline split-layout` (uses the same args as existing toggles).