### PR TITLE
fix(welcome): read session cwd from file header for accurate project names

### DIFF
--- a/tests/session-name.test.ts
+++ b/tests/session-name.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { readSessionCwd } from "../welcome.ts";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+function setup() {
+  tmpDir = join(tmpdir(), `pi-powerline-test-${process.pid}`);
+  mkdirSync(tmpDir, { recursive: true });
+}
+
+function teardown() {
+  rmSync(tmpDir, { recursive: true, force: true });
+}
+
+function writeTempSession(filename: string, firstLine: string, rest = ""): string {
+  const filePath = join(tmpDir, filename);
+  writeFileSync(filePath, firstLine + (rest ? "\n" + rest : ""), "utf-8");
+  return filePath;
+}
+
+// ── readSessionCwd ────────────────────────────────────────────────────────────
+
+test("readSessionCwd returns cwd from a valid session header", () => {
+  setup();
+  try {
+    const filePath = writeTempSession(
+      "valid.jsonl",
+      JSON.stringify({ type: "session", version: 3, id: "abc", cwd: "/Users/jsmith/src/foo-bar" }),
+    );
+    assert.equal(readSessionCwd(filePath), "/Users/jsmith/src/foo-bar");
+  } finally {
+    teardown();
+  }
+});
+
+test("readSessionCwd returns cwd when file has multiple lines", () => {
+  setup();
+  try {
+    const header = JSON.stringify({ type: "session", cwd: "/Users/jsmith/dotfiles" });
+    const filePath = writeTempSession(
+      "multi.jsonl",
+      header,
+      JSON.stringify({ type: "model_change", modelId: "claude-sonnet-4" }),
+    );
+    assert.equal(readSessionCwd(filePath), "/Users/jsmith/dotfiles");
+  } finally {
+    teardown();
+  }
+});
+
+test("readSessionCwd handles dashes in the cwd path without truncation", () => {
+  setup();
+  try {
+    // This is the case that was broken: a project name containing dashes
+    // (e.g. "foo-bar") would be mangled to "bar" by the old dir-splitting logic.
+    const filePath = writeTempSession(
+      "dashed.jsonl",
+      JSON.stringify({ type: "session", cwd: "/Users/jsmith/src/github.com/org/foo-bar" }),
+    );
+    assert.equal(readSessionCwd(filePath), "/Users/jsmith/src/github.com/org/foo-bar");
+  } finally {
+    teardown();
+  }
+});
+
+test("readSessionCwd returns null for a non-existent file", () => {
+  assert.equal(readSessionCwd("/nonexistent/path/session.jsonl"), null);
+});
+
+test("readSessionCwd returns null when first line is not valid JSON", () => {
+  setup();
+  try {
+    const filePath = writeTempSession("bad-json.jsonl", "not json at all");
+    assert.equal(readSessionCwd(filePath), null);
+  } finally {
+    teardown();
+  }
+});
+
+test("readSessionCwd returns null when cwd field is missing", () => {
+  setup();
+  try {
+    const filePath = writeTempSession(
+      "no-cwd.jsonl",
+      JSON.stringify({ type: "session", version: 3, id: "abc" }),
+    );
+    assert.equal(readSessionCwd(filePath), null);
+  } finally {
+    teardown();
+  }
+});
+
+test("readSessionCwd returns null when cwd is not a string", () => {
+  setup();
+  try {
+    const filePath = writeTempSession(
+      "bad-cwd.jsonl",
+      JSON.stringify({ type: "session", cwd: 42 }),
+    );
+    assert.equal(readSessionCwd(filePath), null);
+  } finally {
+    teardown();
+  }
+});
+
+test("readSessionCwd returns null for an empty file", () => {
+  setup();
+  try {
+    const filePath = writeTempSession("empty.jsonl", "");
+    assert.equal(readSessionCwd(filePath), null);
+  } finally {
+    teardown();
+  }
+});

--- a/welcome.ts
+++ b/welcome.ts
@@ -1,4 +1,4 @@
-import { readdirSync, existsSync, statSync, readFileSync } from "node:fs";
+import { readdirSync, existsSync, statSync, readFileSync, openSync, readSync, closeSync } from "node:fs";
 import { join, basename } from "node:path";
 import { homedir as osHomedir } from "node:os";
 import type { Component } from "@earendil-works/pi-tui";
@@ -536,6 +536,30 @@ export function discoverLoadedCounts(): LoadedCounts {
 /**
  * Get recent sessions from the sessions directory.
  */
+/**
+ * Read the `cwd` field from the first line of a pi session JSONL file.
+ * Reads only the first 512 bytes to avoid loading large session files.
+ * Returns null if the file cannot be read or does not contain a valid cwd.
+ */
+export function readSessionCwd(filePath: string): string | null {
+  let fd: number | null = null;
+  try {
+    fd = openSync(filePath, "r");
+    const buffer = Buffer.alloc(512);
+    const bytesRead = readSync(fd, buffer, 0, 512, 0);
+    const firstLine = buffer.subarray(0, bytesRead).toString("utf-8").split("\n")[0];
+    if (!firstLine) return null;
+    const parsed = JSON.parse(firstLine);
+    return typeof parsed?.cwd === "string" ? parsed.cwd : null;
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) {
+      try { closeSync(fd); } catch {}
+    }
+  }
+}
+
 export function getRecentSessions(maxCount: number = 3): RecentSession[] {
   const homeDir = process.env.HOME || process.env.USERPROFILE || osHomedir();
   
@@ -559,7 +583,16 @@ export function getRecentSessions(maxCount: number = 3): RecentSession[] {
           } else if (entry.endsWith(".jsonl")) {
             const parentName = basename(dir);
             let projectName = parentName;
-            if (parentName.startsWith("--")) {
+            // Prefer reading cwd from the session header (first line of the JSONL).
+            // The encoded directory name (e.g. --Users-jsmith-src-github.com-org-foo-bar--)
+            // uses "-" for both path separators and literal dashes, making it impossible to
+            // reliably recover the last path component by splitting on "-" alone.
+            // (e.g. "foo-bar" would incorrectly resolve to "bar")
+            const cwdFromHeader = readSessionCwd(entryPath);
+            if (cwdFromHeader) {
+              projectName = basename(cwdFromHeader);
+            } else if (parentName.startsWith("--")) {
+              // Fallback for unreadable files: best-effort parse of encoded dir name.
               const parts = parentName.split("-").filter(p => p);
               projectName = parts[parts.length - 1] || parentName;
             }


### PR DESCRIPTION
## Problem

The welcome screen's recent sessions list showed truncated project names for any project whose directory name contained a dash. For example, `foo-bar` would appear as `bar`.

The root cause: session directories use `-` to encode both path separators *and* literal dashes (e.g. `--Users-jsmith-src-github-com-org-foo-bar--`), making the two indistinguishable. The previous approach split on `-` and took the last segment, which breaks as soon as the project name itself contains a dash.

## Fix

Read the `cwd` field directly from the first line of the session JSONL file, which contains the original unambiguous path. Only the first 512 bytes are read so large session files aren't loaded into memory. The old directory-name heuristic is kept as a fallback for files that can't be opened or parsed.

## Testing
- Added 8 unit tests for `readSessionCwd` in `tests/session-name.test.ts` covering: valid session header, multi-line files, dashed project names (the broken case), non-existent file, invalid JSON, missing cwd field, non-string cwd, and empty file. All 129 tests pass.
- Verified locally with sessions for `foo-bar`, `dotfiles`, and `.pi` — all resolve correctly.