### PR TITLE
feat(welcome): Add initial prompt token estimate

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,34 @@
+# Third-Party License Notices
+
+## tokenx
+
+- Source: https://github.com/johannschopplich/tokenx
+- License: MIT
+- Adapted on: 2026-06-10
+- Used in: `token-estimate.ts`
+
+### MIT License
+
+```text
+MIT License
+
+Copyright (c) Johann Schopplich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/context-usage.ts
+++ b/context-usage.ts
@@ -1,3 +1,6 @@
+export { estimatePromptTokens } from "./token-estimate.ts";
+import { estimatePromptTokens } from "./token-estimate.ts";
+
 interface CoreContextUsage {
   contextTokens: number;
   contextWindow: number;
@@ -38,4 +41,17 @@ export function readCoreContextUsage(ctx: unknown): CoreContextUsage | null {
       ? percent
       : (tokens / contextWindow) * 100,
   };
+}
+
+export function estimateInitialContextTokens(ctx: unknown): number | null {
+  if (!isRecord(ctx) || typeof ctx.getSystemPrompt !== "function") {
+    return null;
+  }
+
+  const prompt = ctx.getSystemPrompt();
+  if (typeof prompt !== "string" || !prompt.trim()) {
+    return null;
+  }
+
+  return estimatePromptTokens(prompt);
 }

--- a/index.ts
+++ b/index.ts
@@ -33,7 +33,7 @@ import { ansi, getFgAnsiCode } from "./colors.ts";
 import { WelcomeComponent, WelcomeHeader, discoverLoadedCounts, getRecentSessions } from "./welcome.ts";
 import { createWelcomeDismissScheduler } from "./welcome-dismiss.ts";
 import { createRenderScheduler } from "./render-scheduler.ts";
-import { readCoreContextUsage } from "./context-usage.ts";
+import { estimateInitialContextTokens, readCoreContextUsage } from "./context-usage.ts";
 import { renderFixedEditorCluster } from "./fixed-editor/cluster.ts";
 import { emergencyTerminalModeReset, TerminalSplitCompositor } from "./fixed-editor/terminal-split.ts";
 import { getDefaultColors } from "./theme.ts";
@@ -2767,8 +2767,9 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const providerName = ctx.model?.provider || "Unknown";
     const loadedCounts = discoverLoadedCounts();
     const recentSessions = getRecentSessions(3);
+    const initialContextTokens = estimateInitialContextTokens(ctx);
     
-    const header = new WelcomeHeader(modelName, providerName, recentSessions, loadedCounts);
+    const header = new WelcomeHeader(modelName, providerName, recentSessions, loadedCounts, initialContextTokens);
     welcomeHeaderActive = true;
     
     ctx.ui.setHeader(() => {
@@ -2788,6 +2789,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const providerName = ctx.model?.provider || "Unknown";
     const loadedCounts = discoverLoadedCounts();
     const recentSessions = getRecentSessions(3);
+    const initialContextTokens = estimateInitialContextTokens(ctx);
     
     const overlaySessionGeneration = sessionGeneration;
 
@@ -2815,6 +2817,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
             providerName,
             recentSessions,
             loadedCounts,
+            initialContextTokens,
           );
           
           let countdown = 30;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3279,7 +3279,6 @@
       "version": "4.4.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/tests/context-usage.test.ts
+++ b/tests/context-usage.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readCoreContextUsage } from "../context-usage.ts";
+import { estimateInitialContextTokens, estimatePromptTokens, readCoreContextUsage } from "../context-usage.ts";
 
 test("readCoreContextUsage returns Pi context estimates for branch summaries", () => {
   const usage = readCoreContextUsage({
@@ -35,4 +35,20 @@ test("readCoreContextUsage ignores unknown or unusable estimates", () => {
   assert.equal(readCoreContextUsage({ getContextUsage: () => undefined }), null);
   assert.equal(readCoreContextUsage({ getContextUsage: () => ({ tokens: null, contextWindow: 5000, percent: null }) }), null);
   assert.equal(readCoreContextUsage({ getContextUsage: () => ({ tokens: 100, contextWindow: 0, percent: 0 }) }), null);
+});
+
+test("estimatePromptTokens uses embedded tokenx-style heuristic", () => {
+  assert.equal(estimatePromptTokens(""), 0);
+  assert.equal(estimatePromptTokens("hello world"), 4);
+  assert.equal(estimatePromptTokens("Use `read`, `write`, and `edit` on ./src/index.ts"), 20);
+  assert.equal(estimatePromptTokens("Line 1\nLine 2\nLine 3"), 6);
+});
+
+test("estimateInitialContextTokens uses system prompt text instead of live usage", () => {
+  assert.equal(estimateInitialContextTokens({}), null);
+  assert.equal(estimateInitialContextTokens({ getSystemPrompt: () => "" }), null);
+  assert.equal(
+    estimateInitialContextTokens({ getSystemPrompt: () => "You are helpful. Use bash and read." }),
+    estimatePromptTokens("You are helpful. Use bash and read."),
+  );
 });

--- a/tests/welcome.test.ts
+++ b/tests/welcome.test.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const welcomeSource = readFileSync(new URL("../welcome.ts", import.meta.url), "utf-8");
+const indexSource = readFileSync(new URL("../index.ts", import.meta.url), "utf-8");
+const contextUsageSource = readFileSync(new URL("../context-usage.ts", import.meta.url), "utf-8");
+const tokenEstimateSource = readFileSync(new URL("../token-estimate.ts", import.meta.url), "utf-8");
+
+test("welcome renders initial context token estimate when available", () => {
+  assert.match(welcomeSource, /initialContextTokens: number \| null/);
+  assert.match(welcomeSource, /function formatTokens\(n: number\): string/);
+  assert.match(welcomeSource, /typeof data\.initialContextTokens === "number"/);
+  assert.match(welcomeSource, /countLines\.push\(` \$\{itemPrefix\}\$\{fgOnly\("gitClean", `≈ ?\$\{formatTokens\(data\.initialContextTokens\)\}`\)\} initial tokens`\);/);
+});
+
+test("welcome setup pulls initial context tokens from system prompt estimate", () => {
+  assert.match(contextUsageSource, /export \{ estimatePromptTokens \} from "\.\/token-estimate\.ts";/);
+  assert.match(tokenEstimateSource, /export function estimatePromptTokens\(text: string\): number/);
+  assert.match(contextUsageSource, /export function estimateInitialContextTokens\(ctx: unknown\): number \| null/);
+  assert.match(contextUsageSource, /const prompt = ctx\.getSystemPrompt\(\);/);
+  assert.match(indexSource, /const initialContextTokens = estimateInitialContextTokens\(ctx\);/);
+  assert.match(indexSource, /new WelcomeHeader\(/);
+  assert.match(indexSource, /loadedCounts,\n\s+initialContextTokens,\n\s+\);/);
+});

--- a/token-estimate.ts
+++ b/token-estimate.ts
@@ -1,0 +1,74 @@
+// Adapted from tokenx (MIT): https://github.com/johannschopplich/tokenx
+// Copyright (c) Johann Schopplich
+// Adaptation date: 2026-06-10
+
+const TOKENX_PATTERNS = {
+  whitespace: /^\s+$/,
+  cjk: /[\u4E00-\u9FFF\u3400-\u4DBF\u3000-\u303F\uFF00-\uFFEF\u30A0-\u30FF\u2E80-\u2EFF\u31C0-\u31EF\u3200-\u32FF\u3300-\u33FF\uAC00-\uD7AF\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uD7B0-\uD7FF]/,
+  numeric: /^\d+(?:[.,]\d+)*$/,
+  punctuation: /[.,!?;(){}[\]<>:/\\|@#$%^&*+=`~_-]/,
+  alphanumeric: /^[a-zA-Z0-9\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]+$/,
+} as const;
+
+const TOKENX_SPLIT_PATTERN = new RegExp(`(\\s+|${TOKENX_PATTERNS.punctuation.source}+)`);
+const TOKENX_SHORT_TOKEN_THRESHOLD = 3;
+const TOKENX_DEFAULT_CHARS_PER_TOKEN = 4;
+const TOKENX_LANGUAGE_CONFIGS = [
+  { pattern: /[äöüßẞ]/i, averageCharsPerToken: 3 },
+  { pattern: /[éèêëàâîïôûùüÿçœæáíóúñ]/i, averageCharsPerToken: 3 },
+  { pattern: /[ąćęłńóśźżěščřžýůúďťň]/i, averageCharsPerToken: 3.5 },
+] as const;
+
+function estimateTokenxSegmentTokens(segment: string): number {
+  if (TOKENX_PATTERNS.whitespace.test(segment)) {
+    return 0;
+  }
+
+  if (TOKENX_PATTERNS.cjk.test(segment)) {
+    return Array.from(segment).length;
+  }
+
+  if (TOKENX_PATTERNS.numeric.test(segment)) {
+    return 1;
+  }
+
+  if (segment.length <= TOKENX_SHORT_TOKEN_THRESHOLD) {
+    return 1;
+  }
+
+  if (TOKENX_PATTERNS.punctuation.test(segment)) {
+    return segment.length > 1 ? Math.ceil(segment.length / 2) : 1;
+  }
+
+  const charsPerToken = getTokenxCharsPerToken(segment);
+  if (TOKENX_PATTERNS.alphanumeric.test(segment)) {
+    return Math.ceil(segment.length / charsPerToken);
+  }
+
+  return Math.ceil(segment.length / charsPerToken);
+}
+
+function getTokenxCharsPerToken(segment: string): number {
+  for (const config of TOKENX_LANGUAGE_CONFIGS) {
+    if (config.pattern.test(segment)) {
+      return config.averageCharsPerToken;
+    }
+  }
+
+  return TOKENX_DEFAULT_CHARS_PER_TOKEN;
+}
+
+export function estimatePromptTokens(text: string): number {
+  if (!text) {
+    return 0;
+  }
+
+  const segments = text.split(TOKENX_SPLIT_PATTERN).filter(Boolean);
+  let tokenCount = 0;
+
+  for (const segment of segments) {
+    tokenCount += estimateTokenxSegmentTokens(segment);
+  }
+
+  return tokenCount;
+}

--- a/welcome.ts
+++ b/welcome.ts
@@ -17,6 +17,14 @@ export interface LoadedCounts {
   promptTemplates: number;
 }
 
+function formatTokens(n: number): string {
+  if (n < 1000) return n.toString();
+  if (n < 10000) return `${(n / 1000).toFixed(1)}k`;
+  if (n < 1000000) return `${Math.round(n / 1000)}k`;
+  if (n < 10000000) return `${(n / 1000000).toFixed(1)}M`;
+  return `${Math.round(n / 1000000)}M`;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Shared rendering utilities
 // ═══════════════════════════════════════════════════════════════════════════
@@ -85,6 +93,7 @@ interface WelcomeData {
   providerName: string;
   recentSessions: RecentSession[];
   loadedCounts: LoadedCounts;
+  initialContextTokens: number | null;
 }
 
 function buildLeftColumn(data: WelcomeData, colWidth: number): string[] {
@@ -121,7 +130,7 @@ function buildRightColumn(data: WelcomeData, colWidth: number): string[] {
   const countLines: string[] = [];
   const { contextFiles, extensions, skills, promptTemplates } = data.loadedCounts;
   const itemPrefix = dim("- ");
-  
+
   if (contextFiles > 0 || extensions > 0 || skills > 0 || promptTemplates > 0) {
     if (contextFiles > 0) {
       countLines.push(` ${itemPrefix}${fgOnly("gitClean", `${contextFiles}`)} context file${contextFiles !== 1 ? "s" : ""}`);
@@ -138,6 +147,11 @@ function buildRightColumn(data: WelcomeData, colWidth: number): string[] {
   } else {
     countLines.push(` ${dim("No extensions loaded")}`);
   }
+
+  if (typeof data.initialContextTokens === "number" && Number.isFinite(data.initialContextTokens) && data.initialContextTokens > 0) {
+    countLines.push(` ${itemPrefix}${fgOnly("gitClean", `≈ ${formatTokens(data.initialContextTokens)}`)} initial tokens`);
+  }
+  
   
   return [
     ` ${bold(fgOnly("accent", "Tips"))}`,
@@ -226,8 +240,9 @@ export class WelcomeComponent implements Component {
     providerName: string,
     recentSessions: RecentSession[] = [],
     loadedCounts: LoadedCounts = { contextFiles: 0, extensions: 0, skills: 0, promptTemplates: 0 },
+    initialContextTokens: number | null = null,
   ) {
-    this.data = { modelName, providerName, recentSessions, loadedCounts };
+    this.data = { modelName, providerName, recentSessions, loadedCounts, initialContextTokens };
   }
 
   setCountdown(seconds: number): void {
@@ -276,8 +291,9 @@ export class WelcomeHeader implements Component {
     providerName: string,
     recentSessions: RecentSession[] = [],
     loadedCounts: LoadedCounts = { contextFiles: 0, extensions: 0, skills: 0, promptTemplates: 0 },
+    initialContextTokens: number | null = null,
   ) {
-    this.data = { modelName, providerName, recentSessions, loadedCounts };
+    this.data = { modelName, providerName, recentSessions, loadedCounts, initialContextTokens };
   }
 
   invalidate(): void {}


### PR DESCRIPTION
## Summary

   Add startup token estimate to welcome UI.

   Welcome header / overlay now shows approximate initial prompt token count for
   Pi session startup context, alongside existing loaded resource counts.

   Example:
   - `≈1.9k initial tokens`

   ## Why

   Startup context is not free.

   Before first user message, Pi already loads meaningful context into system
   prompt:
   - built-in tool descriptions
   - loaded skills
   - repo / project instructions
   - global agent instructions
   - other startup-loaded prompt content

   That initial prompt can consume non-trivial context window budget. Showing it
   early is useful because it helps users:

   - understand baseline context cost before they type
   - notice unusually heavy startup configuration
   - compare setups across projects / agents
   - reason about available remaining context on smaller-window models
   - debug why a session starts “large” even before any chat history exists

   ## What I tried to get a good estimate of startup tokens

   ### 1. `ctx.getContextUsage()`
   Rejected.

   Reason:
   - always `0` during startup timing we need for welcome UI

   ### 2. Simple word-based heuristic
   Tried:
   - `words * 1.33`

   Rejected.

   Reason:
   - severely undercounted system prompts
   - system prompts are punctuation / path / markdown / identifier heavy, not plain prose

   ### 3. Homegrown mixed heuristics
   Tried a few blends of:
   - char count
   - word count
   - punctuation / newline penalties

   Rejected.

   Reason:
   - easy to overfit to one prompt shape
   - not great for reusable library behavior

   ### 4. `tokenx` package
   Tried external library heuristic.

   Improved results, but we did not want to carry extra runtime dependency for one
   small estimation function.

   ## Final approach

   Use startup system prompt text as source of truth:

   - `ctx.getSystemPrompt()`

   Estimate token count with embedded tokenx-style heuristic extracted into its own
   file:

   - `token-estimate.ts`

   This gives:
   - usable estimate at `session_start`
   - no extra package dependency
   - better behavior for mixed prose / code / punctuation-heavy prompt text
   - cleaner separation from core context-usage logic

   ## Implementation

   - add welcome metric wiring in `index.ts`
   - render initial token estimate in `welcome.ts`
   - add `estimateInitialContextTokens(ctx)` in `context-usage.ts`
   - move adapted estimator into `token-estimate.ts`
   - add MIT attribution in source and `THIRD_PARTY_LICENSES.md`
   - add focused tests for estimator + welcome wiring

   ## Notes

   This is intentionally approximate (`≈`), not tokenizer-exact.

   Goal is useful startup visibility, not exact provider-specific accounting.