### PR TITLE
feat: make scroll-away card toggleable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Scroll-away card toggle** — Added `powerline.scrollAwayCard` and `/powerline scroll-away-card on|off|toggle` so the fixed editor and chat navigation shortcuts can remain enabled while the scroll-away hint card is hidden. Thanks to Alexander Gerdes (@Avg8888), Whisperfall, and Bruno Orsolon (@brunoorsolon) for #97/#108/#99.
+
 ### Changed
 - **Fixed-editor scrolling performance** — Uses terminal row shifts, cached transcript lines, an 8 ms repaint cadence, and transient shortcut-card hiding during active wheel movement to cut scroll latency and terminal output churn.
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,16 @@ Restart pi to activate.
 
 ## Usage
 
-Activates automatically. Toggle with `/powerline`, switch presets with `/powerline <name>`, fixed-editor mode with `/powerline fixed-editor on|off|toggle`, primary-row placement with `/powerline placement above|below|toggle`, and wheel mode with `/powerline mouse-scroll on|off|toggle`.
+Activates automatically. Toggle with `/powerline`, switch presets with `/powerline <name>`, fixed-editor mode with `/powerline fixed-editor on|off|toggle`, the scroll-away card with `/powerline scroll-away-card on|off|toggle`, primary-row placement with `/powerline placement above|below|toggle`, and wheel mode with `/powerline mouse-scroll on|off|toggle`.
 
 Fixed editor is on by default.
 
 - `/powerline fixed-editor off` — return to Pi’s regular scrolling layout
 - `/powerline fixed-editor on` — re-enable the fixed editor
 - `/powerline fixed-editor toggle` — switch between the two
+- `/powerline scroll-away-card off` — hide the navigation hint card while keeping the fixed editor and its shortcuts
+- `/powerline scroll-away-card on` — show the navigation hint card when scrolled away from the bottom
+- `/powerline scroll-away-card toggle` — switch the hint card between shown and hidden
 - `/powerline placement below` — move the primary powerline row below the editor
 - `/powerline placement above` — restore the default placement
 - `/powerline placement toggle` — switch between above and below
@@ -64,6 +67,7 @@ You can also set it in the agent settings file (`~/.pi/agent/settings.json` by d
   "powerline": {
     "preset": "default",
     "fixedEditor": false,
+    "scrollAwayCard": true,
     "placement": "below",
     "welcome": true,
     "mouseScroll": true
@@ -71,7 +75,7 @@ You can also set it in the agent settings file (`~/.pi/agent/settings.json` by d
 }
 ```
 
-Use `"fixedEditor": true` to enable it again. `"placement"` accepts `"above"` (default) or `"below"` in both fixed and regular editor modes. It moves only the primary powerline row; notifications and Pi working status stay above, while responsive overflow, bash transcript, and the last-prompt reminder stay below. Set `"welcome": false` to skip the startup welcome overlay/header while leaving powerline itself enabled. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling. In Herdr, tmux, and other terminal multiplexers, fixed-editor scrolling is Pi-owned while fixed-editor mode is on; keep mouse scrolling enabled for the fixed-editor viewport, or use `/powerline fixed-editor off` when you want the host multiplexer scrollback to own the experience. While fixed-editor mouse reporting is enabled, hold Shift during your terminal’s normal modifier-click to bypass capture for OSC 8 links; otherwise use `/powerline mouse-scroll off` or `/powerline fixed-editor off` for native link handling.
+Use `"fixedEditor": true` to enable it again. Set `"scrollAwayCard": false` to keep the fixed editor and navigation shortcuts while hiding the scroll-away hint card. `"placement"` accepts `"above"` (default) or `"below"` in both fixed and regular editor modes. It moves only the primary powerline row; notifications and Pi working status stay above, while responsive overflow, bash transcript, and the last-prompt reminder stay below. Set `"welcome": false` to skip the startup welcome overlay/header while leaving powerline itself enabled. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling. In Herdr, tmux, and other terminal multiplexers, fixed-editor scrolling is Pi-owned while fixed-editor mode is on; keep mouse scrolling enabled for the fixed-editor viewport, or use `/powerline fixed-editor off` when you want the host multiplexer scrollback to own the experience. While fixed-editor mouse reporting is enabled, hold Shift during your terminal’s normal modifier-click to bypass capture for OSC 8 links; otherwise use `/powerline mouse-scroll off` or `/powerline fixed-editor off` for native link handling.
 
 | Preset | Description |
 |--------|-------------|
@@ -274,7 +278,7 @@ Selecting an entry inserts it into the editor. If the editor already has text, y
 - `ctrl+alt+.` — jump the fixed-editor chat viewport to the next LLM message
 - `ctrl+alt+g` — jump the fixed-editor chat viewport to the bottom
 
-Copy/cut actions do not modify stash state or stash history. Dragging files, folders, images, or screenshots from Finder into the custom editor inserts their path strings. Chat jumps require fixed-editor mode because they use its app-owned scroll viewport. When fixed-editor chat is scrolled away from the bottom, the viewport shows a shortcut hint card with these configured shortcut labels; with mouse scrolling enabled, clicking anywhere in the card jumps to the bottom. Submitting editor text also returns that viewport to the bottom so new output stays in view.
+Copy/cut actions do not modify stash state or stash history. Dragging files, folders, images, or screenshots from Finder into the custom editor inserts their path strings. Chat jumps require fixed-editor mode because they use its app-owned scroll viewport. When fixed-editor chat is scrolled away from the bottom, the viewport shows a shortcut hint card with these configured shortcut labels unless `powerline.scrollAwayCard` is `false`; with mouse scrolling enabled, clicking anywhere in the card jumps to the bottom. Submitting editor text also returns that viewport to the bottom so new output stays in view.
 
 ### Shortcut configuration
 

--- a/index.ts
+++ b/index.ts
@@ -78,6 +78,7 @@ let config: PowerlineConfig = {
   segmentOptions: {},
   mouseScroll: true,
   fixedEditor: true,
+  scrollAwayCard: true,
   placement: "above",
   invalidPlacement: null,
   welcome: true,
@@ -638,7 +639,7 @@ function writePowerlinePresetSetting(preset: StatusLinePreset, cwd: string = pro
 
 function writePowerlineOptionSetting(
   cwd: string,
-  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "welcome" | "stashSharpSShortcut" | "placement">>,
+  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "scrollAwayCard" | "welcome" | "stashSharpSShortcut" | "placement">>,
   currentPreset: StatusLinePreset,
 ): boolean {
   return writePowerlineSetting(cwd, (existingPowerlineSetting) => (
@@ -1918,6 +1919,22 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         return;
       }
 
+      const scrollAwayCardMatch = /^scroll-away-card(?:\s+(on|off|toggle))?$/.exec(normalizedArgs);
+      if (scrollAwayCardMatch) {
+        const mode = scrollAwayCardMatch[1] ?? "toggle";
+        config.scrollAwayCard = mode === "toggle" ? !config.scrollAwayCard : mode === "on";
+        if (enabled && ctx.hasUI && config.fixedEditor && tuiRef && currentEditor) {
+          installFixedEditorCompositor(ctx, tuiRef);
+        }
+
+        if (writePowerlineOptionSetting(ctx.cwd, { scrollAwayCard: config.scrollAwayCard }, config.preset)) {
+          ctx.ui.notify(`Powerline scroll-away card ${config.scrollAwayCard ? "enabled" : "disabled"}`, "info");
+        } else {
+          ctx.ui.notify(`Powerline scroll-away card ${config.scrollAwayCard ? "enabled" : "disabled"} (not persisted; check settings.json)`, "warning");
+        }
+        return;
+      }
+
       const placementMatch = /^placement(?:\s+(above|below|toggle))?$/.exec(normalizedArgs);
       if (placementMatch) {
         const requestedPlacement = placementMatch[1];
@@ -2441,7 +2458,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         down: resolvedShortcuts.scrollChatDown,
       },
       scrollRepaintThrottleMs: DEFAULT_SCROLL_REPAINT_THROTTLE_MS,
-      scrollAwayNavigationCard: {
+      scrollAwayNavigationCard: config.scrollAwayCard ? {
         shortcuts: [
           scrollAwayShortcutEntry("bottom", resolvedShortcuts.jumpChatBottom),
           scrollAwayShortcutEntry("previousUser", resolvedShortcuts.jumpPreviousUserMessage),
@@ -2450,7 +2467,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           scrollAwayShortcutEntry("nextAssistant", resolvedShortcuts.jumpNextLlmMessage),
         ].filter((shortcut): shortcut is { id: ScrollAwayShortcutId; shortcutLabel: string } => shortcut !== null),
         onClickBottom: resolvedShortcuts.jumpChatBottom ? () => jumpChatToBottom(ctx) : undefined,
-      },
+      } : undefined,
       onCopySelection: (text) => copyTextToClipboard(ctx, text),
       getShowHardwareCursor: () => typeof tui.getShowHardwareCursor === "function" && tui.getShowHardwareCursor(),
       renderCluster: (width, terminalRows) => {

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -12,6 +12,7 @@ export interface PowerlineConfig {
   segmentOptions: StatusLineSegmentOptions;
   mouseScroll: boolean;
   fixedEditor: boolean;
+  scrollAwayCard: boolean;
   placement: PowerlinePlacement;
   invalidPlacement: string | null;
   welcome: boolean;
@@ -261,6 +262,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     segmentOptions: {},
     mouseScroll: true,
     fixedEditor: true,
+    scrollAwayCard: true,
     placement: "above",
     invalidPlacement: null,
     welcome: true,
@@ -287,6 +289,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     segmentOptions: normalizeSegmentOptions(value),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,
+    scrollAwayCard: value.scrollAwayCard !== false,
     placement,
     invalidPlacement,
     welcome: value.welcome !== false,
@@ -351,7 +354,7 @@ export function nextPowerlineSettingWithPreset(existingPowerlineSetting: unknown
 
 export function nextPowerlineSettingWithOptions(
   existingPowerlineSetting: unknown,
-  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "welcome" | "stashSharpSShortcut" | "placement">>,
+  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "scrollAwayCard" | "welcome" | "stashSharpSShortcut" | "placement">>,
   currentPreset: StatusLinePreset,
 ): unknown {
   if (!isRecord(existingPowerlineSetting)) {

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -31,6 +31,7 @@ test("parsePowerlineConfig supports object config with custom items", () => {
   assert.deepEqual(config.invalidLayoutSegments, []);
   assert.equal(config.mouseScroll, true);
   assert.equal(config.fixedEditor, true);
+  assert.equal(config.scrollAwayCard, true);
   assert.equal(config.placement, "above");
   assert.equal(config.invalidPlacement, null);
   assert.equal(config.welcome, true);
@@ -115,6 +116,16 @@ test("parsePowerlineConfig supports disabling fixed editor", () => {
 
   assert.equal(config.preset, "compact");
   assert.equal(config.fixedEditor, false);
+});
+
+test("parsePowerlineConfig supports hiding the scroll-away card while keeping fixed editor", () => {
+  const config = parsePowerlineConfig(
+    { preset: "compact", fixedEditor: true, scrollAwayCard: false },
+    ["default", "compact"],
+  );
+
+  assert.equal(config.fixedEditor, true);
+  assert.equal(config.scrollAwayCard, false);
 });
 
 test("parsePowerlineConfig supports welcome and legacy sharp-S toggles", () => {
@@ -254,7 +265,7 @@ test("nextPowerlineSettingWithPreset preserves object settings", () => {
 test("nextPowerlineSettingWithOptions preserves object settings", () => {
   const updated = nextPowerlineSettingWithOptions(
     { preset: "default", customItems: [{ id: "ci" }], mouseScroll: false },
-    { fixedEditor: false, placement: "below" },
+    { fixedEditor: false, scrollAwayCard: false, placement: "below" },
     "compact",
   );
   if (typeof updated !== "object" || updated === null || Array.isArray(updated)) {
@@ -263,6 +274,7 @@ test("nextPowerlineSettingWithOptions preserves object settings", () => {
 
   assert.equal(updated.preset, "default");
   assert.equal(updated.fixedEditor, false);
+  assert.equal(updated.scrollAwayCard, false);
   assert.equal(updated.mouseScroll, false);
   assert.equal(updated.placement, "below");
   assert.deepEqual(updated.customItems, [{ id: "ci" }]);

--- a/tests/jump-shortcuts.test.ts
+++ b/tests/jump-shortcuts.test.ts
@@ -79,7 +79,9 @@ test("chat jump shortcuts are configurable and route through fixed editor scroll
   assert.match(source, /let resolvedShortcuts = resolveShortcutConfig\(startupSettings\)/);
   assert.match(source, /resolvedShortcuts = resolveShortcutConfig\(settings\)/);
   assert.match(source, /keyboardScrollShortcuts: \{\n\s+up: resolvedShortcuts\.scrollChatUp,\n\s+down: resolvedShortcuts\.scrollChatDown,/);
-  assert.match(source, /scrollAwayNavigationCard: \{/);
+  assert.match(source, /scrollAwayNavigationCard: config\.scrollAwayCard \? \{/);
+  assert.match(source, /const scrollAwayCardMatch = \/\^scroll-away-card/);
+  assert.match(source, /writePowerlineOptionSetting\(ctx\.cwd, \{ scrollAwayCard: config\.scrollAwayCard \}, config\.preset\)/);
   assert.match(source, /shortcuts: \[/);
   assert.match(source, /scrollAwayShortcutEntry\("bottom", resolvedShortcuts\.jumpChatBottom\)/);
   assert.match(source, /onClickBottom: resolvedShortcuts\.jumpChatBottom \? \(\) => jumpChatToBottom\(ctx\) : undefined/);
@@ -171,7 +173,7 @@ test("fixed editor captures Pi status messages with the editor cluster", () => {
 });
 
 test("primary powerline placement applies in fixed and regular editor modes", () => {
-  assert.match(source, /Partial<Pick<PowerlineConfig, "mouseScroll" \| "fixedEditor" \| "welcome" \| "stashSharpSShortcut" \| "placement">>/);
+  assert.match(source, /Partial<Pick<PowerlineConfig, "mouseScroll" \| "fixedEditor" \| "scrollAwayCard" \| "welcome" \| "stashSharpSShortcut" \| "placement">>/);
   assert.match(source, /primaryLines: renderPowerlinePrimaryLines\(width, theme\)/);
   assert.match(source, /placement: config\.placement/);
   assert.match(source, /\{ placement: config\.placement === "below" \? "belowEditor" : "aboveEditor" \}/);


### PR DESCRIPTION
## What Problem This Solves

The fixed editor's scroll-away navigation card can cover several lines of chat whenever the viewport is away from the bottom. Users who know or have customized the navigation shortcuts may want to keep the fixed editor, mouse scrolling, and message-jump shortcuts without showing the card.

## Why This Change Was Made

Today, hiding the card requires disabling every navigation shortcut or turning off the fixed editor. Neither preserves the full fixed-editor workflow. This adds a focused display toggle that defaults to the current behavior.

## Shipped Solution

- Add `powerline.scrollAwayCard` (default `true`).
- Add `/powerline scroll-away-card on|off|toggle` with persisted settings.
- Omit `scrollAwayNavigationCard` from the compositor when disabled while leaving fixed-editor scrolling and shortcuts unchanged.
- Document the setting and command and add changelog coverage.

Example:

```json
{
  "powerline": {
    "fixedEditor": true,
    "scrollAwayCard": false
  }
}
```

## User Impact

Users can hide the hint card without giving up the fixed editor or any chat navigation behavior. Existing users see no change unless they opt out.

## Evidence

- `npm test` — 175 passed, 0 failed
- `git diff --check` — passed
- Added config parsing/persistence and source-wiring assertions for the new option.

## AI Assistance

AI-assisted implementation, reviewed and validated locally.
