### PR TITLE
fix: only intercept default arrow keys for history recall

### DIFF
--- a/bash-mode/editor.ts
+++ b/bash-mode/editor.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { CustomEditor } from "@earendil-works/pi-coding-agent";
-import { isKeyRelease, matchesKey, visibleWidth, truncateToWidth } from "@earendil-works/pi-tui";
+import { isKeyRelease, matchesKey, Key, visibleWidth, truncateToWidth } from "@earendil-works/pi-tui";
 import type { KeybindingsManager } from "@earendil-works/pi-coding-agent/dist/core/keybindings.js";
 import type { AutocompleteProvider } from "@earendil-works/pi-tui";
 import { matchesConfiguredShortcut } from "../shortcuts.ts";
@@ -224,7 +224,7 @@ export class BashModeEditor extends CustomEditor {
         return;
       }
 
-      if (!bashMode && this.keybindingsRef.matches(data, "tui.editor.cursorUp") && this.isPromptHistoryRecallPosition()) {
+      if (!bashMode && matchesKey(data, Key.up) && this.isPromptHistoryRecallPosition()) {
         const navigateHistory = Reflect.get(this, "navigateHistory");
         if (typeof navigateHistory === "function") {
           if (Reflect.get(this, "historyIndex") === -1) {
@@ -235,7 +235,7 @@ export class BashModeEditor extends CustomEditor {
         }
       }
 
-      if (!bashMode && this.keybindingsRef.matches(data, "tui.editor.cursorDown") && Reflect.get(this, "historyIndex") > -1) {
+      if (!bashMode && matchesKey(data, Key.down) && Reflect.get(this, "historyIndex") > -1) {
         const isOnLastVisualLine = Reflect.get(this, "isOnLastVisualLine");
         if (typeof isOnLastVisualLine !== "function" || isOnLastVisualLine.call(this)) {
           const navigateHistory = Reflect.get(this, "navigateHistory");


### PR DESCRIPTION
## Problem

The BashModeEditor intercepts cursorUp/cursorDown for prompt history recall, but it checks against ALL keys mapped to these actions. When a user adds custom bindings like alt+j→cursorDown and alt+k→cursorUp, pressing these keys triggers history navigation instead of cursor movement.

## Fix

Use matchesKey(Key.up) and matchesKey(Key.down) to only intercept literal arrow key events. User-customized cursor bindings pass through to normal cursor movement.

## Before/After

**Before**: pressing alt+k (mapped to cursorUp by user keybindings) → history navigation
**After**: pressing alt+k → moves cursor up. Pressing Up arrow → history recall (unchanged)

## Related

- https://github.com/earendil-works/pi/issues/6459