### PR TITLE
feat: show context tokens alongside max and percentage

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2165,6 +2165,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       sessionId: ctx.sessionManager?.getSessionId?.(),
       cwd: ctx.cwd,
       usageStats: { input, output, cacheRead, cacheWrite, cost },
+      contextTokens,
       contextPercent,
       contextWindow,
       autoCompactEnabled: ctx.settingsManager?.getCompactionSettings?.()?.enabled ?? true,

--- a/segments.ts
+++ b/segments.ts
@@ -295,11 +295,10 @@ const contextPctSegment: StatusLineSegment = {
     if (ctx.customCompactionEnabled) return { content: "", visible: false };
 
     const icons = getIcons();
-    const pct = ctx.contextPercent;
-    const window = ctx.contextWindow;
+    const { contextTokens, contextPercent: pct, contextWindow: window } = ctx;
 
     const autoIcon = ctx.autoCompactEnabled && icons.auto ? ` ${icons.auto}` : "";
-    const text = `${pct.toFixed(1)}%/${formatTokens(window)}${autoIcon}`;
+    const text = `${formatTokens(contextTokens)}/${formatTokens(window)} (${pct.toFixed(1)}%)${autoIcon}`;
 
     // Icon outside color, text inside - use semantic colors for thresholds
     let content: string;

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -33,6 +33,7 @@ function createSegmentContext(overrides: Partial<SegmentContext> = {}): SegmentC
     sessionId: undefined,
     cwd: "/tmp/project",
     usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+    contextTokens: 0,
     contextPercent: 0,
     contextWindow: 0,
     autoCompactEnabled: true,
@@ -99,6 +100,17 @@ test("cost segment supports subscription display modes", () => {
   assert.deepEqual(both, { content: "$0.42 (sub)", visible: true });
   assert.deepEqual(zeroReported, { content: "(sub)", visible: true });
   assert.deepEqual(zeroBoth, { content: "(sub)", visible: true });
+});
+
+test("context segment shows used tokens, maximum, and percentage", () => {
+  const context = renderSegment("context_pct", createSegmentContext({
+    contextTokens: 4_500,
+    contextPercent: 1.7,
+    contextWindow: 272_000,
+  }));
+
+  assert.equal(stripAnsi(context.content), "◫ 4.5k/272k (1.7%) AC");
+  assert.equal(context.visible, true);
 });
 
 test("Nerd Font context icon uses stable database glyph", () => {

--- a/tests/thinking-segment.test.ts
+++ b/tests/thinking-segment.test.ts
@@ -17,6 +17,7 @@ function createSegmentContext(thinkingLevel: string, colors: ColorScheme): Segme
     thinkingLevel,
     sessionId: undefined,
     usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+    contextTokens: 0,
     contextPercent: 0,
     contextWindow: 0,
     autoCompactEnabled: true,

--- a/types.ts
+++ b/types.ts
@@ -162,6 +162,7 @@ export interface SegmentContext {
   
   // Computed
   usageStats: UsageStats;
+  contextTokens: number;
   contextPercent: number;
   contextWindow: number;
   autoCompactEnabled: boolean;


### PR DESCRIPTION
Adding the context's tokens to the display so you don't need to do mental arithmetic.

<img width="1473" height="144" alt="image" src="https://github.com/user-attachments/assets/e473c3d9-ed93-4c0e-854a-694ea128c735" />
