### PR TITLE
Release mouse reporting at fixed-editor scroll edges

### DIFF
--- a/fixed-editor/terminal-split.ts
+++ b/fixed-editor/terminal-split.ts
@@ -629,10 +629,11 @@ export class TerminalSplitCompositor {
 
     const mousePackets = this.mouseScroll ? parseSgrMousePackets(data) : null;
     if (mousePackets) {
+      let consumed = false;
       for (const packet of mousePackets) {
-        this.handleMousePacket(packet);
+        consumed = this.handleMousePacket(packet) || consumed;
       }
-      return { consume: true };
+      return consumed ? { consume: true } : undefined;
     }
 
     const keyboardDelta = parseKeyboardScrollDelta(data, this.keyboardScrollShortcuts);
@@ -642,12 +643,13 @@ export class TerminalSplitCompositor {
     return { consume: true };
   }
 
-  private handleMousePacket(packet: SgrMousePacket): void {
+  private handleMousePacket(packet: SgrMousePacket): boolean {
     const delta = mouseScrollDelta(packet);
     if (delta !== 0) {
       this.selectionDragging = false;
-      this.scrollBy(delta);
-      return;
+      if (this.scrollBy(delta)) return true;
+      this.pauseMouseReportingForWheelPassthrough();
+      return true;
     }
 
     this.refreshRootWindow(Math.max(1, this.terminal.columns || 80));
@@ -661,26 +663,26 @@ export class TerminalSplitCompositor {
         this.onCopySelection?.(selectedText);
         this.lastLeftPress = null;
         this.pauseMouseReportingForContextMenu(selectedText);
-        return;
+        return true;
       }
 
       this.clearSelection();
       this.lastLeftPress = null;
       this.pauseMouseReportingForContextMenu();
-      return;
+      return true;
     }
 
-    if (this.scrollSelectionAtViewportEdge(packet)) return;
+    if (this.scrollSelectionAtViewportEdge(packet)) return true;
     if (this.selectionDragging && isMouseRelease(packet)) {
       this.finishSelection(packet, location);
-      return;
+      return true;
     }
 
-    if (!location) return;
+    if (!location) return false;
 
     if (isLeftPress(packet)) {
       this.startSelection(location);
-      return;
+      return true;
     }
 
     if (this.selectionDragging && isLeftDrag(packet) && location.area === this.selectionArea) {
@@ -688,8 +690,10 @@ export class TerminalSplitCompositor {
       this.preserveSelectionFocusOnRelease = false;
       this.selectionFocus = location.point;
       this.requestRender();
-      return;
+      return true;
     }
+
+    return false;
   }
 
   private updateVisibleRootWindow(scrollableRows = this.visibleScrollableRows): number {
@@ -874,12 +878,12 @@ export class TerminalSplitCompositor {
     return Boolean(range && location.point.col >= range.startCol && location.point.col < range.endCol);
   }
 
-  private scrollBy(delta: number): void {
+  private scrollBy(delta: number): boolean {
     const width = Math.max(1, this.terminal.columns || 80);
     this.refreshRootWindow(width);
 
     const nextOffset = Math.max(0, Math.min(this.scrollOffset + delta, this.maxScrollOffset));
-    if (nextOffset === this.scrollOffset) return;
+    if (nextOffset === this.scrollOffset) return false;
 
     this.clearSelection();
     this.lastLeftPress = null;
@@ -887,6 +891,7 @@ export class TerminalSplitCompositor {
     this.pendingImageCleanup = true;
     this.repaintScrollableViewport(width);
     this.requestRender();
+    return true;
   }
 
   private requestRender(): void {
@@ -966,6 +971,22 @@ export class TerminalSplitCompositor {
     };
 
     scheduleClipboardRestore();
+  }
+
+  private pauseMouseReportingForWheelPassthrough(): void {
+    if (this.mouseReportingResumeTimer) return;
+
+    this.originalWrite(beginSynchronizedOutput() + disableMouseReporting() + endSynchronizedOutput());
+    this.mouseReportingResumeTimer = setTimeout(() => {
+      this.mouseReportingResumeTimer = null;
+      if (!this.disposed) {
+        this.originalWrite(beginSynchronizedOutput() + enableMouseReporting() + endSynchronizedOutput());
+      }
+    }, CONTEXT_MENU_MOUSE_REPORTING_PAUSE_MS);
+
+    if (typeof this.mouseReportingResumeTimer === "object" && "unref" in this.mouseReportingResumeTimer) {
+      this.mouseReportingResumeTimer.unref();
+    }
   }
 
   private clearSelection(): void {

--- a/tests/fixed-editor.test.ts
+++ b/tests/fixed-editor.test.ts
@@ -634,6 +634,61 @@ test("terminal split handles modified SGR wheel packets", () => {
   compositor.dispose();
 });
 
+test("terminal split releases mouse reporting when wheel scrolling hits a viewport edge", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const terminal = new FakeTerminal();
+  let inputListener: ((data: string) => { consume?: boolean; data?: string } | undefined) | null = null;
+  const renderRequests: Array<boolean | undefined> = [];
+  const tui = {
+    terminal,
+    addInputListener(listener: (data: string) => { consume?: boolean; data?: string } | undefined) {
+      inputListener = listener;
+      return () => {
+        inputListener = null;
+      };
+    },
+    requestRender(force?: boolean) {
+      renderRequests.push(force);
+    },
+    render() {
+      return Array.from({ length: 15 }, (_, index) => `line-${index}`);
+    },
+  };
+
+  const compositor = new TerminalSplitCompositor({
+    tui,
+    terminal,
+    renderCluster: () => ({ lines: ["cluster-a", "cluster-b"], cursor: null }),
+  });
+
+  compositor.install();
+  tui.render(40);
+
+  assert.deepEqual(inputListener?.("\x1b[<65;1;10M"), { consume: true });
+  assert.ok(terminal.writes.at(-1)?.includes("\x1b[?1006l\x1b[?1002l\x1b[?1000l"));
+  assert.deepEqual(renderRequests, []);
+
+  t.mock.timers.tick(1200);
+  assert.ok(terminal.writes.at(-1)?.includes("\x1b[?1002h\x1b[?1006h"));
+
+  assert.deepEqual(inputListener?.("\x1b[5~"), { consume: true });
+  assert.deepEqual(renderRequests, [undefined]);
+  assert.deepEqual(tui.render(40), [
+    "line-0", "line-1", "line-2", "line-3", "line-4",
+    "line-5", "line-6", "line-7", "line-8", "line-9",
+  ]);
+
+  assert.deepEqual(inputListener?.("\x1b[<64;1;1M"), { consume: true });
+  assert.ok(terminal.writes.at(-1)?.includes("\x1b[?1006l\x1b[?1002l\x1b[?1000l"));
+  assert.deepEqual(renderRequests, [undefined]);
+
+  t.mock.timers.tick(1200);
+  assert.ok(terminal.writes.at(-1)?.includes("\x1b[?1002h\x1b[?1006h"));
+
+  compositor.dispose();
+});
+
 test("terminal split guards wrapped terminal writes", () => {
   const terminal = new FakeTerminal();
   const tui = {


### PR DESCRIPTION
## Summary

When fixed-editor mouse scrolling reaches the top or bottom of the app-owned chat viewport, temporarily release xterm mouse reporting instead of keeping every wheel packet trapped inside the compositor.

This lets follow-up wheel events fall back to the terminal while preserving the fixed-editor viewport behavior when it can actually scroll.

## Changes

- Make `TerminalSplitCompositor.scrollBy()` report whether the viewport moved.
- Keep consuming wheel packets while fixed-editor scroll succeeds.
- When a wheel packet hits a viewport edge, briefly disable mouse reporting and restore it on the existing timeout path.
- Keep keyboard PageUp/PageDown behavior consumed as before.
- Add a regression test for top/bottom wheel-edge mouse reporting release.

## Test

```sh
npm test
```

Passes locally: 129/129.
