### PR TITLE
fix: restrict terminal cleanup to TUI shutdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - **Fixed-editor scrolling performance** — Uses terminal row shifts, cached transcript lines, an 8 ms repaint cadence, and transient shortcut-card hiding during active wheel movement to cut scroll latency and terminal output churn.
 
+### Fixed
+- **Print-mode terminal cleanup** — Terminal reset and cursor restoration sequences run only during interactive TUI shutdowns, keeping `pi -p` output visible. Thanks to Sergey Konkin (@sergeykonkin) for #101.
+
 ## [0.7.0] - 2026-07-14
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -1368,12 +1368,12 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   });
 
-  pi.on("session_shutdown", async (event) => {
-    // When switching sessions or reloading, preserve keyboard modes (Kitty
-    // protocol, modifyOtherKeys) so Shift+Enter and other modified keys keep
-    // working after the next session starts. Only a real quit should hard-reset
-    // the terminal back to plain keyboard mode.
-    const isTerminalExit = shouldResetExtendedKeyboardModesOnShutdown(event?.reason);
+  pi.on("session_shutdown", async (event, ctx) => {
+    // Session switches and reloads preserve keyboard modes (Kitty protocol,
+    // modifyOtherKeys), while non-UI modes must not emit terminal sequences.
+    // In the supported Pi extension API, ctx.hasUI is the available terminal/UI guard.
+    const hasUI = Boolean(ctx.hasUI);
+    const isTerminalExit = shouldResetExtendedKeyboardModesOnShutdown(hasUI, event?.reason);
 
     sessionGeneration++;
     dismissWelcomeOverlay?.();
@@ -1385,7 +1385,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     restoreFooterStatusRepaintHook?.();
     restoreFooterStatusRepaintHook = null;
     const hadFixedEditorCompositor = teardownFixedEditorCompositor(isTerminalExit ? { resetExtendedKeyboardModes: true } : undefined);
-    if (shouldRestoreInlineEditorCursorOnShutdown(event?.reason, config.fixedEditor, hadFixedEditorCompositor)) {
+    if (shouldRestoreInlineEditorCursorOnShutdown(hasUI, event?.reason, config.fixedEditor, hadFixedEditorCompositor)) {
       try {
         process.stdout.write(inlineEditorQuitCursorRestore({
           rows: tuiRef?.terminal?.rows ?? process.stdout.rows,

--- a/lifecycle.ts
+++ b/lifecycle.ts
@@ -2,16 +2,17 @@ export function shouldShowStartupWelcome(reason: unknown, welcomeEnabled: boolea
   return reason === "startup" && welcomeEnabled;
 }
 
-export function shouldResetExtendedKeyboardModesOnShutdown(reason: unknown): boolean {
-  return reason === "quit";
+export function shouldResetExtendedKeyboardModesOnShutdown(hasUI: boolean, reason: unknown): boolean {
+  return hasUI && reason === "quit";
 }
 
 export function shouldRestoreInlineEditorCursorOnShutdown(
+  hasUI: boolean,
   reason: unknown,
   fixedEditorEnabled: boolean,
   hadFixedEditorCompositor: boolean,
 ): boolean {
-  return reason === "quit" && !fixedEditorEnabled && !hadFixedEditorCompositor;
+  return hasUI && reason === "quit" && !fixedEditorEnabled && !hadFixedEditorCompositor;
 }
 
 export function isStaleExtensionContextError(error: unknown): boolean {

--- a/tests/quit-cursor.test.ts
+++ b/tests/quit-cursor.test.ts
@@ -20,14 +20,15 @@ test("inline editor quit cursor restore clamps terminal rows", () => {
   assert.equal(inlineEditorQuitCursorRestore({ rows: 12, cursorRow: 5, previousViewportTop: 1 }), "\x1b[5;1H\x1b[2K\x1b[?25h\n");
 });
 
-test("inline editor cursor restore only runs on real quit without fixed editor cleanup", () => {
-  assert.equal(shouldRestoreInlineEditorCursorOnShutdown("quit", false, false), true);
-  assert.equal(shouldRestoreInlineEditorCursorOnShutdown("reload", false, false), false);
-  assert.equal(shouldRestoreInlineEditorCursorOnShutdown("switch", false, false), false);
-  assert.equal(shouldRestoreInlineEditorCursorOnShutdown("quit", true, false), false);
-  assert.equal(shouldRestoreInlineEditorCursorOnShutdown("quit", false, true), false);
+test("inline editor cursor restore only runs on UI quit without fixed editor cleanup", () => {
+  assert.equal(shouldRestoreInlineEditorCursorOnShutdown(true, "quit", false, false), true);
+  assert.equal(shouldRestoreInlineEditorCursorOnShutdown(true, "reload", false, false), false);
+  assert.equal(shouldRestoreInlineEditorCursorOnShutdown(true, "switch", false, false), false);
+  assert.equal(shouldRestoreInlineEditorCursorOnShutdown(true, "quit", true, false), false);
+  assert.equal(shouldRestoreInlineEditorCursorOnShutdown(true, "quit", false, true), false);
+  assert.equal(shouldRestoreInlineEditorCursorOnShutdown(false, "quit", false, false), false);
 
   assert.match(source, /const hadFixedEditorCompositor = teardownFixedEditorCompositor/);
-  assert.match(source, /shouldRestoreInlineEditorCursorOnShutdown\(event\?\.reason, config\.fixedEditor, hadFixedEditorCompositor\)/);
+  assert.match(source, /shouldRestoreInlineEditorCursorOnShutdown\(hasUI, event\?\.reason, config\.fixedEditor, hadFixedEditorCompositor\)/);
   assert.match(source, /inlineEditorQuitCursorRestore\(\{\n\s+rows: tuiRef\?\.terminal\?\.rows \?\? process\.stdout\.rows,\n\s+cursorRow: tuiRef\?\.cursorRow,\n\s+previousViewportTop: tuiRef\?\.previousViewportTop,/);
 });

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -124,11 +124,14 @@ test("startup welcome predicate respects powerline.welcome false", () => {
   assert.match(source, /setupCustomEditor\(ctx\);\n\s+if \(shouldShowStartupWelcome\(event\.reason, config\.welcome\)\)/);
 });
 
-test("reload preserves extended keyboard modes but quit resets them", () => {
-  assert.equal(shouldResetExtendedKeyboardModesOnShutdown("quit"), true);
-  assert.equal(shouldResetExtendedKeyboardModesOnShutdown("reload"), false);
-  assert.equal(shouldResetExtendedKeyboardModesOnShutdown("resume"), false);
+test("only UI quit resets extended keyboard modes", () => {
+  assert.equal(shouldResetExtendedKeyboardModesOnShutdown(true, "quit"), true);
+  assert.equal(shouldResetExtendedKeyboardModesOnShutdown(true, "reload"), false);
+  assert.equal(shouldResetExtendedKeyboardModesOnShutdown(true, "resume"), false);
+  assert.equal(shouldResetExtendedKeyboardModesOnShutdown(false, "quit"), false);
   assert.doesNotMatch(source, /event\?\.reason === "quit" \|\| event\?\.reason === "reload"/);
+  assert.match(source, /const hasUI = Boolean\(ctx\.hasUI\);/);
+  assert.match(source, /shouldResetExtendedKeyboardModesOnShutdown\(hasUI, event\?\.reason\)/);
   assert.match(source, /teardownFixedEditorCompositor\(isTerminalExit \? \{ resetExtendedKeyboardModes: true \} : undefined\)/);
 });
 


### PR DESCRIPTION
## Bug

`pi-powerline-footer` emits terminal reset sequences when Pi exits print mode.

### Steps to reproduce

1. Enable `pi-powerline-footer`.
2. Run `pi -p "Reply only with OK"` in a terminal.
3. Wait for Pi to print the response and exit.

### Expected behavior

The response remains visible and the shell prompt appears below it.

### Actual behavior

The terminal screen changes immediately after the response is printed, hiding the response. During `session_shutdown`, the extension writes `ESC[?1049l`, which restores the alternate screen buffer.

## Fix implementation

- Pass `ctx.mode` to the terminal-cleanup predicates.
- Reset extended keyboard modes only for a TUI shutdown with reason `quit`.
- Restore the inline-editor cursor only for the same TUI shutdown path.
- Cover print, JSON, RPC, reload, session-switch, and TUI-quit paths in tests.

## Validation

- `npm test` — 174 tests pass.
- `git diff --check`
- A captured `pi -p --no-extensions -e ./index.ts` shutdown emits zero terminal-control bytes on stderr.
