### PR TITLE
feat: configure subscription cost display

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,28 @@ The path segment supports three modes:
 
 Configure via preset options: `path: { mode: "full" }`
 
+## Cost Display
+
+When Pi detects subscription/OAuth auth, the cost segment defaults to the existing subscription marker behavior:
+
+```json
+{
+  "powerline": {
+    "cost": { "subscriptionDisplay": "subscription" }
+  }
+}
+```
+
+`subscriptionDisplay` supports three modes:
+
+| Mode | Subscription + reported cost | Subscription + no reported cost | Description |
+|------|------------------------------|----------------------------------|-------------|
+| `subscription` | `(sub)` | `(sub)` | Existing/default behavior |
+| `reported-cost` | `$0.12` | `(sub)` | Prefer provider-reported session cost when available |
+| `both` | `$0.12 (sub)` | `(sub)` | Show both reported cost and subscription marker |
+
+Non-subscription auth keeps the normal dollar-cost behavior.
+
 ## Git polling
 
 By default the git segment polls both branch and dirty state. If background `git status --porcelain` calls interfere with your workflow, use branch-only polling:

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,5 +1,5 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
-import type { ColorValue, CustomItemPosition, CustomStatusItem, PresetDef, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions } from "./types.ts";
+import type { ColorValue, CostSubscriptionDisplay, CustomItemPosition, CustomStatusItem, PresetDef, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions } from "./types.ts";
 
 export interface PowerlineConfig {
   preset: StatusLinePreset;
@@ -41,6 +41,11 @@ function normalizeCustomPrefix(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const normalized = value.trim();
   return normalized ? normalized : undefined;
+}
+
+function normalizeCostSubscriptionDisplay(value: unknown): CostSubscriptionDisplay | undefined {
+  if (value === "subscription" || value === "reported-cost" || value === "both") return value;
+  return undefined;
 }
 
 function normalizeCustomStatusItem(raw: unknown, idOverride?: string): CustomStatusItem | null {
@@ -119,6 +124,13 @@ function normalizeSegmentOptions(raw: Record<string, unknown>): StatusLineSegmen
     };
   }
 
+  if (isRecord(raw.cost)) {
+    const subscriptionDisplay = normalizeCostSubscriptionDisplay(raw.cost.subscriptionDisplay);
+    options.cost = {
+      ...(subscriptionDisplay ? { subscriptionDisplay } : {}),
+    };
+  }
+
   return options;
 }
 
@@ -133,6 +145,7 @@ export function mergeSegmentOptions(
     path: { ...defaults.path, ...overrides.path },
     git: { ...defaults.git, ...overrides.git },
     time: { ...defaults.time, ...overrides.time },
+    cost: { ...defaults.cost, ...overrides.cost },
   };
 }
 

--- a/segments.ts
+++ b/segments.ts
@@ -263,13 +263,23 @@ const costSegment: StatusLineSegment = {
   render(ctx) {
     const { cost } = ctx.usageStats;
     const usingSubscription = ctx.usingSubscription;
+    const reportedCost = cost > 0 ? `$${cost.toFixed(2)}` : null;
 
-    if (!cost && !usingSubscription) {
-      return { content: "", visible: false };
+    if (!usingSubscription) {
+      return reportedCost
+        ? { content: color(ctx, "cost", reportedCost), visible: true }
+        : { content: "", visible: false };
     }
 
-    const costDisplay = usingSubscription ? "(sub)" : `$${cost.toFixed(2)}`;
-    return { content: color(ctx, "cost", costDisplay), visible: true };
+    const subscriptionDisplay = ctx.options.cost?.subscriptionDisplay ?? "subscription";
+    if (subscriptionDisplay === "reported-cost" && reportedCost) {
+      return { content: color(ctx, "cost", reportedCost), visible: true };
+    }
+    if (subscriptionDisplay === "both" && reportedCost) {
+      return { content: color(ctx, "cost", `${reportedCost} (sub)`), visible: true };
+    }
+
+    return { content: color(ctx, "cost", "(sub)"), visible: true };
   },
 };
 

--- a/tests/cost-segment.test.ts
+++ b/tests/cost-segment.test.ts
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renderSegment } from "../segments.ts";
+import type { SegmentContext } from "../types.ts";
+
+function createSegmentContext(overrides: Partial<SegmentContext> = {}): SegmentContext {
+  return {
+    model: undefined,
+    thinkingLevel: "off",
+    sessionId: undefined,
+    cwd: "/tmp/project",
+    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+    contextPercent: 0,
+    contextWindow: 0,
+    autoCompactEnabled: true,
+    customCompactionEnabled: false,
+    usingSubscription: false,
+    sessionStartTime: Date.now(),
+    shellModeActive: false,
+    shellRunning: false,
+    shellName: null,
+    shellCwd: null,
+    git: { branch: null, staged: 0, unstaged: 0, untracked: 0 },
+    extensionStatuses: new Map(),
+    hiddenExtensionStatusKeys: new Set(),
+    customItemsById: new Map(),
+    options: {},
+    theme: { fg: (_color: string, text: string) => text },
+    colors: {},
+    ...overrides,
+  };
+}
+
+test("cost segment defaults to subscription marker for subscription auth", () => {
+  const rendered = renderSegment(
+    "cost",
+    createSegmentContext({
+      usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.1234 },
+      usingSubscription: true,
+    }),
+  );
+
+  assert.equal(rendered.visible, true);
+  assert.equal(rendered.content, "(sub)");
+});
+
+test("cost segment can show reported cost for subscription auth", () => {
+  const rendered = renderSegment(
+    "cost",
+    createSegmentContext({
+      usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.1234 },
+      usingSubscription: true,
+      options: { cost: { subscriptionDisplay: "reported-cost" } },
+    }),
+  );
+
+  assert.equal(rendered.visible, true);
+  assert.equal(rendered.content, "$0.12");
+});
+
+test("cost segment can show reported cost and subscription marker together", () => {
+  const rendered = renderSegment(
+    "cost",
+    createSegmentContext({
+      usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.1234 },
+      usingSubscription: true,
+      options: { cost: { subscriptionDisplay: "both" } },
+    }),
+  );
+
+  assert.equal(rendered.visible, true);
+  assert.equal(rendered.content, "$0.12 (sub)");
+});
+
+test("cost segment falls back to subscription marker when no cost is reported", () => {
+  for (const subscriptionDisplay of ["reported-cost", "both"] as const) {
+    const rendered = renderSegment(
+      "cost",
+      createSegmentContext({
+        usingSubscription: true,
+        options: { cost: { subscriptionDisplay } },
+      }),
+    );
+
+    assert.equal(rendered.visible, true);
+    assert.equal(rendered.content, "(sub)");
+  }
+});
+
+test("cost segment keeps non-subscription cost behavior", () => {
+  const rendered = renderSegment(
+    "cost",
+    createSegmentContext({
+      usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.1234 },
+      options: { cost: { subscriptionDisplay: "both" } },
+    }),
+  );
+
+  assert.equal(rendered.visible, true);
+  assert.equal(rendered.content, "$0.12");
+});

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -52,6 +52,7 @@ test("parsePowerlineConfig extracts supported segment options", () => {
       path: { mode: "full", maxLength: 120 },
       git: { showBranch: false, showStaged: false, showUnstaged: true, showUntracked: false, polling: "branch" },
       time: { format: "12h", showSeconds: true },
+      cost: { subscriptionDisplay: "reported-cost" },
     },
     ["default", "compact"],
   );
@@ -61,20 +62,22 @@ test("parsePowerlineConfig extracts supported segment options", () => {
     path: { mode: "full", maxLength: 120 },
     git: { showBranch: false, showStaged: false, showUnstaged: true, showUntracked: false, polling: "branch" },
     time: { format: "12h", showSeconds: true },
+    cost: { subscriptionDisplay: "reported-cost" },
   });
 });
 
 test("mergeSegmentOptions lets user config override preset segment defaults", () => {
   assert.deepEqual(
     mergeSegmentOptions(
-      { path: { mode: "basename", maxLength: 20 }, git: { showBranch: true, showUntracked: true } },
-      { path: { mode: "full" }, git: { showUntracked: false } },
+      { path: { mode: "basename", maxLength: 20 }, git: { showBranch: true, showUntracked: true }, cost: { subscriptionDisplay: "subscription" } },
+      { path: { mode: "full" }, git: { showUntracked: false }, cost: { subscriptionDisplay: "both" } },
     ),
     {
       model: {},
       path: { mode: "full", maxLength: 20 },
       git: { showBranch: true, showUntracked: false },
       time: {},
+      cost: { subscriptionDisplay: "both" },
     },
   );
 });

--- a/types.ts
+++ b/types.ts
@@ -74,6 +74,8 @@ export type StatusLinePreset =
   | "ascii"
   | "custom";
 
+export type CostSubscriptionDisplay = "subscription" | "reported-cost" | "both";
+
 // Per-segment options
 export interface StatusLineSegmentOptions {
   model?: { showThinkingLevel?: boolean };
@@ -89,6 +91,7 @@ export interface StatusLineSegmentOptions {
     polling?: "full" | "branch" | "off";
   };
   time?: { format?: "12h" | "24h"; showSeconds?: boolean };
+  cost?: { subscriptionDisplay?: CostSubscriptionDisplay };
 }
 
 export type CustomItemPosition = "left" | "right" | "secondary";


### PR DESCRIPTION
## Summary

Adds a `powerline.cost.subscriptionDisplay` option so users can choose how the cost segment behaves when Pi detects subscription/OAuth auth.

Supported modes:

- `subscription` — existing/default behavior: show `(sub)`
- `reported-cost` — show provider-reported cost when available, fallback to `(sub)`
- `both` — show provider-reported cost plus `(sub)` when available, fallback to `(sub)`

Non-subscription auth keeps the existing dollar-cost display.

## Verification

- `npm test` — 133 pass, 0 fail
