### PR TITLE
fix(reload): only reset terminal keyboard protocol on quit, not reload

### DIFF
--- a/fixed-editor/terminal-split.ts
+++ b/fixed-editor/terminal-split.ts
@@ -71,6 +71,7 @@ interface DisposeOptions {
 }
 
 type ExtendedKeyboardMode = "kitty" | "modifyOtherKeys";
+const KEYBOARD_PROTOCOL_DISCOVERY_SEQUENCE = "\x1b[>7u\x1b[?u\x1b[c";
 
 const CONTEXT_MENU_MOUSE_REPORTING_PAUSE_MS = 1200;
 const CONTEXT_MENU_SELECTION_RESTORE_WINDOW_MS = 5000;
@@ -984,7 +985,9 @@ export class TerminalSplitCompositor {
 
   private enableAlternateScreenKeyboardMode(): string {
     this.extendedKeyboardMode = this.activeExtendedKeyboardMode();
-    return this.extendedKeyboardMode ? enableExtendedKeyboardMode(this.extendedKeyboardMode) : "";
+    return this.extendedKeyboardMode
+      ? enableExtendedKeyboardMode(this.extendedKeyboardMode)
+      : KEYBOARD_PROTOCOL_DISCOVERY_SEQUENCE;
   }
 
   private restoreTerminalState(options: DisposeOptions = {}): void {

--- a/index.ts
+++ b/index.ts
@@ -1257,11 +1257,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async (event) => {
-    // When switching sessions (resume/new/fork), preserve keyboard modes
-    // (Kitty protocol, modifyOtherKeys) so that Shift+Enter and other
-    // modified keys continue to work. Only reset on quit/reload where
-    // the terminal should be restored to a clean state.
-    const isTerminalExit = event?.reason === "quit" || event?.reason === "reload";
+    // `/reload` keeps the same live TUI/ProcessTerminal. Resetting Kitty
+    // keyboard protocol or modifyOtherKeys there makes Shift+Enter collapse to
+    // plain Enter until the protocol is negotiated again. Only do the hard
+    // terminal reset when Pi is actually quitting.
+    const shouldResetTerminalModes = event?.reason === "quit";
 
     sessionGeneration++;
     dismissWelcomeOverlay?.();
@@ -1272,7 +1272,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     statusRenderScheduler.cancel();
     restoreFooterStatusRepaintHook?.();
     restoreFooterStatusRepaintHook = null;
-    teardownFixedEditorCompositor(isTerminalExit ? { resetExtendedKeyboardModes: true } : undefined);
+    teardownFixedEditorCompositor(shouldResetTerminalModes ? { resetExtendedKeyboardModes: true } : undefined);
     stashShortcutInputUnsubscribe?.();
     stashShortcutInputUnsubscribe = null;
     shellSession?.dispose();


### PR DESCRIPTION
The session_shutdown handler was resetting Kitty/modifyOtherKeys keyboard
protocol on both `/reload` and `quit`. Since Pi's TUI process stays alive
across reload, resetting these modes caused Shift+Enter to collapse to plain Enter until protocol was re-negotiated.

- `session_shutdown`: only pass `resetExtendedKeyboardModes: true` on qui
- Remove explicit `requeryKeyboardProtocol()` calls — Pi owns keyboard negotiation; keep compositor-level discovery sequence in terminal-split
  as safe fallback during timing windows
- Revert unrelated package.json dependency range widening

Solves #81 