### PR TITLE
feat: add scroll hint card toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [0.7.0] - 2026-07-14
 
 ### Added
+- **Scroll hint toggle** — Added `powerline.scrollHintCard` and `/powerline scroll-hint on|off|toggle` to hide the fixed-editor scroll-away shortcut card without disabling scrolling or chat-jump shortcuts.
 - **Fixed-editor scroll-away shortcut hint card** — Shows a stacked bottom/user/assistant shortcut card when chat is scrolled away from the bottom; clicking anywhere in the card jumps back to the bottom when fixed-editor mouse handling is enabled.
 - **Welcome toggle** — Added `powerline.welcome` so the startup welcome UI can be disabled without disabling the footer. Thanks to OCPdev25, miloslavnosek, vzeazy, and Florian Kinder (@fank) for #48/#89.
 - **Display options** — Added `powerline.cost.subscriptionDisplay` and `powerline.model.display` for subscription cost and provider-qualified model names. Thanks to Alexandr Burdiyan (@burdiyan), Meidhy (@dymayday), Mathu Mounasamy (@Mathuv), and pserey for #3/#83/#50.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The screenshot is illustrative and may differ from current Pi versions. The supp
 
 **Rounded box design** — Status renders directly in the editor's top border, not as a separate footer.
 
-**Fixed editor cluster** — In interactive TUI sessions, chat/feed content scrolls above the fixed Pi working/status line, powerline rows, editor, ghost suggestions, bash transcript, and last-prompt/status rows. Scroll chat with the mouse wheel, PageUp/PageDown, Command+PageUp/PageDown, Ctrl+Shift+Up/Down, or message-jump shortcuts; the editor stays put. When you are scrolled away from the bottom, a stacked shortcut hint card appears over the bottom of the chat viewport with the configured bottom, user-message, and assistant-response jump shortcuts. When mouse scrolling is enabled, click anywhere in that card to jump back to the bottom. Drag text to copy it, drag selection to the viewport edge to scroll, double-click a line to select it, and right-click to open the terminal menu. Mouse capture blocks native modifier-click link handling; hold Shift while using your terminal’s normal modifier-click to open OSC 8 links. Use `/powerline fixed-editor off` for Pi’s regular scrolling layout, or `/powerline mouse-scroll off` for native link handling and selection.
+**Fixed editor cluster** — In interactive TUI sessions, chat/feed content scrolls above the fixed Pi working/status line, powerline rows, editor, ghost suggestions, bash transcript, and last-prompt/status rows. Scroll chat with the mouse wheel, PageUp/PageDown, Command+PageUp/PageDown, Ctrl+Shift+Up/Down, or message-jump shortcuts; the editor stays put. When you are scrolled away from the bottom, a stacked shortcut hint card appears over the bottom of the chat viewport with the configured bottom, user-message, and assistant-response jump shortcuts. When mouse scrolling is enabled, click anywhere in that card to jump back to the bottom. Disable the card with `/powerline scroll-hint off` while keeping fixed-editor scrolling and shortcuts enabled. Drag text to copy it, drag selection to the viewport edge to scroll, double-click a line to select it, and right-click to open the terminal menu. Mouse capture blocks native modifier-click link handling; hold Shift while using your terminal’s normal modifier-click to open OSC 8 links. Use `/powerline fixed-editor off` for Pi’s regular scrolling layout, or `/powerline mouse-scroll off` for native link handling and selection.
 
 **Live thinking level indicator** — Shows current thinking level (`think:off`, `think:med`, etc.) with per-level colors. High, xhigh, and max levels use a rainbow effect inspired by Claude Code's ultrathink.
 
@@ -46,7 +46,7 @@ Restart pi to activate.
 
 ## Usage
 
-Activates automatically. Toggle with `/powerline`, switch presets with `/powerline <name>`, fixed-editor mode with `/powerline fixed-editor on|off|toggle`, primary-row placement with `/powerline placement above|below|toggle`, and wheel mode with `/powerline mouse-scroll on|off|toggle`.
+Activates automatically. Toggle with `/powerline`, switch presets with `/powerline <name>`, fixed-editor mode with `/powerline fixed-editor on|off|toggle`, primary-row placement with `/powerline placement above|below|toggle`, wheel mode with `/powerline mouse-scroll on|off|toggle`, and the scroll-away shortcut card with `/powerline scroll-hint on|off|toggle`.
 
 Fixed editor is on by default.
 
@@ -65,13 +65,14 @@ You can also set it in the agent settings file (`~/.pi/agent/settings.json` by d
     "preset": "default",
     "fixedEditor": false,
     "placement": "below",
+    "scrollHintCard": true,
     "welcome": true,
     "mouseScroll": true
   }
 }
 ```
 
-Use `"fixedEditor": true` to enable it again. `"placement"` accepts `"above"` (default) or `"below"` in both fixed and regular editor modes. It moves only the primary powerline row; notifications and Pi working status stay above, while responsive overflow, bash transcript, and the last-prompt reminder stay below. Set `"welcome": false` to skip the startup welcome overlay/header while leaving powerline itself enabled. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling. In Herdr, tmux, and other terminal multiplexers, fixed-editor scrolling is Pi-owned while fixed-editor mode is on; keep mouse scrolling enabled for the fixed-editor viewport, or use `/powerline fixed-editor off` when you want the host multiplexer scrollback to own the experience. While fixed-editor mouse reporting is enabled, hold Shift during your terminal’s normal modifier-click to bypass capture for OSC 8 links; otherwise use `/powerline mouse-scroll off` or `/powerline fixed-editor off` for native link handling.
+Use `"fixedEditor": true` to enable it again. `"placement"` accepts `"above"` (default) or `"below"` in both fixed and regular editor modes. It moves only the primary powerline row; notifications and Pi working status stay above, while responsive overflow, bash transcript, and the last-prompt reminder stay below. Set `"scrollHintCard": false` to hide the shortcut card while preserving fixed-editor scrolling and chat-jump shortcuts. Set `"welcome": false` to skip the startup welcome overlay/header while leaving powerline itself enabled. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling. In Herdr, tmux, and other terminal multiplexers, fixed-editor scrolling is Pi-owned while fixed-editor mode is on; keep mouse scrolling enabled for the fixed-editor viewport, or use `/powerline fixed-editor off` when you want the host multiplexer scrollback to own the experience. While fixed-editor mouse reporting is enabled, hold Shift during your terminal’s normal modifier-click to bypass capture for OSC 8 links; otherwise use `/powerline mouse-scroll off` or `/powerline fixed-editor off` for native link handling.
 
 | Preset | Description |
 |--------|-------------|
@@ -177,6 +178,7 @@ For a compact current footer setup:
   "powerline": {
     "preset": "default",
     "fixedEditor": true,
+    "scrollHintCard": true,
     "mouseScroll": true,
     "path": { "mode": "basename" },
     "model": { "display": "name" },

--- a/index.ts
+++ b/index.ts
@@ -80,6 +80,7 @@ let config: PowerlineConfig = {
   fixedEditor: true,
   placement: "above",
   invalidPlacement: null,
+  scrollHintCard: true,
   welcome: true,
   stashSharpSShortcut: false,
 };
@@ -638,7 +639,7 @@ function writePowerlinePresetSetting(preset: StatusLinePreset, cwd: string = pro
 
 function writePowerlineOptionSetting(
   cwd: string,
-  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "welcome" | "stashSharpSShortcut" | "placement">>,
+  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "scrollHintCard" | "welcome" | "stashSharpSShortcut" | "placement">>,
   currentPreset: StatusLinePreset,
 ): boolean {
   return writePowerlineSetting(cwd, (existingPowerlineSetting) => (
@@ -1957,6 +1958,22 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         return;
       }
 
+      const scrollHintMatch = /^scroll-hint(?:\s+(on|off|toggle))?$/.exec(normalizedArgs);
+      if (scrollHintMatch) {
+        const mode = scrollHintMatch[1] ?? "toggle";
+        config.scrollHintCard = mode === "toggle" ? !config.scrollHintCard : mode === "on";
+        if (enabled && ctx.hasUI && config.fixedEditor && tuiRef && currentEditor) {
+          installFixedEditorCompositor(ctx, tuiRef);
+        }
+
+        if (writePowerlineOptionSetting(ctx.cwd, { scrollHintCard: config.scrollHintCard }, config.preset)) {
+          ctx.ui.notify(`Powerline scroll hint ${config.scrollHintCard ? "enabled" : "disabled"}`, "info");
+        } else {
+          ctx.ui.notify(`Powerline scroll hint ${config.scrollHintCard ? "enabled" : "disabled"} (not persisted; check settings.json)`, "warning");
+        }
+        return;
+      }
+
       const preset = normalizePreset(args);
       if (preset) {
         config.preset = preset;
@@ -2441,16 +2458,18 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         down: resolvedShortcuts.scrollChatDown,
       },
       scrollRepaintThrottleMs: DEFAULT_SCROLL_REPAINT_THROTTLE_MS,
-      scrollAwayNavigationCard: {
-        shortcuts: [
-          scrollAwayShortcutEntry("bottom", resolvedShortcuts.jumpChatBottom),
-          scrollAwayShortcutEntry("previousUser", resolvedShortcuts.jumpPreviousUserMessage),
-          scrollAwayShortcutEntry("nextUser", resolvedShortcuts.jumpNextUserMessage),
-          scrollAwayShortcutEntry("previousAssistant", resolvedShortcuts.jumpPreviousLlmMessage),
-          scrollAwayShortcutEntry("nextAssistant", resolvedShortcuts.jumpNextLlmMessage),
-        ].filter((shortcut): shortcut is { id: ScrollAwayShortcutId; shortcutLabel: string } => shortcut !== null),
-        onClickBottom: resolvedShortcuts.jumpChatBottom ? () => jumpChatToBottom(ctx) : undefined,
-      },
+      scrollAwayNavigationCard: config.scrollHintCard
+        ? {
+            shortcuts: [
+              scrollAwayShortcutEntry("bottom", resolvedShortcuts.jumpChatBottom),
+              scrollAwayShortcutEntry("previousUser", resolvedShortcuts.jumpPreviousUserMessage),
+              scrollAwayShortcutEntry("nextUser", resolvedShortcuts.jumpNextUserMessage),
+              scrollAwayShortcutEntry("previousAssistant", resolvedShortcuts.jumpPreviousLlmMessage),
+              scrollAwayShortcutEntry("nextAssistant", resolvedShortcuts.jumpNextLlmMessage),
+            ].filter((shortcut): shortcut is { id: ScrollAwayShortcutId; shortcutLabel: string } => shortcut !== null),
+            onClickBottom: resolvedShortcuts.jumpChatBottom ? () => jumpChatToBottom(ctx) : undefined,
+          }
+        : undefined,
       onCopySelection: (text) => copyTextToClipboard(ctx, text),
       getShowHardwareCursor: () => typeof tui.getShowHardwareCursor === "function" && tui.getShowHardwareCursor(),
       renderCluster: (width, terminalRows) => {

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -14,6 +14,7 @@ export interface PowerlineConfig {
   fixedEditor: boolean;
   placement: PowerlinePlacement;
   invalidPlacement: string | null;
+  scrollHintCard: boolean;
   welcome: boolean;
   stashSharpSShortcut: boolean;
 }
@@ -263,6 +264,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     fixedEditor: true,
     placement: "above",
     invalidPlacement: null,
+    scrollHintCard: true,
     welcome: true,
     stashSharpSShortcut: false,
   };
@@ -289,6 +291,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     fixedEditor: value.fixedEditor !== false,
     placement,
     invalidPlacement,
+    scrollHintCard: value.scrollHintCard !== false,
     welcome: value.welcome !== false,
     stashSharpSShortcut: value.stashSharpSShortcut === true,
   };
@@ -351,7 +354,7 @@ export function nextPowerlineSettingWithPreset(existingPowerlineSetting: unknown
 
 export function nextPowerlineSettingWithOptions(
   existingPowerlineSetting: unknown,
-  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "welcome" | "stashSharpSShortcut" | "placement">>,
+  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "scrollHintCard" | "welcome" | "stashSharpSShortcut" | "placement">>,
   currentPreset: StatusLinePreset,
 ): unknown {
   if (!isRecord(existingPowerlineSetting)) {

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -33,6 +33,7 @@ test("parsePowerlineConfig supports object config with custom items", () => {
   assert.equal(config.fixedEditor, true);
   assert.equal(config.placement, "above");
   assert.equal(config.invalidPlacement, null);
+  assert.equal(config.scrollHintCard, true);
   assert.equal(config.welcome, true);
   assert.equal(config.stashSharpSShortcut, false);
 });
@@ -117,15 +118,17 @@ test("parsePowerlineConfig supports disabling fixed editor", () => {
   assert.equal(config.fixedEditor, false);
 });
 
-test("parsePowerlineConfig supports welcome and legacy sharp-S toggles", () => {
+test("parsePowerlineConfig supports scroll hint, welcome, and legacy sharp-S toggles", () => {
   const disabled = parsePowerlineConfig(
-    { preset: "compact", welcome: false, stashSharpSShortcut: true },
+    { preset: "compact", scrollHintCard: false, welcome: false, stashSharpSShortcut: true },
     ["default", "compact"],
   );
   const shorthand = parsePowerlineConfig("compact", ["default", "compact"]);
 
+  assert.equal(disabled.scrollHintCard, false);
   assert.equal(disabled.welcome, false);
   assert.equal(disabled.stashSharpSShortcut, true);
+  assert.equal(shorthand.scrollHintCard, true);
   assert.equal(shorthand.welcome, true);
   assert.equal(shorthand.stashSharpSShortcut, false);
 });
@@ -254,7 +257,7 @@ test("nextPowerlineSettingWithPreset preserves object settings", () => {
 test("nextPowerlineSettingWithOptions preserves object settings", () => {
   const updated = nextPowerlineSettingWithOptions(
     { preset: "default", customItems: [{ id: "ci" }], mouseScroll: false },
-    { fixedEditor: false, placement: "below" },
+    { fixedEditor: false, placement: "below", scrollHintCard: false },
     "compact",
   );
   if (typeof updated !== "object" || updated === null || Array.isArray(updated)) {
@@ -263,6 +266,7 @@ test("nextPowerlineSettingWithOptions preserves object settings", () => {
 
   assert.equal(updated.preset, "default");
   assert.equal(updated.fixedEditor, false);
+  assert.equal(updated.scrollHintCard, false);
   assert.equal(updated.mouseScroll, false);
   assert.equal(updated.placement, "below");
   assert.deepEqual(updated.customItems, [{ id: "ci" }]);

--- a/tests/jump-shortcuts.test.ts
+++ b/tests/jump-shortcuts.test.ts
@@ -79,10 +79,12 @@ test("chat jump shortcuts are configurable and route through fixed editor scroll
   assert.match(source, /let resolvedShortcuts = resolveShortcutConfig\(startupSettings\)/);
   assert.match(source, /resolvedShortcuts = resolveShortcutConfig\(settings\)/);
   assert.match(source, /keyboardScrollShortcuts: \{\n\s+up: resolvedShortcuts\.scrollChatUp,\n\s+down: resolvedShortcuts\.scrollChatDown,/);
-  assert.match(source, /scrollAwayNavigationCard: \{/);
+  assert.match(source, /scrollAwayNavigationCard: config\.scrollHintCard/);
   assert.match(source, /shortcuts: \[/);
   assert.match(source, /scrollAwayShortcutEntry\("bottom", resolvedShortcuts\.jumpChatBottom\)/);
   assert.match(source, /onClickBottom: resolvedShortcuts\.jumpChatBottom \? \(\) => jumpChatToBottom\(ctx\) : undefined/);
+  assert.match(source, /const scrollHintMatch = \/\^scroll-hint/);
+  assert.match(source, /writePowerlineOptionSetting\(ctx\.cwd, \{ scrollHintCard: config\.scrollHintCard \}/);
   assert.match(source, /function formatShortcutLabel\(shortcut: ShortcutBinding\): string \| null/);
   assert.match(source, /part\.toLowerCase\(\) === "super" \? "cmd" : part/);
   assert.match(source, /editorBoundaryShortcuts: \{\n\s+start: resolvedShortcuts\.editorStart,\n\s+end: resolvedShortcuts\.editorEnd,/);
@@ -171,7 +173,7 @@ test("fixed editor captures Pi status messages with the editor cluster", () => {
 });
 
 test("primary powerline placement applies in fixed and regular editor modes", () => {
-  assert.match(source, /Partial<Pick<PowerlineConfig, "mouseScroll" \| "fixedEditor" \| "welcome" \| "stashSharpSShortcut" \| "placement">>/);
+  assert.match(source, /Partial<Pick<PowerlineConfig, "mouseScroll" \| "fixedEditor" \| "scrollHintCard" \| "welcome" \| "stashSharpSShortcut" \| "placement">>/);
   assert.match(source, /primaryLines: renderPowerlinePrimaryLines\(width, theme\)/);
   assert.match(source, /placement: config\.placement/);
   assert.match(source, /\{ placement: config\.placement === "below" \? "belowEditor" : "aboveEditor" \}/);


### PR DESCRIPTION
## Summary

- Add `powerline.scrollHintCard`, enabled by default
- Add `/powerline scroll-hint on|off|toggle`
- Allow hiding the fixed-editor scroll-away shortcut card without disabling fixed-editor scrolling or chat-jump shortcuts
- Document the new setting and command

## Motivation

The shortcut card can obscure chat content while scrolling. Previously, removing it required disabling the fixed editor or disabling every chat-jump shortcut.

## Configuration

```json
{
  "powerline": {
    "scrollHintCard": false
  }
}
```

## Testing

- `node --experimental-strip-types --test tests/custom-items.test.ts tests/jump-shortcuts.test.ts` — 36/36 passed
- `npm test` — 173/174 passed
- The remaining Alt+Enter test failure reproduces on unchanged `origin/main` and is unrelated to this change
- `git diff --check` passed
