### PR TITLE
Fix stash shortcut stealing German sharp-s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Editor stash shortcut** — Stash no longer consumes a literal `ß` by default, so German keyboard input can type sharp-s normally while real Alt/Meta-S sequences still toggle stash. The old printable-`ß` fallback is available with `powerline.stashSharpSShortcut`.
+
 ## [0.6.1] - 2026-06-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ In `~/.pi/agent/settings.json`:
 
 ## Editor Stash
 
-Use `Alt+S` / `Option+S` as a quick stash toggle while drafting. It keeps one active stash and clears the editor when stashing.
+Use `Alt+S` / `Option+S` as a quick stash toggle while drafting. Literal `ß` remains normal text by default. It keeps one active stash and clears the editor when stashing.
 
 | Editor | Stash | `Alt+S` result |
 |--------|-------|----------------|
@@ -171,6 +171,8 @@ Use `Alt+S` / `Option+S` as a quick stash toggle while drafting. It keeps one ac
 Auto-restore after an agent run only happens when the editor is still empty. If you typed meanwhile, the stash is preserved.
 
 The `stash` indicator appears in the powerline bar (on presets with `extension_statuses`). Active stash is still session-local and resets on session switch / disable, but stash history is persisted to `~/.pi/agent/powerline-footer/stash-history.json` so it survives restarts.
+
+If your terminal sends `Option+S` as printable `ß`, set `powerline.stashSharpSShortcut` to `true`; leave it off for German layouts because plain `ß` will stash too.
 
 ### Stash history
 

--- a/index.ts
+++ b/index.ts
@@ -1877,14 +1877,6 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     },
   });
 
-  pi.registerShortcut("alt+s", {
-    description: "Stash/restore editor text",
-    handler: async (ctx) => {
-      if (!enabled || !ctx.hasUI) return;
-      stashOrRestoreEditorText(ctx);
-    },
-  });
-
   pi.registerShortcut(resolvedShortcuts.stashHistory, {
     description: "Open prompt history picker",
     handler: async (ctx) => {

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ import {
   type Theme,
 } from "@earendil-works/pi-coding-agent";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
-import { isKeyRelease, matchesKey, type AutocompleteProvider, type SelectItem, SelectList, truncateToWidth, TUI_KEYBINDINGS, visibleWidth } from "@earendil-works/pi-tui";
+import { isKeyRelease, type AutocompleteProvider, type SelectItem, SelectList, truncateToWidth, TUI_KEYBINDINGS, visibleWidth } from "@earendil-works/pi-tui";
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -38,6 +38,7 @@ import { renderFixedEditorCluster } from "./fixed-editor/cluster.ts";
 import { emergencyTerminalModeReset, TerminalSplitCompositor } from "./fixed-editor/terminal-split.ts";
 import { getDefaultColors } from "./theme.ts";
 import {
+  isStashShortcutInput,
   isSupportedSuperShortcut,
   matchesConfiguredShortcut,
   shortcutConflictKey,
@@ -69,6 +70,7 @@ let config: PowerlineConfig = {
   customItems: [],
   mouseScroll: true,
   fixedEditor: true,
+  stashSharpSShortcut: false,
 };
 
 const CUSTOM_COMPACTION_STATUS_KEY = "compact-policy";
@@ -1571,18 +1573,6 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
   }
 
-  function isStashShortcutInput(data: string): boolean {
-    if (isKeyRelease(data)) return false;
-
-    return data === "ß"
-      || data === "\x1bs"
-      || data === "\x1bS"
-      || /^\x1b\[(?:83|115)(?::\d*)?(?::\d*)?;3(?::\d+)?u$/.test(data)
-      || data === "\x1b[27;3;115~"
-      || data === "\x1b[27;3;83~"
-      || matchesKey(data, "alt+s");
-  }
-
   function getChatJumpShortcutAction(data: string): ChatJumpShortcutAction | null {
     return CHAT_JUMP_SHORTCUTS.find(({ shortcutKey }) => matchesConfiguredShortcut(data, resolvedShortcuts[shortcutKey]))?.action ?? null;
   }
@@ -2528,7 +2518,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         if (!enabled || !ctx.hasUI || tuiRef?.hasOverlay?.()) {
           return undefined;
         }
-        if (isStashShortcutInput(data)) {
+        if (isStashShortcutInput(data, config.stashSharpSShortcut)) {
           stashOrRestoreEditorText(ctx);
           scheduleDismissWelcome(ctx);
           tuiRef?.requestRender();
@@ -2648,7 +2638,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       editor.handleInput = (data: string) => {
         lastEditorInputAt = Date.now();
 
-        if (isStashShortcutInput(data)) {
+        if (isStashShortcutInput(data, config.stashSharpSShortcut)) {
           stashOrRestoreEditorText(ctx);
           scheduleDismissWelcome(ctx);
           return;

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -7,6 +7,7 @@ export interface PowerlineConfig {
   segmentOptions: StatusLineSegmentOptions;
   mouseScroll: boolean;
   fixedEditor: boolean;
+  stashSharpSShortcut: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -137,7 +138,7 @@ export function mergeSegmentOptions(
 }
 
 export function parsePowerlineConfig(value: unknown, presets: readonly StatusLinePreset[]): PowerlineConfig {
-  const defaultConfig: PowerlineConfig = { preset: "default", customItems: [], segmentOptions: {}, mouseScroll: true, fixedEditor: true };
+  const defaultConfig: PowerlineConfig = { preset: "default", customItems: [], segmentOptions: {}, mouseScroll: true, fixedEditor: true, stashSharpSShortcut: false };
 
   const directPreset = normalizePreset(value, presets);
   if (directPreset) return { ...defaultConfig, preset: directPreset };
@@ -150,6 +151,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     segmentOptions: normalizeSegmentOptions(value),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,
+    stashSharpSShortcut: value.stashSharpSShortcut === true,
   };
 }
 

--- a/shortcuts.ts
+++ b/shortcuts.ts
@@ -1,4 +1,4 @@
-import { matchesKey } from "@earendil-works/pi-tui";
+import { isKeyRelease, matchesKey } from "@earendil-works/pi-tui";
 
 const SUPER_SHORTCUT_PATTERNS = new Map<string, RegExp>([
   ["super+up", /^\x1b\[(?:1;9(?::[12])?[AH]|574(?:19|23);9(?::[12])?u|7;9(?::[12])?~|27;9;65~)$/],
@@ -35,6 +35,18 @@ export function shortcutConflictKey(shortcut: string): string {
     default:
       return shortcut;
   }
+}
+
+export function isStashShortcutInput(data: string, stashSharpSShortcut = false): boolean {
+  if (isKeyRelease(data)) return false;
+
+  return (stashSharpSShortcut && data === "ß")
+    || data === "\x1bs"
+    || data === "\x1bS"
+    || /^\x1b\[(?:83|115)(?::\d*)?(?::\d*)?;3(?::\d+)?u$/.test(data)
+    || data === "\x1b[27;3;115~"
+    || data === "\x1b[27;3;83~"
+    || matchesKey(data, "alt+s");
 }
 
 export function matchesConfiguredShortcut(data: string, shortcut: string): boolean {

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -22,6 +22,7 @@ test("parsePowerlineConfig supports object config with custom items", () => {
   assert.equal(config.customItems[1].hideWhenMissing, false);
   assert.equal(config.mouseScroll, true);
   assert.equal(config.fixedEditor, true);
+  assert.equal(config.stashSharpSShortcut, false);
 });
 
 test("parsePowerlineConfig supports disabling mouse scroll", () => {
@@ -42,6 +43,10 @@ test("parsePowerlineConfig supports disabling fixed editor", () => {
 
   assert.equal(config.preset, "compact");
   assert.equal(config.fixedEditor, false);
+});
+
+test("parsePowerlineConfig supports opt-in sharp-s stash shortcut", () => {
+  assert.equal(parsePowerlineConfig({ stashSharpSShortcut: true }, ["default", "compact"]).stashSharpSShortcut, true);
 });
 
 test("parsePowerlineConfig extracts supported segment options", () => {

--- a/tests/stash-shortcut.test.ts
+++ b/tests/stash-shortcut.test.ts
@@ -18,6 +18,10 @@ test("index passes stash shortcut config to the shared matcher", () => {
   assert.equal([...indexSource.matchAll(/isStashShortcutInput\(data, config\.stashSharpSShortcut\)/g)].length, 2);
 });
 
+test("index does not register a core Alt-S shortcut", () => {
+  assert.doesNotMatch(indexSource, /registerShortcut\("alt\+s"/);
+});
+
 test("index keeps prompt-history shortcut behavior", () => {
   assert.match(indexSource, /function isPromptHistoryShortcutInput\(data: string\): boolean/);
   assert.match(indexSource, /matchesConfiguredShortcut\(data, resolvedShortcuts\.stashHistory\)/);

--- a/tests/stash-shortcut.test.ts
+++ b/tests/stash-shortcut.test.ts
@@ -1,33 +1,30 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { isStashShortcutInput } from "../shortcuts.ts";
 
-const source = readFileSync(new URL("../index.ts", import.meta.url), "utf-8");
+const indexSource = readFileSync(new URL("../index.ts", import.meta.url), "utf-8");
 
-test("stash shortcut supports macOS Option+S character input", () => {
-  assert.match(source, /isKeyRelease, matchesKey, type AutocompleteProvider/);
-  assert.match(source, /pi\.registerShortcut\("alt\+s"/);
-  assert.match(source, /function isStashShortcutInput\(data: string\): boolean/);
-  assert.match(source, /if \(isKeyRelease\(data\)\) return false;/);
-  assert.match(source, /data === "ß"/);
-  assert.match(source, /data === "\\x1bs"/);
-  assert.match(source, /data === "\\x1bS"/);
-  assert.match(source, /27;3;115/);
-  assert.match(source, /matchesKey\(data, "alt\+s"\)/);
-  assert.match(source, /ctx\.ui\.onTerminalInput\(\(data: string\) =>/);
-  assert.match(source, /if \(isStashShortcutInput\(data\)\)/);
-  assert.match(source, /return \{ consume: true \};/);
-  assert.match(source, /function getCurrentEditorText\(ctx: any, editor: any\): string \{\n\s+const editorText = editor\?\.getExpandedText\?\.\(\);\n\s+if \(typeof editorText === "string" && editorText\.length > 0\) return editorText;\n\s+return ctx\.ui\.getEditorText\?\.\(\) \?\? editorText \?\? "";\n\}/);
-  assert.match(source, /function stashOrRestoreEditorText\(ctx: any\): void/);
-  assert.match(source, /if \(isStashShortcutInput\(data\)\)/);
-  assert.match(source, /stashOrRestoreEditorText\(ctx\);/);
-  assert.match(source, /function isPromptHistoryShortcutInput\(data: string\): boolean/);
-  assert.match(source, /if \(isKeyRelease\(data\)\) return null;/);
-  assert.match(source, /matchesConfiguredShortcut\(data, resolvedShortcuts\.stashHistory\)/);
-  assert.doesNotMatch(source, /data === "\\x1b\\b"/);
-  assert.doesNotMatch(source, /data === "\\x1b\\x7f"/);
-  assert.match(source, /104\(\?:/);
-  assert.match(source, /27;7;104/);
-  assert.match(source, /return \{ kind: "stashHistory" \};/);
-  assert.match(source, /void openStashHistory\(ctx\);/);
+test("stash shortcut matches Alt/Meta-S without consuming German sharp-s by default", () => {
+  assert.equal(isStashShortcutInput("ß"), false);
+  assert.equal(isStashShortcutInput("ß", true), true);
+
+  for (const sequence of ["\x1bs", "\x1bS", "\x1b[115;3u", "\x1b[83;3u", "\x1b[27;3;115~", "\x1b[27;3;83~"]) {
+    assert.equal(isStashShortcutInput(sequence), true);
+  }
+});
+
+test("index passes stash shortcut config to the shared matcher", () => {
+  assert.equal([...indexSource.matchAll(/isStashShortcutInput\(data, config\.stashSharpSShortcut\)/g)].length, 2);
+});
+
+test("index keeps prompt-history shortcut behavior", () => {
+  assert.match(indexSource, /function isPromptHistoryShortcutInput\(data: string\): boolean/);
+  assert.match(indexSource, /matchesConfiguredShortcut\(data, resolvedShortcuts\.stashHistory\)/);
+  assert.doesNotMatch(indexSource, /data === "\\x1b\\b"/);
+  assert.doesNotMatch(indexSource, /data === "\\x1b\\x7f"/);
+  assert.match(indexSource, /104\(\?:/);
+  assert.match(indexSource, /27;7;104/);
+  assert.match(indexSource, /return \{ kind: "stashHistory" \};/);
+  assert.match(indexSource, /void openStashHistory\(ctx\);/);
 });


### PR DESCRIPTION
## Summary
- stop treating a literal `ß` as the editor stash shortcut by default
- keep real Alt/Meta-S escape/CSI sequences wired to stash
- move stash shortcut decoding into `shortcuts.ts` and test the matcher directly
- add `powerline.stashSharpSShortcut` for users who intentionally want the old printable-`ß` fallback

## Why
On German keyboard layouts, `ß` is a normal printable key. The previous fallback consumed that character and stashed the editor prompt instead of inserting it. Terminals cannot distinguish plain `ß` from macOS `Option+S` when both arrive as the same printable character, so the printable fallback is now opt-in.

Moving the matcher to `shortcuts.ts` keeps terminal shortcut decoding with the other shortcut helpers and lets this regression be tested as behavior instead of brittle source-grep against `index.ts`.

## Test
- `node --experimental-strip-types --test tests/stash-shortcut.test.ts tests/custom-items.test.ts`
- `npm test`
