### PR TITLE
chore(deps): widen peer ranges to allow 0.75.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "test": "node --experimental-strip-types --test tests/**/*.test.ts"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "^0.74.0",
-    "@earendil-works/pi-coding-agent": "^0.74.0",
-    "@earendil-works/pi-tui": "^0.74.0"
+    "@earendil-works/pi-ai": ">=0.74.0 <0.76.0",
+    "@earendil-works/pi-coding-agent": ">=0.74.0 <0.76.0",
+    "@earendil-works/pi-tui": ">=0.74.0 <0.76.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.74.0",
-    "@earendil-works/pi-coding-agent": "^0.74.0",
-    "@earendil-works/pi-tui": "^0.74.0"
+    "@earendil-works/pi-ai": ">=0.74.0 <0.76.0",
+    "@earendil-works/pi-coding-agent": ">=0.74.0 <0.76.0",
+    "@earendil-works/pi-tui": ">=0.74.0 <0.76.0"
   },
   "pi": {
     "extensions": [


### PR DESCRIPTION
## Summary

Closes #67.

Widen the `@earendil-works/pi-{ai,coding-agent,tui}` peer ranges in `package.json` from `^0.74.0` to `>=0.74.0 <0.76.0`.

The current `^0.74.0` ceiling (`<0.75.0`) prevents installing any extension that peers `^0.75.x` (e.g. `pi-rtk-optimizer@0.8.0`, `pi-tool-display@0.4.0`) alongside `pi-powerline-footer`. npm resolves the intersection to `0.74.x` for the powerline-footer constraint, then the newer extension's `^0.75.4` peer is unsatisfiable, and `pi update` / `pi install npm:pi-rtk-optimizer` fail with `ERESOLVE`.

Widening to `>=0.74.0 <0.76.0` (caret-OR equivalent: `^0.74.0 || ^0.75.0`) keeps existing 0.74.x users working while unblocking the 0.75 line. Same change applied to `devDependencies` so local development matches.

Pi itself shipped 0.75 weeks ago and `pi -v` reports `0.75.x` on current installs, so this just realigns the peer range with the runtime that's already deployed.

## Test plan

- [ ] Confirm npm parses the range form (`>=0.74.0 <0.76.0`) — standard semver, no compatibility risk
- [ ] After release, run `pi install npm:pi-rtk-optimizer` on a host that already has `pi-powerline-footer` installed — should resolve cleanly without `--legacy-peer-deps`
- [ ] `pi update` should succeed on a host with the current extension set