### PR TITLE
Add configurable powerline placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,15 @@ Restart pi to activate.
 
 ## Usage
 
-Activates automatically. Toggle with `/powerline`, switch presets with `/powerline <name>`, fixed-editor mode with `/powerline fixed-editor on|off|toggle`, and wheel mode with `/powerline mouse-scroll on|off|toggle`.
+Activates automatically. Toggle with `/powerline`, switch presets with `/powerline <name>`, fixed-editor mode with `/powerline fixed-editor on|off|toggle`, powerline placement with `/powerline placement above|below|toggle`, and wheel mode with `/powerline mouse-scroll on|off|toggle`.
 
 Fixed editor is on by default.
 
 - `/powerline fixed-editor off` — return to Pi’s regular scrolling layout
 - `/powerline fixed-editor on` — re-enable the fixed editor
 - `/powerline fixed-editor toggle` — switch between the two
+- `/powerline placement below` — render the main powerline row below the editor
+- `/powerline placement above` — restore the default top-of-editor placement
 
 You can also set it in `~/.pi/agent/settings.json` or project-local `.pi/settings.json`:
 
@@ -58,12 +60,13 @@ You can also set it in `~/.pi/agent/settings.json` or project-local `.pi/setting
 {
   "powerline": {
     "preset": "default",
-    "fixedEditor": false
+    "fixedEditor": false,
+    "placement": "below"
   }
 }
 ```
 
-Use `"fixedEditor": true` to enable it again. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling.
+Use `"fixedEditor": true` to enable it again. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling. `placement` defaults to `"above"` and accepts `"below"` to put the main powerline row under the prompt.
 
 | Preset | Description |
 |--------|-------------|

--- a/fixed-editor/cluster.ts
+++ b/fixed-editor/cluster.ts
@@ -1,4 +1,5 @@
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { PowerlinePlacement } from "../types.ts";
 
 export const CURSOR_MARKER = "\x1b_pi:c\x07";
 
@@ -11,6 +12,7 @@ export interface FixedEditorClusterInput {
   secondaryLines?: string[];
   transcriptLines?: string[];
   lastPromptLines?: string[];
+  powerlinePlacement?: PowerlinePlacement;
 }
 
 export interface FixedEditorCursor {
@@ -87,6 +89,31 @@ export function renderFixedEditorCluster(input: FixedEditorClusterInput): FixedE
 
   const editorLines = capEditorLines(editorSource, maxRows);
   let remaining = maxRows - editorLines.length;
+
+  if (input.powerlinePlacement === "below") {
+    const top = takeTail(topLines, remaining);
+    remaining -= top.length;
+
+    const secondary = takeTail(secondaryLines, remaining);
+    remaining -= secondary.length;
+
+    const lastPrompt = takeTail(lastPromptLines, remaining);
+    remaining -= lastPrompt.length;
+
+    const status = takeTail(statusLines, remaining);
+    remaining -= status.length;
+
+    const transcript = takeTail(transcriptLines, remaining);
+
+    return extractCursor([
+      ...status,
+      ...editorLines,
+      ...top,
+      ...secondary,
+      ...transcript,
+      ...lastPrompt,
+    ]);
+  }
 
   const top = takeTail(topLines, remaining);
   remaining -= top.length;

--- a/index.ts
+++ b/index.ts
@@ -69,6 +69,7 @@ let config: PowerlineConfig = {
   customItems: [],
   mouseScroll: true,
   fixedEditor: true,
+  placement: "above",
 };
 
 const CUSTOM_COMPACTION_STATUS_KEY = "compact-policy";
@@ -627,7 +628,7 @@ function writePowerlinePresetSetting(preset: StatusLinePreset, cwd: string = pro
 
 function writePowerlineOptionSetting(
   cwd: string,
-  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor">>,
+  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "placement">>,
   currentPreset: StatusLinePreset,
 ): boolean {
   return writePowerlineSetting(cwd, (existingPowerlineSetting) => (
@@ -1709,7 +1710,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   // Command to toggle/configure
   pi.registerCommand("powerline", {
-    description: "Configure powerline status (toggle, preset)",
+    description: "Configure powerline status (toggle, preset, placement)",
     handler: async (args, ctx) => {
       // Update context reference (command ctx may have more methods)
       currentCtx = ctx;
@@ -1786,6 +1787,26 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           ctx.ui.notify(`Powerline fixed editor ${config.fixedEditor ? "enabled" : "disabled"}`, "info");
         } else {
           ctx.ui.notify(`Powerline fixed editor ${config.fixedEditor ? "enabled" : "disabled"} (not persisted; check settings.json)`, "warning");
+        }
+        return;
+      }
+
+
+      const placementMatch = /^placement(?:\s+(above|below|top|bottom|toggle))?$/.exec(normalizedArgs);
+      if (placementMatch) {
+        const mode = placementMatch[1] ?? "toggle";
+        config.placement = mode === "toggle"
+          ? config.placement === "above" ? "below" : "above"
+          : mode === "below" || mode === "bottom" ? "below" : "above";
+        resetLayoutCache();
+        if (enabled && ctx.hasUI) {
+          setupCustomEditor(ctx);
+        }
+
+        if (writePowerlineOptionSetting(ctx.cwd, { placement: config.placement }, config.preset)) {
+          ctx.ui.notify(`Powerline placement set to: ${config.placement}`, "info");
+        } else {
+          ctx.ui.notify(`Powerline placement set to: ${config.placement} (not persisted; check settings.json)`, "warning");
         }
         return;
       }
@@ -2321,6 +2342,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           secondaryLines: [...renderPowerlineSecondaryLines(width, theme), ...belowWidgetLines],
           transcriptLines: renderBashTranscriptLines(width, theme),
           lastPromptLines: renderLastPromptLines(width),
+          powerlinePlacement: config.placement,
         });
       },
     });
@@ -2430,6 +2452,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   }
 
   function installPowerlineWidgets(ctx: any) {
+    const powerlinePlacement = config.placement === "below" ? "belowEditor" : "aboveEditor";
     ctx.ui.setWidget("powerline-status", () => ({
       dispose() {},
       invalidate() {
@@ -2448,7 +2471,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       render(width: number): string[] {
         return renderPowerlineTopLines(width, theme);
       },
-    }), { placement: "aboveEditor" });
+    }), { placement: powerlinePlacement });
 
     ctx.ui.setWidget("powerline-secondary", (_tui: any, theme: Theme) => ({
       dispose() {},

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,11 +1,12 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
-import type { ColorValue, CustomItemPosition, CustomStatusItem, PresetDef, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
+import type { ColorValue, CustomItemPosition, CustomStatusItem, PowerlinePlacement, PresetDef, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
 
 export interface PowerlineConfig {
   preset: StatusLinePreset;
   customItems: CustomStatusItem[];
   mouseScroll: boolean;
   fixedEditor: boolean;
+  placement: PowerlinePlacement;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -28,6 +29,13 @@ function normalizeCustomItemId(value: unknown): string | null {
 function normalizeCustomItemPosition(value: unknown): CustomItemPosition {
   if (value === "left" || value === "right" || value === "secondary") return value;
   return "right";
+}
+
+function normalizePowerlinePlacement(value: unknown): PowerlinePlacement {
+  if (typeof value !== "string") return "above";
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "below" || normalized === "bottom") return "below";
+  return "above";
 }
 
 function normalizeCustomColor(value: unknown): ColorValue | undefined {
@@ -84,7 +92,7 @@ function normalizeCustomItems(raw: unknown): CustomStatusItem[] {
 }
 
 export function parsePowerlineConfig(value: unknown, presets: readonly StatusLinePreset[]): PowerlineConfig {
-  const defaultConfig: PowerlineConfig = { preset: "default", customItems: [], mouseScroll: true, fixedEditor: true };
+  const defaultConfig: PowerlineConfig = { preset: "default", customItems: [], mouseScroll: true, fixedEditor: true, placement: "above" };
 
   const directPreset = normalizePreset(value, presets);
   if (directPreset) return { ...defaultConfig, preset: directPreset };
@@ -96,6 +104,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     customItems: normalizeCustomItems(value.customItems),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,
+    placement: normalizePowerlinePlacement(value.placement),
   };
 }
 
@@ -127,7 +136,7 @@ export function nextPowerlineSettingWithPreset(existingPowerlineSetting: unknown
 
 export function nextPowerlineSettingWithOptions(
   existingPowerlineSetting: unknown,
-  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor">>,
+  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "placement">>,
   currentPreset: StatusLinePreset,
 ): unknown {
   if (!isRecord(existingPowerlineSetting)) {

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -44,6 +44,16 @@ test("parsePowerlineConfig supports disabling fixed editor", () => {
   assert.equal(config.fixedEditor, false);
 });
 
+test("parsePowerlineConfig supports below placement with bottom alias", () => {
+  const config = parsePowerlineConfig(
+    { preset: "compact", placement: "bottom" },
+    ["default", "compact"],
+  );
+
+  assert.equal(config.preset, "compact");
+  assert.equal(config.placement, "below");
+});
+
 test("mergeSegmentsWithCustomItems appends custom segment ids by position", () => {
   const merged = mergeSegmentsWithCustomItems(
     {
@@ -83,16 +93,20 @@ test("nextPowerlineSettingWithPreset preserves object settings", () => {
 test("nextPowerlineSettingWithOptions preserves object settings", () => {
   const updated = nextPowerlineSettingWithOptions(
     { preset: "default", customItems: [{ id: "ci" }], mouseScroll: false },
-    { fixedEditor: false },
+    { fixedEditor: false, placement: "below" },
     "compact",
   );
   if (typeof updated !== "object" || updated === null || Array.isArray(updated)) {
     assert.fail("expected an object powerline setting");
   }
+  if (!("preset" in updated && "fixedEditor" in updated && "mouseScroll" in updated && "placement" in updated && "customItems" in updated)) {
+    assert.fail("expected all existing object settings to be preserved");
+  }
 
   assert.equal(updated.preset, "default");
   assert.equal(updated.fixedEditor, false);
   assert.equal(updated.mouseScroll, false);
+  assert.equal(updated.placement, "below");
   assert.deepEqual(updated.customItems, [{ id: "ci" }]);
 });
 

--- a/tests/fixed-editor.test.ts
+++ b/tests/fixed-editor.test.ts
@@ -51,6 +51,20 @@ test("fixed cluster keeps the editor visible before optional rows", () => {
   assert.deepEqual(rendered.cursor, { row: 2, col: 7 });
 });
 
+test("fixed cluster can render the powerline below the editor", () => {
+  const rendered = renderFixedEditorCluster({
+    width: 80,
+    terminalRows: 5,
+    topLines: ["powerline"],
+    editorLines: ["edit-a", `edit-b ${CURSOR_MARKER}`],
+    secondaryLines: ["secondary"],
+    powerlinePlacement: "below",
+  });
+
+  assert.deepEqual(rendered.lines, ["edit-a", "edit-b ", "powerline", "secondary"]);
+  assert.deepEqual(rendered.cursor, { row: 1, col: 7 });
+});
+
 test("fixed cluster caps oversized editor around the cursor", () => {
   const rendered = renderFixedEditorCluster({
     width: 80,

--- a/types.ts
+++ b/types.ts
@@ -85,6 +85,8 @@ export interface StatusLineSegmentOptions {
   time?: { format?: "12h" | "24h"; showSeconds?: boolean };
 }
 
+export type PowerlinePlacement = "above" | "below";
+
 export type CustomItemPosition = "left" | "right" | "secondary";
 
 export interface CustomStatusItem {


### PR DESCRIPTION
## Summary

- add `powerline.placement` with `above` default and `below` support
- add `/powerline placement above|below|toggle` persistence
- render the main powerline row below the editor in both fixed-editor and widget modes when configured
- document the setting and command

Closes #77

## Tests

- `npm test`