### PR TITLE
feat: add powerline.welcome setting to disable startup welcome UI

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1244,10 +1244,12 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     if (enabled && ctx.hasUI) {
       setupCustomEditor(ctx);
       if (event.reason === "startup") {
-        if (settings.quietStartup === true) {
-          setupWelcomeHeader(ctx);
-        } else {
-          setupWelcomeOverlay(ctx);
+        if (config.welcome !== false) {
+          if (settings.quietStartup === true) {
+            setupWelcomeHeader(ctx);
+          } else {
+            setupWelcomeOverlay(ctx);
+          }
         }
       } else {
         dismissWelcome(ctx);

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -7,6 +7,8 @@ export interface PowerlineConfig {
   segmentOptions: StatusLineSegmentOptions;
   mouseScroll: boolean;
   fixedEditor: boolean;
+  /** Show welcome UI on startup. Set to false to skip both overlay and header. */
+  welcome: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -137,7 +139,7 @@ export function mergeSegmentOptions(
 }
 
 export function parsePowerlineConfig(value: unknown, presets: readonly StatusLinePreset[]): PowerlineConfig {
-  const defaultConfig: PowerlineConfig = { preset: "default", customItems: [], segmentOptions: {}, mouseScroll: true, fixedEditor: true };
+  const defaultConfig: PowerlineConfig = { preset: "default", customItems: [], segmentOptions: {}, mouseScroll: true, fixedEditor: true, welcome: true };
 
   const directPreset = normalizePreset(value, presets);
   if (directPreset) return { ...defaultConfig, preset: directPreset };
@@ -150,6 +152,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     segmentOptions: normalizeSegmentOptions(value),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,
+    welcome: value.welcome !== false,
   };
 }
 


### PR DESCRIPTION
## Description

Adds a `powerline.welcome: false` config option that skips both the startup welcome overlay (default) and the welcome header (`quietStartup: true`) while keeping all powerline/status features fully functional.

Closes #48

## Changes

- **powerline-config.ts**: Added `welcome: boolean` field to `PowerlineConfig` interface, parser, and default config (defaults to `true` for backwards compatibility)
- **index.ts**: Gated welcome UI setup behind `config.welcome !== false`

## Usage

```json
{
  "powerline": {
    "welcome": false
  }
}
```

## Testing

- Default (no config) — welcome UI shows as before ✅
- `"welcome": false` — no overlay or header on startup, powerline footer works ✅
- `"welcome": true` — welcome UI shows ✅
- String preset shorthand (`"powerline": "minimal"`) — defaults to `welcome: true` ✅
- `quietStartup: true` with `welcome: false` — no header on startup ✅

## Checklist

- [x] Feature is backward-compatible (defaults to existing behavior)
- [x] Code follows existing conventions (`!== false` pattern matching `mouseScroll`/`fixedEditor`)
- [x] Config is re-read from settings on each session start before the welcome check
