### PR TITLE
feat: add disabledSegments setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,21 @@ You can promote any extension status key into its own dedicated powerline item. 
 
 If you still prefer the old style, `"powerline": "default"` continues to work.
 
+### Disabling segments
+
+Set `powerline.disabledSegments` to hide segments from whichever preset you use:
+
+```json
+{
+  "powerline": {
+    "preset": "default",
+    "disabledSegments": ["cost", "token_total", "custom:ci"]
+  }
+}
+```
+
+Use the segment names listed below. Custom items use their rendered segment id, `custom:<id>` (for example, `custom:ci`). Unknown names are ignored with a warning so typos do not break the footer.
+
 ## Bash mode
 
 Toggle bash mode with either:
@@ -334,7 +349,7 @@ Use `"off"` to disable extension-owned git polling entirely and only show the br
 
 ## Segments
 
-`model` · `thinking` · `shell_mode` · `path` · `git` · `subagents` · `token_in` · `token_out` · `token_total` · `cost` · `context_pct` · `context_total` · `time_spent` · `time` · `session` · `hostname` · `cache_read` · `cache_write`
+`model` · `thinking` · `shell_mode` · `path` · `git` · `subagents` · `token_in` · `token_out` · `token_total` · `cost` · `context_pct` · `context_total` · `time_spent` · `time` · `session` · `hostname` · `cache_read` · `cache_write` · `extension_statuses`
 
 ## Separators
 

--- a/index.ts
+++ b/index.ts
@@ -67,6 +67,9 @@ import {
 let config: PowerlineConfig = {
   preset: "default",
   customItems: [],
+  disabledSegments: [],
+  invalidDisabledSegments: [],
+  segmentOptions: {},
   mouseScroll: true,
   fixedEditor: true,
 };
@@ -822,6 +825,15 @@ function resolveShortcutConfig(settings: Record<string, unknown>): PowerlineShor
   return resolved;
 }
 
+function warnInvalidDisabledSegments(ctx: any): void {
+  if (config.invalidDisabledSegments.length === 0) return;
+
+  const list = config.invalidDisabledSegments.map((id) => JSON.stringify(id)).join(", ");
+  const message = `Ignoring unknown powerline disabled segment${config.invalidDisabledSegments.length === 1 ? "" : "s"}: ${list}`;
+  console.debug(`[powerline-footer] ${message}`);
+  ctx.ui?.notify?.(message, "warning");
+}
+
 function parseBashModeSettings(settings: Record<string, unknown>): BashModeSettings {
   const raw = isRecord(settings.bashMode) ? settings.bashMode : {};
 
@@ -891,7 +903,7 @@ function computeResponsiveLayout(
   const sepWidth = visibleWidth(separatorDef.left) + 2; // separator + spaces around it
   
   // Get all segments: primary first, then secondary
-  const mergedSegments = mergeSegmentsWithCustomItems(presetDef, config.customItems);
+  const mergedSegments = mergeSegmentsWithCustomItems(presetDef, config.customItems, config.disabledSegments);
   const primaryIds = [...mergedSegments.leftSegments, ...mergedSegments.rightSegments];
   const secondaryIds = mergedSegments.secondarySegments;
   const allSegmentIds = [...primaryIds, ...secondaryIds];
@@ -1224,6 +1236,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     resolvedShortcuts = resolveShortcutConfig(settings);
     showLastPrompt = settings.showLastPrompt !== false;
     config = parsePowerlineConfig(settings.powerline, PRESET_NAMES);
+    warnInvalidDisabledSegments(ctx);
     stashedPromptHistory = readPersistedStashHistory();
     bashModeActive = false;
     bashTranscript = new BashTranscriptStore(bashModeSettings);

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,9 +1,11 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
-import type { ColorValue, CustomItemPosition, CustomStatusItem, PresetDef, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions } from "./types.ts";
+import { BUILTIN_STATUS_LINE_SEGMENT_IDS, type ColorValue, type CustomItemPosition, type CustomStatusItem, type PresetDef, type StatusLinePreset, type StatusLineSegmentId, type StatusLineSegmentOptions } from "./types.ts";
 
 export interface PowerlineConfig {
   preset: StatusLinePreset;
   customItems: CustomStatusItem[];
+  disabledSegments: StatusLineSegmentId[];
+  invalidDisabledSegments: string[];
   segmentOptions: StatusLineSegmentOptions;
   mouseScroll: boolean;
   fixedEditor: boolean;
@@ -84,6 +86,49 @@ function normalizeCustomItems(raw: unknown): CustomStatusItem[] {
   return [...deduped.values()];
 }
 
+const BUILTIN_STATUS_LINE_SEGMENT_ID_SET = new Set<string>(BUILTIN_STATUS_LINE_SEGMENT_IDS);
+
+function normalizeDisabledSegments(
+  raw: unknown,
+  customItems: readonly CustomStatusItem[],
+): { disabledSegments: StatusLineSegmentId[]; invalidDisabledSegments: string[] } {
+  if (!Array.isArray(raw)) return { disabledSegments: [], invalidDisabledSegments: [] };
+
+  const disabledSegments: StatusLineSegmentId[] = [];
+  const invalidDisabledSegments: string[] = [];
+  const customItemIds = new Set(customItems.map((item) => item.id));
+  const seen = new Set<string>();
+
+  for (const entry of raw) {
+    if (typeof entry !== "string") {
+      invalidDisabledSegments.push(String(entry));
+      continue;
+    }
+
+    const normalized = entry.trim();
+    if (!normalized) {
+      invalidDisabledSegments.push(entry);
+      continue;
+    }
+
+    const isBuiltin = BUILTIN_STATUS_LINE_SEGMENT_ID_SET.has(normalized);
+    const customId = normalized.startsWith("custom:") ? normalizeCustomItemId(normalized.slice("custom:".length)) : null;
+    const segmentId = isBuiltin ? normalized : customId && customItemIds.has(customId) ? `custom:${customId}` : null;
+
+    if (!segmentId) {
+      invalidDisabledSegments.push(normalized);
+      continue;
+    }
+
+    if (!seen.has(segmentId)) {
+      seen.add(segmentId);
+      disabledSegments.push(segmentId as StatusLineSegmentId);
+    }
+  }
+
+  return { disabledSegments, invalidDisabledSegments };
+}
+
 function normalizeSegmentOptions(raw: Record<string, unknown>): StatusLineSegmentOptions {
   const options: StatusLineSegmentOptions = {};
 
@@ -137,23 +182,40 @@ export function mergeSegmentOptions(
 }
 
 export function parsePowerlineConfig(value: unknown, presets: readonly StatusLinePreset[]): PowerlineConfig {
-  const defaultConfig: PowerlineConfig = { preset: "default", customItems: [], segmentOptions: {}, mouseScroll: true, fixedEditor: true };
+  const defaultConfig: PowerlineConfig = {
+    preset: "default",
+    customItems: [],
+    disabledSegments: [],
+    invalidDisabledSegments: [],
+    segmentOptions: {},
+    mouseScroll: true,
+    fixedEditor: true,
+  };
 
   const directPreset = normalizePreset(value, presets);
   if (directPreset) return { ...defaultConfig, preset: directPreset };
 
   if (!isRecord(value)) return defaultConfig;
 
+  const customItems = normalizeCustomItems(value.customItems);
+  const disabledSegmentConfig = normalizeDisabledSegments(value.disabledSegments, customItems);
+
   return {
     preset: normalizePreset(value.preset, presets) ?? defaultConfig.preset,
-    customItems: normalizeCustomItems(value.customItems),
+    customItems,
+    disabledSegments: disabledSegmentConfig.disabledSegments,
+    invalidDisabledSegments: disabledSegmentConfig.invalidDisabledSegments,
     segmentOptions: normalizeSegmentOptions(value),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,
   };
 }
 
-export function mergeSegmentsWithCustomItems(presetDef: PresetDef, customItems: readonly CustomStatusItem[]): {
+export function mergeSegmentsWithCustomItems(
+  presetDef: PresetDef,
+  customItems: readonly CustomStatusItem[],
+  disabledSegments: readonly StatusLineSegmentId[] = [],
+): {
   leftSegments: StatusLineSegmentId[];
   rightSegments: StatusLineSegmentId[];
   secondarySegments: StatusLineSegmentId[];
@@ -169,7 +231,16 @@ export function mergeSegmentsWithCustomItems(presetDef: PresetDef, customItems: 
     else right.push(segmentId);
   }
 
-  return { leftSegments: left, rightSegments: right, secondarySegments: secondary };
+  const disabled = new Set(disabledSegments);
+  if (disabled.size === 0) {
+    return { leftSegments: left, rightSegments: right, secondarySegments: secondary };
+  }
+
+  return {
+    leftSegments: left.filter((id) => !disabled.has(id)),
+    rightSegments: right.filter((id) => !disabled.has(id)),
+    secondarySegments: secondary.filter((id) => !disabled.has(id)),
+  };
 }
 
 export function nextPowerlineSettingWithPreset(existingPowerlineSetting: unknown, preset: StatusLinePreset): unknown {

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -20,8 +20,34 @@ test("parsePowerlineConfig supports object config with custom items", () => {
   assert.equal(config.customItems[0].statusKey, "ci-status");
   assert.equal(config.customItems[1].statusKey, "review");
   assert.equal(config.customItems[1].hideWhenMissing, false);
+  assert.deepEqual(config.disabledSegments, []);
+  assert.deepEqual(config.invalidDisabledSegments, []);
   assert.equal(config.mouseScroll, true);
   assert.equal(config.fixedEditor, true);
+});
+
+test("parsePowerlineConfig supports disabled segments", () => {
+  const config = parsePowerlineConfig(
+    {
+      preset: "default",
+      customItems: [{ id: "ci" }],
+      disabledSegments: [
+        "cost",
+        " extension_statuses ",
+        "custom:ci",
+        "cost",
+        "bad",
+        "custom:",
+        "custom:bad space",
+        "custom:missing",
+        123,
+      ],
+    },
+    ["default", "compact"],
+  );
+
+  assert.deepEqual(config.disabledSegments, ["cost", "extension_statuses", "custom:ci"]);
+  assert.deepEqual(config.invalidDisabledSegments, ["bad", "custom:", "custom:bad space", "custom:missing", "123"]);
 });
 
 test("parsePowerlineConfig supports disabling mouse scroll", () => {
@@ -97,6 +123,27 @@ test("mergeSegmentsWithCustomItems appends custom segment ids by position", () =
   assert.deepEqual(merged.leftSegments, ["path", "custom:ci"]);
   assert.deepEqual(merged.rightSegments, ["git", "custom:timer"]);
   assert.deepEqual(merged.secondarySegments, ["extension_statuses", "custom:review"]);
+});
+
+test("mergeSegmentsWithCustomItems filters disabled segment ids", () => {
+  const merged = mergeSegmentsWithCustomItems(
+    {
+      leftSegments: ["path", "model"],
+      rightSegments: ["git", "cost"],
+      secondarySegments: ["extension_statuses"],
+      separator: "powerline",
+    },
+    [
+      { id: "ci", statusKey: "ci", position: "left", hideWhenMissing: true, excludeFromExtensionStatuses: true },
+      { id: "timer", statusKey: "timer", position: "right", hideWhenMissing: true, excludeFromExtensionStatuses: true },
+      { id: "review", statusKey: "review", position: "secondary", hideWhenMissing: true, excludeFromExtensionStatuses: true },
+    ],
+    ["model", "cost", "custom:ci", "custom:review"],
+  );
+
+  assert.deepEqual(merged.leftSegments, ["path"]);
+  assert.deepEqual(merged.rightSegments, ["git", "custom:timer"]);
+  assert.deepEqual(merged.secondarySegments, ["extension_statuses"]);
 });
 
 test("nextPowerlineSettingWithPreset preserves object settings", () => {

--- a/types.ts
+++ b/types.ts
@@ -27,26 +27,29 @@ export type SemanticColor =
 export type ColorScheme = Partial<Record<SemanticColor, ColorValue>>;
 
 // Built-in segment identifiers
-export type BuiltinStatusLineSegmentId =
-  | "model"
-  | "shell_mode"
-  | "path"
-  | "git"
-  | "subagents"
-  | "token_in"
-  | "token_out"
-  | "token_total"
-  | "cost"
-  | "context_pct"
-  | "context_total"
-  | "time_spent"
-  | "time"
-  | "session"
-  | "hostname"
-  | "cache_read"
-  | "cache_write"
-  | "thinking"
-  | "extension_statuses";
+export const BUILTIN_STATUS_LINE_SEGMENT_IDS = [
+  "model",
+  "shell_mode",
+  "path",
+  "git",
+  "subagents",
+  "token_in",
+  "token_out",
+  "token_total",
+  "cost",
+  "context_pct",
+  "context_total",
+  "time_spent",
+  "time",
+  "session",
+  "hostname",
+  "cache_read",
+  "cache_write",
+  "thinking",
+  "extension_statuses",
+] as const;
+
+export type BuiltinStatusLineSegmentId = typeof BUILTIN_STATUS_LINE_SEGMENT_IDS[number];
 
 // Segment identifiers (built-in + dynamically registered custom items)
 export type StatusLineSegmentId = BuiltinStatusLineSegmentId | `custom:${string}`;


### PR DESCRIPTION
This allows users to disable segments (including builtin ones) using a setting. Useful for if the user wants to:

- remove a segment which is present in every layout (e.g. git, path, context)
- use a more complete set like `full` or `nerd` but wants to remove just one or two of the included items in those sets

Configuration looks like this:

> Set `powerline.disabledSegments` to hide segments from whichever preset you use:
> ```json
> {
>   "powerline": {
>     "preset": "default",
>     "disabledSegments": ["cost", "token_total", "custom:ci"]
>   }
> }
> ```

Let me know if anything else is needed in the way of tests or docs for this or if you want me to revisit implementation approach at all.