### PR TITLE
fix: preserve keyboard modes on session switch to fix Shift+Enter aft…

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1250,7 +1250,13 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   });
 
-  pi.on("session_shutdown", async () => {
+  pi.on("session_shutdown", async (event) => {
+    // When switching sessions (resume/new/fork), preserve keyboard modes
+    // (Kitty protocol, modifyOtherKeys) so that Shift+Enter and other
+    // modified keys continue to work. Only reset on quit/reload where
+    // the terminal should be restored to a clean state.
+    const isTerminalExit = event?.reason === "quit" || event?.reason === "reload";
+
     sessionGeneration++;
     dismissWelcomeOverlay?.();
     dismissWelcomeOverlay = null;
@@ -1260,7 +1266,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     statusRenderScheduler.cancel();
     restoreFooterStatusRepaintHook?.();
     restoreFooterStatusRepaintHook = null;
-    teardownFixedEditorCompositor({ resetExtendedKeyboardModes: true });
+    teardownFixedEditorCompositor(isTerminalExit ? { resetExtendedKeyboardModes: true } : undefined);
     stashShortcutInputUnsubscribe?.();
     stashShortcutInputUnsubscribe = null;
     shellSession?.dispose();


### PR DESCRIPTION
Unconditionally resetting Kitty protocol and modifyOtherKeys on every session_shutdown caused terminals to lose the ability to distinguish Shift+Enter from Enter. After resuming a session, the terminal would revert to sending plain \r for both keys, making Shift+Enter submit instead of inserting a newline.

Only reset extended keyboard modes (resetExtendedKeyboardModes) when the session is truly ending (reason "quit" or "reload"). For session switches (reason "resume", "new", "fork"), let the compositor dispose gracefully — its restoreTerminalState will disable the mode in the alternate screen and re-enable it for the main screen, keeping Shift+Enter and other modified keys working across sessions.