### PR TITLE
fix: widen Pi peer dependency range for 0.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Pi 0.76 compatibility** — Verified test suite compatibility against `@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, and `@earendil-works/pi-tui` `0.76.0`, then widened peer/dev ranges to `>=0.74.0 <0.77.0`.
+
 ## [0.5.6] - 2026-05-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.5.6",
       "license": "MIT",
       "devDependencies": {
-        "@earendil-works/pi-ai": ">=0.74.0 <0.76.0",
-        "@earendil-works/pi-coding-agent": ">=0.74.0 <0.76.0",
-        "@earendil-works/pi-tui": ">=0.74.0 <0.76.0"
+        "@earendil-works/pi-ai": ">=0.74.0 <0.77.0",
+        "@earendil-works/pi-coding-agent": ">=0.74.0 <0.77.0",
+        "@earendil-works/pi-tui": ">=0.74.0 <0.77.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": ">=0.74.0 <0.76.0",
-        "@earendil-works/pi-coding-agent": ">=0.74.0 <0.76.0",
-        "@earendil-works/pi-tui": ">=0.74.0 <0.76.0"
+        "@earendil-works/pi-ai": ">=0.74.0 <0.77.0",
+        "@earendil-works/pi-coding-agent": ">=0.74.0 <0.77.0",
+        "@earendil-works/pi-tui": ">=0.74.0 <0.77.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "test": "node --experimental-strip-types --test tests/**/*.test.ts"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": ">=0.74.0 <0.76.0",
-    "@earendil-works/pi-coding-agent": ">=0.74.0 <0.76.0",
-    "@earendil-works/pi-tui": ">=0.74.0 <0.76.0"
+    "@earendil-works/pi-ai": ">=0.74.0 <0.77.0",
+    "@earendil-works/pi-coding-agent": ">=0.74.0 <0.77.0",
+    "@earendil-works/pi-tui": ">=0.74.0 <0.77.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": ">=0.74.0 <0.76.0",
-    "@earendil-works/pi-coding-agent": ">=0.74.0 <0.76.0",
-    "@earendil-works/pi-tui": ">=0.74.0 <0.76.0"
+    "@earendil-works/pi-ai": ">=0.74.0 <0.77.0",
+    "@earendil-works/pi-coding-agent": ">=0.74.0 <0.77.0",
+    "@earendil-works/pi-tui": ">=0.74.0 <0.77.0"
   },
   "pi": {
     "extensions": [


### PR DESCRIPTION
## Summary
- verify compatibility with `@earendil-works/pi-ai@0.76.0`, `@earendil-works/pi-coding-agent@0.76.0`, and `@earendil-works/pi-tui@0.76.0`
- run test suite successfully (`121 passed`)
- widen peer/dev ranges from `>=0.74.0 <0.76.0` to `>=0.74.0 <0.77.0`
- sync lockfile ranges and add changelog entry under `[Unreleased]`

## Testing
- `npm test`
