### PR TITLE
Improve light-theme contrast and make scroll card optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+- **Light-theme footer colors** — Uses higher-contrast model, path, and thinking-rainbow colors with Pi's built-in light theme while preserving the existing dark palette and `theme.json` overrides.
+- **Scroll-away card toggle** — Added `powerline.scrollAwayCard` and `/powerline scroll-away-card on|off|toggle` to hide the shortcut card while keeping fixed-editor scrolling and jump shortcuts.
+
 ## [0.7.0] - 2026-07-14
 
 ### Added
-- **Fixed-editor scroll-away shortcut hint card** — Shows a stacked bottom/user/assistant shortcut card when chat is scrolled away from the bottom; clicking anywhere in the card jumps back to the bottom when fixed-editor mouse handling is enabled.
 - **Welcome toggle** — Added `powerline.welcome` so the startup welcome UI can be disabled without disabling the footer. Thanks to OCPdev25, miloslavnosek, vzeazy, and Florian Kinder (@fank) for #48/#89.
 - **Display options** — Added `powerline.cost.subscriptionDisplay` and `powerline.model.display` for subscription cost and provider-qualified model names. Thanks to Alexandr Burdiyan (@burdiyan), Meidhy (@dymayday), Mathu Mounasamy (@Mathuv), and pserey for #3/#83/#50.
 - **Legacy sharp-S stash opt-in** — Added `powerline.stashSharpSShortcut` for users who intentionally want printable `ß` to trigger stash. Thanks to SebastianRuettiRuettger and Filip (@filipores) for #39/#84.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The screenshot is illustrative and may differ from current Pi versions. The supp
 
 **Live thinking level indicator** — Shows current thinking level (`think:off`, `think:med`, etc.) with per-level colors. High, xhigh, and max levels use a rainbow effect inspired by Claude Code's ultrathink.
 
-**Smart defaults** — Nerd Font auto-detection for iTerm, WezTerm, Kitty, Ghostty, and Alacritty with ASCII fallbacks. Colors matched to oh-my-pi's dark theme.
+**Smart defaults** — Nerd Font auto-detection for iTerm, WezTerm, Kitty, Ghostty, and Alacritty with ASCII fallbacks. Colors preserve the oh-my-pi-inspired dark palette and automatically use higher-contrast variants with Pi's built-in light theme.
 
 **Git integration** — Async status fetching with 1s cache TTL. Automatically invalidates on file writes/edits. Shows branch, staged (+), unstaged (*), and untracked (?) counts.
 
@@ -46,7 +46,7 @@ Restart pi to activate.
 
 ## Usage
 
-Activates automatically. Toggle with `/powerline`, switch presets with `/powerline <name>`, fixed-editor mode with `/powerline fixed-editor on|off|toggle`, primary-row placement with `/powerline placement above|below|toggle`, and wheel mode with `/powerline mouse-scroll on|off|toggle`.
+Activates automatically. Toggle with `/powerline`, switch presets with `/powerline <name>`, fixed-editor mode with `/powerline fixed-editor on|off|toggle`, primary-row placement with `/powerline placement above|below|toggle`, wheel mode with `/powerline mouse-scroll on|off|toggle`, and the scroll-away shortcut card with `/powerline scroll-away-card on|off|toggle`.
 
 Fixed editor is on by default.
 
@@ -65,13 +65,14 @@ You can also set it in the agent settings file (`~/.pi/agent/settings.json` by d
     "preset": "default",
     "fixedEditor": false,
     "placement": "below",
+    "scrollAwayCard": true,
     "welcome": true,
     "mouseScroll": true
   }
 }
 ```
 
-Use `"fixedEditor": true` to enable it again. `"placement"` accepts `"above"` (default) or `"below"` in both fixed and regular editor modes. It moves only the primary powerline row; notifications and Pi working status stay above, while responsive overflow, bash transcript, and the last-prompt reminder stay below. Set `"welcome": false` to skip the startup welcome overlay/header while leaving powerline itself enabled. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling. In Herdr, tmux, and other terminal multiplexers, fixed-editor scrolling is Pi-owned while fixed-editor mode is on; keep mouse scrolling enabled for the fixed-editor viewport, or use `/powerline fixed-editor off` when you want the host multiplexer scrollback to own the experience. While fixed-editor mouse reporting is enabled, hold Shift during your terminal’s normal modifier-click to bypass capture for OSC 8 links; otherwise use `/powerline mouse-scroll off` or `/powerline fixed-editor off` for native link handling.
+Use `"fixedEditor": true` to enable it again. `"placement"` accepts `"above"` (default) or `"below"` in both fixed and regular editor modes. It moves only the primary powerline row; notifications and Pi working status stay above, while responsive overflow, bash transcript, and the last-prompt reminder stay below. Set `"scrollAwayCard": false` to hide the shortcut card without disabling the fixed editor, scrolling, or jump shortcuts. Set `"welcome": false` to skip the startup welcome overlay/header while leaving powerline itself enabled. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling. In Herdr, tmux, and other terminal multiplexers, fixed-editor scrolling is Pi-owned while fixed-editor mode is on; keep mouse scrolling enabled for the fixed-editor viewport, or use `/powerline fixed-editor off` when you want the host multiplexer scrollback to own the experience. While fixed-editor mouse reporting is enabled, hold Shift during your terminal’s normal modifier-click to bypass capture for OSC 8 links; otherwise use `/powerline mouse-scroll off` or `/powerline fixed-editor off` for native link handling.
 
 | Preset | Description |
 |--------|-------------|
@@ -274,7 +275,7 @@ Selecting an entry inserts it into the editor. If the editor already has text, y
 - `ctrl+alt+.` — jump the fixed-editor chat viewport to the next LLM message
 - `ctrl+alt+g` — jump the fixed-editor chat viewport to the bottom
 
-Copy/cut actions do not modify stash state or stash history. Dragging files, folders, images, or screenshots from Finder into the custom editor inserts their path strings. Chat jumps require fixed-editor mode because they use its app-owned scroll viewport. When fixed-editor chat is scrolled away from the bottom, the viewport shows a shortcut hint card with these configured shortcut labels; with mouse scrolling enabled, clicking anywhere in the card jumps to the bottom. Submitting editor text also returns that viewport to the bottom so new output stays in view.
+Copy/cut actions do not modify stash state or stash history. Dragging files, folders, images, or screenshots from Finder into the custom editor inserts their path strings. Chat jumps require fixed-editor mode because they use its app-owned scroll viewport. When fixed-editor chat is scrolled away from the bottom, the viewport shows a shortcut hint card with these configured shortcut labels; with mouse scrolling enabled, clicking anywhere in the card jumps to the bottom. Hide it with `/powerline scroll-away-card off` or `"scrollAwayCard": false`; scrolling and jump shortcuts remain enabled. Submitting editor text also returns that viewport to the bottom so new output stays in view.
 
 ### Shortcut configuration
 
@@ -426,22 +427,24 @@ Colors are configurable via pi's theme system. Each preset defines its own color
 
 ### Default Colors
 
-| Semantic | Theme Color | Description |
-|----------|-------------|-------------|
-| `model` | `#d787af` | Model name |
-| `shellMode` | `accent` | Bash mode segment |
-| `path` | `#00afaf` | Directory path |
-| `gitClean` | `success` | Git branch (clean) |
-| `gitDirty` | `warning` | Git branch (dirty) |
-| `thinking` | `thinkingOff` | Thinking level (`off`) |
-| `thinkingMinimal` | `thinkingMinimal` | Thinking level (`minimal`) |
-| `thinkingLow` | `thinkingLow` | Thinking level (`low`) |
-| `thinkingMedium` | `thinkingMedium` | Thinking level (`medium`) |
-| `context` | `dim` | Context usage |
-| `contextWarn` | `warning` | Context usage >70% |
-| `contextError` | `error` | Context usage >90% |
-| `cost` | `text` | Cost display |
-| `tokens` | `muted` | Token counts |
+| Semantic | Dark | Light | Description |
+|----------|------|-------|-------------|
+| `model` | `#d787af` | `#8f3f71` | Model name |
+| `shellMode` | `accent` | `accent` | Bash mode segment |
+| `path` | `#00afaf` | `#007070` | Directory path |
+| `gitClean` | `success` | `success` | Git branch (clean) |
+| `gitDirty` | `warning` | `warning` | Git branch (dirty) |
+| `thinking` | `thinkingOff` | `thinkingOff` | Thinking level (`off`) |
+| `thinkingMinimal` | `thinkingMinimal` | `thinkingMinimal` | Thinking level (`minimal`) |
+| `thinkingLow` | `thinkingLow` | `thinkingLow` | Thinking level (`low`) |
+| `thinkingMedium` | `thinkingMedium` | `thinkingMedium` | Thinking level (`medium`) |
+| `context` | `dim` | `dim` | Context usage |
+| `contextWarn` | `warning` | `warning` | Context usage >70% |
+| `contextError` | `error` | `error` | Context usage >90% |
+| `cost` | `text` | `text` | Cost display |
+| `tokens` | `muted` | `muted` | Token counts |
+
+High and extra-high thinking rainbows also switch to a darker palette in Pi's built-in light theme. `theme.json` color overrides still take precedence over these adaptive defaults.
 
 ### Custom Theme Override
 

--- a/index.ts
+++ b/index.ts
@@ -78,6 +78,7 @@ let config: PowerlineConfig = {
   segmentOptions: {},
   mouseScroll: true,
   fixedEditor: true,
+  scrollAwayCard: true,
   placement: "above",
   invalidPlacement: null,
   welcome: true,
@@ -638,7 +639,7 @@ function writePowerlinePresetSetting(preset: StatusLinePreset, cwd: string = pro
 
 function writePowerlineOptionSetting(
   cwd: string,
-  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "welcome" | "stashSharpSShortcut" | "placement">>,
+  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "scrollAwayCard" | "welcome" | "stashSharpSShortcut" | "placement">>,
   currentPreset: StatusLinePreset,
 ): boolean {
   return writePowerlineSetting(cwd, (existingPowerlineSetting) => (
@@ -1941,6 +1942,22 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         return;
       }
 
+      const scrollAwayCardMatch = /^scroll-away-card(?:\s+(on|off|toggle))?$/.exec(normalizedArgs);
+      if (scrollAwayCardMatch) {
+        const mode = scrollAwayCardMatch[1] ?? "toggle";
+        config.scrollAwayCard = mode === "toggle" ? !config.scrollAwayCard : mode === "on";
+        if (enabled && ctx.hasUI && config.fixedEditor && tuiRef && currentEditor) {
+          installFixedEditorCompositor(ctx, tuiRef);
+        }
+
+        if (writePowerlineOptionSetting(ctx.cwd, { scrollAwayCard: config.scrollAwayCard }, config.preset)) {
+          ctx.ui.notify(`Powerline scroll-away card ${config.scrollAwayCard ? "enabled" : "disabled"}`, "info");
+        } else {
+          ctx.ui.notify(`Powerline scroll-away card ${config.scrollAwayCard ? "enabled" : "disabled"} (not persisted; check settings.json)`, "warning");
+        }
+        return;
+      }
+
       const fixedEditorMatch = /^fixed-editor(?:\s+(on|off|toggle))?$/.exec(normalizedArgs);
       if (fixedEditorMatch) {
         const mode = fixedEditorMatch[1] ?? "toggle";
@@ -2441,16 +2458,18 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         down: resolvedShortcuts.scrollChatDown,
       },
       scrollRepaintThrottleMs: DEFAULT_SCROLL_REPAINT_THROTTLE_MS,
-      scrollAwayNavigationCard: {
-        shortcuts: [
-          scrollAwayShortcutEntry("bottom", resolvedShortcuts.jumpChatBottom),
-          scrollAwayShortcutEntry("previousUser", resolvedShortcuts.jumpPreviousUserMessage),
-          scrollAwayShortcutEntry("nextUser", resolvedShortcuts.jumpNextUserMessage),
-          scrollAwayShortcutEntry("previousAssistant", resolvedShortcuts.jumpPreviousLlmMessage),
-          scrollAwayShortcutEntry("nextAssistant", resolvedShortcuts.jumpNextLlmMessage),
-        ].filter((shortcut): shortcut is { id: ScrollAwayShortcutId; shortcutLabel: string } => shortcut !== null),
-        onClickBottom: resolvedShortcuts.jumpChatBottom ? () => jumpChatToBottom(ctx) : undefined,
-      },
+      scrollAwayNavigationCard: config.scrollAwayCard
+        ? {
+            shortcuts: [
+              scrollAwayShortcutEntry("bottom", resolvedShortcuts.jumpChatBottom),
+              scrollAwayShortcutEntry("previousUser", resolvedShortcuts.jumpPreviousUserMessage),
+              scrollAwayShortcutEntry("nextUser", resolvedShortcuts.jumpNextUserMessage),
+              scrollAwayShortcutEntry("previousAssistant", resolvedShortcuts.jumpPreviousLlmMessage),
+              scrollAwayShortcutEntry("nextAssistant", resolvedShortcuts.jumpNextLlmMessage),
+            ].filter((shortcut): shortcut is { id: ScrollAwayShortcutId; shortcutLabel: string } => shortcut !== null),
+            onClickBottom: resolvedShortcuts.jumpChatBottom ? () => jumpChatToBottom(ctx) : undefined,
+          }
+        : undefined,
       onCopySelection: (text) => copyTextToClipboard(ctx, text),
       getShowHardwareCursor: () => typeof tui.getShowHardwareCursor === "function" && tui.getShowHardwareCursor(),
       renderCluster: (width, terminalRows) => {

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -14,6 +14,7 @@ export interface PowerlineConfig {
   fixedEditor: boolean;
   placement: PowerlinePlacement;
   invalidPlacement: string | null;
+  scrollAwayCard: boolean;
   welcome: boolean;
   stashSharpSShortcut: boolean;
 }
@@ -263,6 +264,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     fixedEditor: true,
     placement: "above",
     invalidPlacement: null,
+    scrollAwayCard: true,
     welcome: true,
     stashSharpSShortcut: false,
   };
@@ -289,6 +291,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     fixedEditor: value.fixedEditor !== false,
     placement,
     invalidPlacement,
+    scrollAwayCard: value.scrollAwayCard !== false,
     welcome: value.welcome !== false,
     stashSharpSShortcut: value.stashSharpSShortcut === true,
   };
@@ -351,7 +354,7 @@ export function nextPowerlineSettingWithPreset(existingPowerlineSetting: unknown
 
 export function nextPowerlineSettingWithOptions(
   existingPowerlineSetting: unknown,
-  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "welcome" | "stashSharpSShortcut" | "placement">>,
+  updates: Partial<Pick<PowerlineConfig, "mouseScroll" | "fixedEditor" | "scrollAwayCard" | "welcome" | "stashSharpSShortcut" | "placement">>,
   currentPreset: StatusLinePreset,
 ): unknown {
   if (!isRecord(existingPowerlineSetting)) {

--- a/segments.ts
+++ b/segments.ts
@@ -196,7 +196,7 @@ const thinkingSegment: StatusLineSegment = {
     const content = `think:${label}`;
 
     if (level === "high" || level === "xhigh" || level === "max") {
-      return { content: rainbow(content), visible: true };
+      return { content: rainbow(ctx.theme, content), visible: true };
     }
 
     if (level === "minimal") {

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -33,6 +33,7 @@ test("parsePowerlineConfig supports object config with custom items", () => {
   assert.equal(config.fixedEditor, true);
   assert.equal(config.placement, "above");
   assert.equal(config.invalidPlacement, null);
+  assert.equal(config.scrollAwayCard, true);
   assert.equal(config.welcome, true);
   assert.equal(config.stashSharpSShortcut, false);
 });
@@ -115,6 +116,16 @@ test("parsePowerlineConfig supports disabling fixed editor", () => {
 
   assert.equal(config.preset, "compact");
   assert.equal(config.fixedEditor, false);
+});
+
+test("parsePowerlineConfig can hide the scroll-away card without disabling fixed editor", () => {
+  const config = parsePowerlineConfig(
+    { preset: "compact", fixedEditor: true, scrollAwayCard: false },
+    ["default", "compact"],
+  );
+
+  assert.equal(config.fixedEditor, true);
+  assert.equal(config.scrollAwayCard, false);
 });
 
 test("parsePowerlineConfig supports welcome and legacy sharp-S toggles", () => {
@@ -254,7 +265,7 @@ test("nextPowerlineSettingWithPreset preserves object settings", () => {
 test("nextPowerlineSettingWithOptions preserves object settings", () => {
   const updated = nextPowerlineSettingWithOptions(
     { preset: "default", customItems: [{ id: "ci" }], mouseScroll: false },
-    { fixedEditor: false, placement: "below" },
+    { fixedEditor: false, placement: "below", scrollAwayCard: false },
     "compact",
   );
   if (typeof updated !== "object" || updated === null || Array.isArray(updated)) {
@@ -263,6 +274,7 @@ test("nextPowerlineSettingWithOptions preserves object settings", () => {
 
   assert.equal(updated.preset, "default");
   assert.equal(updated.fixedEditor, false);
+  assert.equal(updated.scrollAwayCard, false);
   assert.equal(updated.mouseScroll, false);
   assert.equal(updated.placement, "below");
   assert.deepEqual(updated.customItems, [{ id: "ci" }]);

--- a/tests/jump-shortcuts.test.ts
+++ b/tests/jump-shortcuts.test.ts
@@ -79,10 +79,12 @@ test("chat jump shortcuts are configurable and route through fixed editor scroll
   assert.match(source, /let resolvedShortcuts = resolveShortcutConfig\(startupSettings\)/);
   assert.match(source, /resolvedShortcuts = resolveShortcutConfig\(settings\)/);
   assert.match(source, /keyboardScrollShortcuts: \{\n\s+up: resolvedShortcuts\.scrollChatUp,\n\s+down: resolvedShortcuts\.scrollChatDown,/);
-  assert.match(source, /scrollAwayNavigationCard: \{/);
+  assert.match(source, /scrollAwayNavigationCard: config\.scrollAwayCard/);
   assert.match(source, /shortcuts: \[/);
   assert.match(source, /scrollAwayShortcutEntry\("bottom", resolvedShortcuts\.jumpChatBottom\)/);
   assert.match(source, /onClickBottom: resolvedShortcuts\.jumpChatBottom \? \(\) => jumpChatToBottom\(ctx\) : undefined/);
+  assert.match(source, /\^scroll-away-card/);
+  assert.match(source, /\{ scrollAwayCard: config\.scrollAwayCard \}/);
   assert.match(source, /function formatShortcutLabel\(shortcut: ShortcutBinding\): string \| null/);
   assert.match(source, /part\.toLowerCase\(\) === "super" \? "cmd" : part/);
   assert.match(source, /editorBoundaryShortcuts: \{\n\s+start: resolvedShortcuts\.editorStart,\n\s+end: resolvedShortcuts\.editorEnd,/);
@@ -171,7 +173,7 @@ test("fixed editor captures Pi status messages with the editor cluster", () => {
 });
 
 test("primary powerline placement applies in fixed and regular editor modes", () => {
-  assert.match(source, /Partial<Pick<PowerlineConfig, "mouseScroll" \| "fixedEditor" \| "welcome" \| "stashSharpSShortcut" \| "placement">>/);
+  assert.match(source, /Partial<Pick<PowerlineConfig, "mouseScroll" \| "fixedEditor" \| "scrollAwayCard" \| "welcome" \| "stashSharpSShortcut" \| "placement">>/);
   assert.match(source, /primaryLines: renderPowerlinePrimaryLines\(width, theme\)/);
   assert.match(source, /placement: config\.placement/);
   assert.match(source, /\{ placement: config\.placement === "below" \? "belowEditor" : "aboveEditor" \}/);

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fg, getDefaultColors, rainbow, resolveColor } from "../theme.ts";
+import type { ThemeLike } from "../types.ts";
+
+function theme(name: string): ThemeLike {
+  return {
+    name,
+    fg(color, text) {
+      return `<${color}>${text}</${color}>`;
+    },
+  };
+}
+
+test("default fixed colors use higher contrast variants with Pi's light theme", () => {
+  const colors = getDefaultColors();
+
+  assert.equal(resolveColor("model", colors, theme("dark")), "#d787af");
+  assert.equal(resolveColor("path", colors, theme("dark")), "#00afaf");
+  assert.equal(resolveColor("model", colors, theme("light")), "#8f3f71");
+  assert.equal(resolveColor("path", colors, theme("light")), "#007070");
+});
+
+test("light palette preserves preset and semantic theme colors", () => {
+  const light = theme("light");
+
+  assert.equal(resolveColor("model", { model: "#123456" }, light), "#123456");
+  assert.equal(fg(light, "context", "42%", getDefaultColors()), "<dim>42%</dim>");
+});
+
+test("rainbow uses a darker palette with Pi's light theme", () => {
+  assert.match(rainbow(theme("dark"), "think:high"), /^\x1b\[38;2;178;129;214m/);
+  assert.match(rainbow(theme("light"), "think:high"), /^\x1b\[38;2;111;66;193m/);
+});

--- a/tests/thinking-segment.test.ts
+++ b/tests/thinking-segment.test.ts
@@ -66,9 +66,10 @@ test("thinking segment uses rainbow styling for high through max", () => {
   const colors: ColorScheme = { thinking: "#111111" };
 
   for (const level of ["high", "xhigh", "max"]) {
-    const rendered = renderSegment("thinking", createSegmentContext(level, colors));
+    const ctx = createSegmentContext(level, colors);
+    const rendered = renderSegment("thinking", ctx);
     assert.deepEqual(rendered, {
-      content: rainbow(`think:${level}`),
+      content: rainbow(ctx.theme, `think:${level}`),
       visible: true,
     });
   }

--- a/theme.ts
+++ b/theme.ts
@@ -18,7 +18,7 @@ export interface PowerlineThemeConfig {
   icons?: unknown;
 }
 
-// Default color scheme (uses pi theme colors)
+// Default dark color scheme (uses pi theme colors where possible)
 const DEFAULT_COLORS: Required<ColorScheme> = {
   model: "#d787af",  // Pink/mauve (matching original colors.ts)
   shellMode: "accent",
@@ -38,11 +38,27 @@ const DEFAULT_COLORS: Required<ColorScheme> = {
   border: "borderMuted",
 };
 
+// The original fixed colors are tuned for dark terminals. Pi exposes the active
+// theme name, so keep those colors while using higher-contrast variants for its
+// built-in light theme. Semantic Pi colors already adapt through theme.fg().
+const LIGHT_COLOR_OVERRIDES: ColorScheme = {
+  model: "#8f3f71",
+  path: "#007070",
+};
+
 // Rainbow colors for high thinking levels
-const RAINBOW_COLORS = [
-  "#b281d6", "#d787af", "#febc38", "#e4c00f", 
+const DARK_RAINBOW_COLORS = [
+  "#b281d6", "#d787af", "#febc38", "#e4c00f",
   "#89d281", "#00afaf", "#178fb9", "#b281d6",
 ];
+const LIGHT_RAINBOW_COLORS = [
+  "#6f42c1", "#9b3a6a", "#9a6200", "#7a6500",
+  "#3f7d3a", "#007070", "#176b87", "#6f42c1",
+];
+
+function usesLightPalette(theme?: ThemeLike): boolean {
+  return theme?.name === "light";
+}
 
 // Cache for user theme overrides
 let userThemeCache: ColorScheme | null = null;
@@ -134,14 +150,25 @@ function loadUserTheme(): ColorScheme {
  */
 export function resolveColor(
   semantic: SemanticColor,
-  presetColors?: ColorScheme
+  presetColors?: ColorScheme,
+  theme?: ThemeLike,
 ): ColorValue {
   const userTheme = loadUserTheme();
-  
+  const userColor = userTheme[semantic];
+  if (userColor !== undefined) {
+    return userColor;
+  }
+
+  const presetColor = presetColors?.[semantic];
+  if (
+    usesLightPalette(theme)
+    && (presetColor === undefined || presetColor === DEFAULT_COLORS[semantic])
+  ) {
+    return LIGHT_COLOR_OVERRIDES[semantic] ?? DEFAULT_COLORS[semantic];
+  }
+
   // Priority: user overrides > preset colors > defaults
-  return userTheme[semantic] 
-    ?? presetColors?.[semantic] 
-    ?? DEFAULT_COLORS[semantic];
+  return presetColor ?? DEFAULT_COLORS[semantic];
 }
 
 /**
@@ -198,21 +225,22 @@ export function fg(
   text: string,
   presetColors?: ColorScheme
 ): string {
-  const color = resolveColor(semantic, presetColors);
+  const color = resolveColor(semantic, presetColors, theme);
   return applyColor(theme, color, text);
 }
 
 /**
  * Apply rainbow gradient to text (for high thinking levels)
  */
-export function rainbow(text: string): string {
+export function rainbow(theme: ThemeLike, text: string): string {
+  const colors = usesLightPalette(theme) ? LIGHT_RAINBOW_COLORS : DARK_RAINBOW_COLORS;
   let result = "";
   let colorIndex = 0;
   for (const char of text) {
     if (char === " " || char === ":") {
       result += char;
     } else {
-      result += hexToAnsi(RAINBOW_COLORS[colorIndex % RAINBOW_COLORS.length]) + char;
+      result += hexToAnsi(colors[colorIndex % colors.length]) + char;
       colorIndex++;
     }
   }

--- a/types.ts
+++ b/types.ts
@@ -2,7 +2,7 @@ import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
 
 // Theme color - either a pi theme color name or a custom hex color
 export type ColorValue = ThemeColor | `#${string}`;
-export type ThemeLike = Pick<Theme, "fg">;
+export type ThemeLike = Pick<Theme, "fg"> & Pick<Theme, "name">;
 
 // Semantic color names for segments
 export type SemanticColor =


### PR DESCRIPTION
## What problems was I solving

The footer's original fixed mauve, teal, and rainbow colors were tuned for dark terminals and had weak contrast on Pi's built-in light theme. Separately, fixed-editor users could not hide the scroll-away shortcut card when it covered chat text without also disabling the fixed editor or its navigation shortcuts.

## What user-facing changes did I ship

- [Adaptive footer colors](https://github.com/nicobailon/pi-powerline-footer/pull/100/files#diff-0f20e3f653ae8b0eaade6007f61d4569fd4d723f5139b02daba09217a09c3db5) — model, path, and high-thinking rainbow colors now use higher-contrast variants on Pi's built-in light theme while preserving the existing dark palette and user overrides.
- [Optional scroll-away card](https://github.com/nicobailon/pi-powerline-footer/pull/100/files#diff-8388a8593b02cdd0f017dd22fde22cda1672f6906d96f116d9da1562c9b9809c) — `powerline.scrollAwayCard: false` hides only the shortcut card; fixed-editor scrolling and jump shortcuts remain active.
- [Runtime command](https://github.com/nicobailon/pi-powerline-footer/pull/100/files#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122) — `/powerline scroll-away-card on|off|toggle` updates and persists that preference without requiring manual JSON edits.

## How I implemented it

- [Theme resolution](https://github.com/nicobailon/pi-powerline-footer/pull/100/files#diff-0f20e3f653ae8b0eaade6007f61d4569fd4d723f5139b02daba09217a09c3db5) checks the active Pi theme name only when choosing built-in fixed colors. Explicit `theme.json` colors and preset-specific colors continue to take precedence.
- [Thinking segment rendering](https://github.com/nicobailon/pi-powerline-footer/pull/100/files#diff-1341671d89e40b18b897ead86a04db82eb93a8d2e11980e925327dd70f76fabc) passes the active theme into rainbow rendering so light and dark palettes can differ.
- [Fixed-editor wiring](https://github.com/nicobailon/pi-powerline-footer/pull/100/files#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122) omits only the compositor's navigation-card options when disabled, leaving the compositor and shortcut routing intact.
- [Regression coverage](https://github.com/nicobailon/pi-powerline-footer/pull/100/files#diff-1031e7dac46bebf59fbee472173eae6f690e1a44fbdf697c881fc16ae937602c) verifies light/dark color selection, custom-color precedence, configuration defaults, persistence, and command wiring.

## How to verify it

### Manual testing

- [ ] Start Pi with its built-in light theme and confirm model, path, and high/xhigh thinking text remain readable on the light background.
- [ ] Run `/powerline scroll-away-card off`, scroll chat away from the bottom, and confirm the fixed editor stays pinned while the card remains hidden.
- [ ] Use the existing chat-jump shortcuts while the card is hidden, then run `/powerline scroll-away-card on` and confirm the card returns.

### Automated tests

```bash
npm test
```

178 tests pass.

## Changelog

Improved light-theme footer contrast and added an opt-out for the fixed-editor scroll-away shortcut card.
