### PR TITLE
feat: pill segment style with seamless color transitions

### DIFF
--- a/fixed-editor/terminal-split.ts
+++ b/fixed-editor/terminal-split.ts
@@ -34,6 +34,13 @@ interface TerminalSplitCompositorOptions {
   mouseScroll?: boolean;
   keyboardScrollShortcuts?: KeyboardScrollShortcuts;
   scrollAwayNavigationCard?: ScrollAwayNavigationCardOptions;
+  /**
+   * Called with editor-text coordinates (visual row/col inside the editor
+   * box) when the user left-clicks inside the editor text area.
+   * Return true to consume the click (e.g. position the text cursor)
+   * instead of starting a text selection.
+   */
+  onEditorTextClick?: (visualRow: number, visualCol: number) => boolean;
   onCopySelection?: (text: string) => void;
   scrollRepaintThrottleMs?: number;
 }
@@ -545,6 +552,7 @@ export class TerminalSplitCompositor {
   private readonly mouseScroll: boolean;
   private readonly keyboardScrollShortcuts: KeyboardScrollShortcuts;
   private readonly scrollAwayNavigationCard: ScrollAwayNavigationCardOptions | null;
+  private readonly onEditorTextClick: ((visualRow: number, visualCol: number) => boolean) | null;
   private readonly onCopySelection: ((text: string) => void) | null;
   private readonly scrollRepaintThrottleMs: number;
   private extendedKeyboardMode: ExtendedKeyboardMode | null = null;
@@ -593,6 +601,7 @@ export class TerminalSplitCompositor {
     this.mouseScroll = options.mouseScroll !== false;
     this.keyboardScrollShortcuts = options.keyboardScrollShortcuts ?? DEFAULT_KEYBOARD_SCROLL_SHORTCUTS;
     this.scrollAwayNavigationCard = options.scrollAwayNavigationCard ?? null;
+    this.onEditorTextClick = options.onEditorTextClick ?? null;
     this.onCopySelection = options.onCopySelection ?? null;
     this.scrollRepaintThrottleMs = Math.max(0, options.scrollRepaintThrottleMs ?? 0);
     this.rowsDescriptor = descriptorForRows(options.terminal);
@@ -931,6 +940,15 @@ export class TerminalSplitCompositor {
     if (!location) return;
 
     if (isLeftPress(packet)) {
+      // Click inside the editor text area: let the host position the text
+      // cursor instead of starting a selection.
+      if (location.area === "cluster") {
+        const editorPoint = this.editorTextLocationForClusterPoint(location.point.line, location.point.col);
+        if (editorPoint && this.onEditorTextClick?.(editorPoint.visualRow, editorPoint.visualCol)) {
+          this.lastLeftPress = null;
+          return;
+        }
+      }
       this.startSelection(location);
       return;
     }
@@ -1075,6 +1093,34 @@ export class TerminalSplitCompositor {
     this.preserveSelectionFocusOnRelease = false;
     this.lastLeftPress = { area: location.area, line, at: now };
     this.requestRender();
+  }
+
+  /**
+   * Map a cluster line/col to editor-text coordinates by locating the
+   * editor box borders in the visible cluster lines. Returns null when the
+   * point is not inside the editor text rows.
+   */
+  private editorTextLocationForClusterPoint(line: number, col: number): { visualRow: number; visualCol: number } | null {
+    if (!this.onEditorTextClick) return null;
+    const lines = this.visibleClusterLines;
+    const stripped = (index: number) => (lines[index] ?? "").replace(/\x1b\[[0-9;]*m/g, "");
+
+    // Editor text columns: " │ " (3) + " ❯ " (3) = text starts at col 6
+    const textCol = col - 6;
+    if (textCol < 0) return null;
+
+    // The clicked row must be a bordered content row
+    if (!/^ │ /.test(stripped(line))) return null;
+
+    // Find the nearest editor top border above the clicked row
+    for (let i = line - 1; i >= 0; i--) {
+      const s = stripped(i);
+      if (/^ ╰─+╯$/.test(s)) return null; // bottom border of a box above: not ours
+      if (/^ ╭─+╮$/.test(s)) {
+        return { visualRow: line - i - 1, visualCol: textCol };
+      }
+    }
+    return null;
   }
 
   private selectionLocationForPacket(packet: SgrMousePacket): SelectionLocation | null {

--- a/git-status.ts
+++ b/git-status.ts
@@ -17,10 +17,13 @@ export type GitPollingMode = "full" | "branch" | "off";
 
 const CACHE_TTL_MS = 1000; // 1 second for file status
 const BRANCH_TTL_MS = 500; // Shorter TTL so branch updates quickly after invalidation
+const REMOTE_TTL_MS = 60_000; // Remote URL almost never changes
 let cachedStatus: CachedGitStatus | null = null;
 let cachedBranch: CachedBranch | null = null;
+let cachedRemote: { url: string | null; timestamp: number } | null = null;
 let pendingFetch: Promise<void> | null = null;
 let pendingBranchFetch: Promise<void> | null = null;
+let pendingRemoteFetch: Promise<void> | null = null;
 let invalidationCounter = 0; // Track invalidations to prevent stale updates
 let branchInvalidationCounter = 0;
 
@@ -151,6 +154,34 @@ export function getCurrentBranch(providerBranch: string | null): string | null {
 }
 
 /**
+ * Whether a git remote URL points at github.com
+ * (handles https and scp-style ssh URLs).
+ */
+export function isGitHubRemoteUrl(url: string | null | undefined): boolean {
+  return !!url && /(^|[@/:.])github\.com[:/]/.test(url);
+}
+
+/**
+ * Get the origin remote URL with long-lived caching (60s TTL).
+ * Used to pick host-specific icons (e.g. GitHub octocat).
+ */
+export function getGitRemoteUrl(): string | null {
+  const now = Date.now();
+  if (cachedRemote && now - cachedRemote.timestamp < REMOTE_TTL_MS) {
+    return cachedRemote.url;
+  }
+
+  if (!pendingRemoteFetch) {
+    pendingRemoteFetch = runGit(["remote", "get-url", "origin"], 300).then((output) => {
+      cachedRemote = { url: output?.trim() || null, timestamp: Date.now() };
+      pendingRemoteFetch = null;
+    });
+  }
+
+  return cachedRemote?.url ?? null;
+}
+
+/**
  * Get git status with caching.
  * Returns cached value if within TTL, otherwise triggers async fetch.
  * This is designed for synchronous render() calls - returns last known value
@@ -205,14 +236,24 @@ export function getGitStatus(providerBranch: string | null, pollingMode: GitPoll
  * Force refresh git status (call when you know files changed)
  */
 export function invalidateGitStatus(): void {
-  cachedStatus = null;
+  // Don't null the cache — just bump the counter to invalidate pending fetches
+  // and let the stale cache serve while the background refresh runs.
+  // This prevents the git segment from flashing invisible during the async fetch.
   invalidationCounter++; // Increment to invalidate any pending fetches
+  if (cachedStatus) {
+    // Force stale: next getGitStatus will trigger a background refresh
+    // but still return this value while waiting
+    cachedStatus = { ...cachedStatus, timestamp: 0 };
+  }
 }
 
 /**
  * Force refresh git branch (call when you know branch might have changed)
  */
 export function invalidateGitBranch(): void {
-  cachedBranch = null;
+  // Same as invalidateGitStatus: serve stale value while refreshing
   branchInvalidationCounter++;
+  if (cachedBranch) {
+    cachedBranch = { ...cachedBranch, timestamp: 0 };
+  }
 }

--- a/icons.ts
+++ b/icons.ts
@@ -61,7 +61,7 @@ export const NERD_ICONS: IconSet = {
   cost: "\uF155",       // nf-fa-dollar
   time: "\uF017",       // nf-fa-clock_o
   agents: "\uF0C0",     // nf-fa-users
-  cache: "\uF1C0",      // nf-fa-database (cache)
+  cache: "\uF0E7",      // nf-fa-bolt (cache hit rate)
   input: "\uF090",      // nf-fa-sign_in (input arrow)
   output: "\uF08B",     // nf-fa-sign_out (output arrow)
   host: "\uF109",       // nf-fa-laptop (host)

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@ import { isKeyRelease, type AutocompleteProvider, type SelectItem, SelectList, t
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 
-import type { ColorScheme, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
+import type { ColorScheme, PowerlineCaps, SegmentContext, StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "./types.ts";
 import type { PowerlineConfig } from "./powerline-config.ts";
 import { BashTranscriptStore } from "./bash-mode/transcript.ts";
 import {
@@ -27,6 +27,7 @@ import { getPreset, PRESETS } from "./presets.ts";
 import { getAgentPath } from "./paths.ts";
 import { collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, mergeSegmentOptions, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, parsePowerlineConfig } from "./powerline-config.ts";
 import { getSeparator } from "./separators.ts";
+import { hasNerdFonts } from "./icons.ts";
 import { renderSegment } from "./segments.ts";
 import { getGitStatus, invalidateGitStatus, invalidateGitBranch } from "./git-status.ts";
 import { ansi, getFgAnsiCode } from "./colors.ts";
@@ -39,7 +40,7 @@ import { isStaleExtensionContextError, shouldResetExtendedKeyboardModesOnShutdow
 import { renderFixedEditorCluster } from "./fixed-editor/cluster.ts";
 import { DEFAULT_SCROLL_REPAINT_THROTTLE_MS, emergencyTerminalModeReset, TerminalSplitCompositor } from "./fixed-editor/terminal-split.ts";
 import { inlineEditorQuitCursorRestore } from "./terminal-cursor.ts";
-import { getDefaultColors } from "./theme.ts";
+import { getDefaultColors, hexToAnsi, hexToBgAnsi, isPillBold, setPillBold, setSettingsColors } from "./theme.ts";
 import {
   isSupportedSuperShortcut,
   matchesConfiguredShortcut,
@@ -76,6 +77,17 @@ let config: PowerlineConfig = {
   layout: null,
   invalidLayoutSegments: [],
   segmentOptions: {},
+  segmentStyle: "fg",
+  separator: null,
+  caps: "round",
+  pillTextColor: "dark",
+  pillBold: true,
+  promptColor: "#cba6f7",
+  highlightBashCall: true,
+  scrollNavCard: false,
+  editorCursorBlink: true,
+  editorClickCursor: true,
+  colors: {},
   mouseScroll: true,
   fixedEditor: true,
   placement: "above",
@@ -951,16 +963,131 @@ function renderSegmentWithWidth(
   return { content: rendered.content, width: visibleWidth(rendered.content), visible: true };
 }
 
+/** Extract background RGB from a pill segment's ANSI content. Returns [r,g,b] or null. */
+function extractBgRgb(content: string): [number, number, number] | null {
+  const match = content.match(/^\x1b\[48;2;(\d+);(\d+);(\d+)m/);
+  if (!match) return null;
+  return [parseInt(match[1]), parseInt(match[2]), parseInt(match[3])];
+}
+
+/** Neutral background for segments that render fg-only content (e.g. rainbow thinking) */
+const NEUTRAL_PILL_BG = "#45475a"; // Catppuccin surface1
+
+/** Wrap a segment that produced no background in a neutral pill so the bar stays seamless. */
+export function ensurePillBg(content: string): string {
+  if (extractBgRgb(content)) return content;
+  const stripped = content.replace(/\x1b\[0m$/, "");
+  const bold = isPillBold() ? "\x1b[1m" : "";
+  return `${hexToBgAnsi(NEUTRAL_PILL_BG)}${bold} ${stripped} \x1b[0m`;
+}
+
+/**
+ * Convert a display column inside a logical line to a string index,
+ * walking graphemes from `fromIndex` and accumulating display widths.
+ */
+export function displayColumnToStringIndex(line: string, fromIndex: number, targetCol: number): number {
+  let col = 0;
+  let i = Math.max(0, Math.min(fromIndex, line.length));
+  while (i < line.length && col < targetCol) {
+    const cp = line.codePointAt(i) ?? 0;
+    const ch = String.fromCodePoint(cp);
+    col += Math.max(1, visibleWidth(ch));
+    i += ch.length;
+  }
+  return i;
+}
+
+/**
+ * Make the editor's software cursor blink: the pi-tui editor draws the
+ * cursor as reverse video (\x1b[7m); add SGR blink on top. Terminals
+ * without blink support degrade to the original reverse block.
+ */
+export function applyEditorCursorBlink(line: string): string {
+  return line.replace(/\x1b\[7m([\s\S]{1,2}?)\x1b\[0m/g, "\x1b[5;7m$1\x1b[0m");
+}
+
+/**
+ * Resolve which separator style to use.
+ * Explicit settings.json "separator" wins; pill mode needs solid powerline
+ * arrows for the color transitions, so it defaults to "powerline" instead of
+ * the preset's (often thin) separator.
+ */
+export function resolveSeparatorStyle(
+  presetDef: ReturnType<typeof getPreset>,
+  segmentStyle: "fg" | "pill",
+  configured: StatusLineSeparatorStyle | null = config.separator
+): StatusLineSeparatorStyle {
+  if (configured) return configured;
+  if (segmentStyle === "pill") return "powerline";
+  return presetDef.separator;
+}
+
+const ROUND_LEFT_CAP = "\uE0B6";  //  rounded bar start
+const ROUND_RIGHT_CAP = "\uE0B4"; //  rounded bar end
+
+/** Round caps need Nerd Font glyphs; without them fall back to flat ends. */
+function effectiveCaps(caps: PowerlineCaps): PowerlineCaps {
+  return caps === "round" && !hasNerdFonts() ? "flat" : caps;
+}
+
 /** Build content string from pre-rendered parts */
-function buildContentFromParts(
+export function buildContentFromParts(
   parts: string[],
-  presetDef: ReturnType<typeof getPreset>
+  separatorStyle: StatusLineSeparatorStyle,
+  segmentStyle: "fg" | "pill" = "fg",
+  caps: PowerlineCaps = "flat"
 ): string {
   if (parts.length === 0) return "";
-  const separatorDef = getSeparator(presetDef.separator);
-  const sepAnsi = getFgAnsiCode("sep");
+  const separatorDef = getSeparator(separatorStyle);
   const sep = separatorDef.left;
-  return " " + parts.join(` ${sepAnsi}${sep}${ansi.reset} `) + ansi.reset + " ";
+
+  // Original behavior: dim separator between segments
+  if (segmentStyle !== "pill") {
+    const sepAnsi = getFgAnsiCode("sep");
+    return " " + parts.join(` ${sepAnsi}${sep}${ansi.reset} `) + ansi.reset + " ";
+  }
+
+  // Pill mode: seamless powerline bar (starship style).
+  // Every segment must carry a background (fg-only segments get a neutral one),
+  // and each transition arrow gets bg=next pill color, fg=current pill color.
+  const pills = parts.map(ensurePillBg);
+  const bgRgbs = pills.map((p) => extractBgRgb(p) as [number, number, number]);
+  const capsStyle = effectiveCaps(caps);
+
+  // Start from a clean slate so no background/attribute leaks into the bar
+  let result = "\x1b[0m ";
+
+  // Left cap: rounded start in the first pill's color (bg is terminal default here)
+  if (capsStyle === "round") {
+    result += `\x1b[38;2;${bgRgbs[0].join(";")}m${ROUND_LEFT_CAP}`;
+  }
+
+  for (let i = 0; i < pills.length; i++) {
+    // Strip trailing reset so the transition ANSI can chain directly
+    result += pills[i].replace(/\x1b\[0m$/, "");
+
+    if (i < pills.length - 1) {
+      const curRgb = bgRgbs[i];
+      const nextRgb = bgRgbs[i + 1];
+      result += `\x1b[48;2;${nextRgb.join(";")}m\x1b[38;2;${curRgb.join(";")}m${sep}`;
+    }
+  }
+
+  // Right cap: rounded end, or closing arrow for powerline separators.
+  // The last pill's bg is still active at this point — reset it to the default
+  // background (\x1b[49m) first or the cap would be drawn fg-on-same-bg (invisible).
+  const lastRgb = bgRgbs[bgRgbs.length - 1];
+  if (capsStyle === "round") {
+    result += `\x1b[49m\x1b[38;2;${lastRgb.join(";")}m${ROUND_RIGHT_CAP}`;
+  } else if (
+    capsStyle === "arrow" &&
+    (separatorStyle === "powerline" || separatorStyle === "powerline-thin")
+  ) {
+    result += `\x1b[49m\x1b[38;2;${lastRgb.join(";")}m${sep}`;
+  }
+
+  result += ansi.reset + " ";
+  return result;
 }
 
 /**
@@ -973,8 +1100,11 @@ function computeResponsiveLayout(
   presetDef: ReturnType<typeof getPreset>,
   availableWidth: number
 ): { topContent: string; secondaryContent: string } {
-  const separatorDef = getSeparator(presetDef.separator);
-  const sepWidth = visibleWidth(separatorDef.left) + 2; // separator + spaces around it
+  const separatorStyle = resolveSeparatorStyle(presetDef, ctx.segmentStyle);
+  const separatorDef = getSeparator(separatorStyle);
+  const capsStyle = ctx.segmentStyle === "pill" ? effectiveCaps(config.caps) : "flat";
+  // fg mode pads separators with spaces; pill transitions are flush
+  const sepWidth = visibleWidth(separatorDef.left) + (ctx.segmentStyle === "pill" ? 0 : 2);
   
   // Get all segments: primary first, then secondary
   const mergedSegments = mergeSegmentsWithCustomItems(presetDef, config.customItems, {
@@ -999,8 +1129,9 @@ function computeResponsiveLayout(
   }
   
   // Calculate how many segments fit in top bar
-  // Account for: leading space (1) + trailing space (1) = 2 chars overhead
-  const baseOverhead = 2;
+  // Overhead: leading + trailing space (2) plus end caps (round: 2, arrow: 1)
+  const capsWidth = capsStyle === "round" ? 2 : capsStyle === "arrow" ? 1 : 0;
+  const baseOverhead = 2 + (ctx.segmentStyle === "pill" ? capsWidth : 0);
   let currentWidth = baseOverhead;
   let topSegments: string[] = [];
   let overflowSegments: { content: string; width: number }[] = [];
@@ -1034,8 +1165,8 @@ function computeResponsiveLayout(
   }
   
   return {
-    topContent: buildContentFromParts(topSegments, presetDef),
-    secondaryContent: buildContentFromParts(secondarySegments, presetDef),
+    topContent: buildContentFromParts(topSegments, separatorStyle, ctx.segmentStyle, capsStyle),
+    secondaryContent: buildContentFromParts(secondarySegments, separatorStyle, ctx.segmentStyle, capsStyle),
   };
 }
 
@@ -1068,6 +1199,10 @@ function warnInvalidSegmentSettings(ctx: any): void {
 export default function powerlineFooter(pi: ExtensionAPI) {
   const startupSettings = readSettings();
   config = parsePowerlineConfig(startupSettings.powerline, PRESET_NAMES);
+  setSettingsColors(config.colors);
+  setPillBold(config.pillBold);
+  if (config.highlightBashCall) {
+  }
   let resolvedShortcuts = resolveShortcutConfig(startupSettings);
   let bashModeSettings = parseBashModeSettings(startupSettings, resolvedShortcuts);
 
@@ -1130,6 +1265,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   const resetLayoutCache = () => {
     lastLayoutResult = null;
     layoutDirty = true;
+    cachedTokenStats = null;
   };
 
   const requestStatusRender = (delayMs?: number) => {
@@ -1335,6 +1471,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     bashModeSettings = parseBashModeSettings(settings, resolvedShortcuts);
     showLastPrompt = settings.showLastPrompt !== false;
     config = parsePowerlineConfig(settings.powerline, PRESET_NAMES);
+    setSettingsColors(config.colors);
+    setPillBold(config.pillBold);
     warnInvalidSegmentSettings(ctx);
     stashedPromptHistory = readPersistedStashHistory();
     bashModeActive = false;
@@ -2154,6 +2292,19 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     },
   });
 
+  // Cache for token counting: avoid re-scanning the full session event list
+  // on every render (250ms-1s cadence). Only recompute when the event count changes.
+  let cachedTokenStats: {
+    eventCount: number;
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    cost: number;
+    lastAssistant: AssistantMessage | undefined;
+    thinkingLevelFromSession: string | null;
+  } | null = null;
+
   function buildSegmentContext(ctx: any, theme: Theme): SegmentContext {
     const presetDef = getPreset(config.preset);
     const colors: ColorScheme = presetDef.colors ?? getDefaultColors();
@@ -2164,32 +2315,46 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     let thinkingLevelFromSession: string | null = null;
     
     const sessionEvents = ctx.sessionManager?.getBranch?.() ?? [];
-    for (const e of sessionEvents) {
-      if (!isRecord(e)) {
-        continue;
-      }
+    const eventCount = sessionEvents.length;
 
-      // Check for thinking level change entries
-      if (e.type === "thinking_level_change" && typeof e.thinkingLevel === "string") {
-        thinkingLevelFromSession = e.thinkingLevel;
-      }
+    // Reuse cached token totals when session hasn't grown
+    if (cachedTokenStats && cachedTokenStats.eventCount === eventCount) {
+      input = cachedTokenStats.input;
+      output = cachedTokenStats.output;
+      cacheRead = cachedTokenStats.cacheRead;
+      cacheWrite = cachedTokenStats.cacheWrite;
+      cost = cachedTokenStats.cost;
+      lastAssistant = cachedTokenStats.lastAssistant;
+      thinkingLevelFromSession = cachedTokenStats.thinkingLevelFromSession;
+    } else {
+      for (const e of sessionEvents) {
+        if (!isRecord(e)) {
+          continue;
+        }
 
-      if (e.type !== "message" || !isSessionAssistantMessage(e.message)) {
-        continue;
-      }
+        // Check for thinking level change entries
+        if (e.type === "thinking_level_change" && typeof e.thinkingLevel === "string") {
+          thinkingLevelFromSession = e.thinkingLevel;
+        }
 
-      const m = e.message;
-      if (m.stopReason === "error" || m.stopReason === "aborted") {
-        continue;
+        if (e.type !== "message" || !isSessionAssistantMessage(e.message)) {
+          continue;
+        }
+
+        const m = e.message;
+        if (m.stopReason === "error" || m.stopReason === "aborted") {
+          continue;
+        }
+        input += m.usage.input;
+        output += m.usage.output;
+        cacheRead += m.usage.cacheRead;
+        cacheWrite += m.usage.cacheWrite;
+        cost += m.usage.cost.total;
+        if (getUsageTokenTotal(m.usage) > 0) {
+          lastAssistant = m;
+        }
       }
-      input += m.usage.input;
-      output += m.usage.output;
-      cacheRead += m.usage.cacheRead;
-      cacheWrite += m.usage.cacheWrite;
-      cost += m.usage.cost.total;
-      if (getUsageTokenTotal(m.usage) > 0) {
-        lastAssistant = m;
-      }
+      cachedTokenStats = { eventCount, input, output, cacheRead, cacheWrite, cost, lastAssistant, thinkingLevelFromSession };
     }
 
     // Calculate context percentage.
@@ -2239,6 +2404,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       options: segmentOptions,
       theme,
       colors,
+      segmentStyle: config.segmentStyle ?? "fg",
+      pillTextColor: config.pillTextColor,
     };
   }
 
@@ -2394,6 +2561,35 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   }
 
   function installFixedEditorCompositor(ctx: any, tui: any) {
+    /**
+     * Position the editor text cursor from editor-text coordinates
+     * (click-to-position inside the editor box). Uses the pi-tui editor's
+     * runtime state; returns false to let the click fall back to selection.
+     */
+    function positionEditorCursorAt(visualRow: number, visualCol: number): boolean {
+      if (!config.editorClickCursor) return false;
+      const editor: any = currentEditor;
+      if (!editor?.state || typeof editor.buildVisualLineMap !== "function") return false;
+      try {
+        const width = Math.max(1, editor.lastWidth ?? 80);
+        const visualLines = editor.buildVisualLineMap(width) as Array<{ logicalLine: number; startCol: number; length: number }>;
+        const row = visualRow + (editor.scrollOffset ?? 0);
+        if (row < 0 || row >= visualLines.length) return false;
+        const vl = visualLines[row]!;
+        const text: string = editor.state.lines[vl.logicalLine] ?? "";
+        const index = displayColumnToStringIndex(text, vl.startCol, visualCol);
+        editor.state.cursorLine = vl.logicalLine;
+        editor.state.cursorCol = Math.max(vl.startCol, Math.min(index, vl.startCol + vl.length));
+        editor.preferredVisualCol = null;
+        editor.snappedFromCursorCol = null;
+        if (typeof tui.requestRender === "function") tui.requestRender();
+        return true;
+      } catch (error) {
+        console.debug("[powerline-footer] editor click cursor failed:", error);
+        return false;
+      }
+    }
+
     teardownFixedEditorCompositor();
 
     if (!ctx.hasUI || !config.fixedEditor) return;
@@ -2441,16 +2637,19 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         down: resolvedShortcuts.scrollChatDown,
       },
       scrollRepaintThrottleMs: DEFAULT_SCROLL_REPAINT_THROTTLE_MS,
-      scrollAwayNavigationCard: {
-        shortcuts: [
-          scrollAwayShortcutEntry("bottom", resolvedShortcuts.jumpChatBottom),
-          scrollAwayShortcutEntry("previousUser", resolvedShortcuts.jumpPreviousUserMessage),
-          scrollAwayShortcutEntry("nextUser", resolvedShortcuts.jumpNextUserMessage),
-          scrollAwayShortcutEntry("previousAssistant", resolvedShortcuts.jumpPreviousLlmMessage),
-          scrollAwayShortcutEntry("nextAssistant", resolvedShortcuts.jumpNextLlmMessage),
-        ].filter((shortcut): shortcut is { id: ScrollAwayShortcutId; shortcutLabel: string } => shortcut !== null),
-        onClickBottom: resolvedShortcuts.jumpChatBottom ? () => jumpChatToBottom(ctx) : undefined,
-      },
+      scrollAwayNavigationCard: config.scrollNavCard
+        ? {
+            shortcuts: [
+              scrollAwayShortcutEntry("bottom", resolvedShortcuts.jumpChatBottom),
+              scrollAwayShortcutEntry("previousUser", resolvedShortcuts.jumpPreviousUserMessage),
+              scrollAwayShortcutEntry("nextUser", resolvedShortcuts.jumpNextUserMessage),
+              scrollAwayShortcutEntry("previousAssistant", resolvedShortcuts.jumpPreviousLlmMessage),
+              scrollAwayShortcutEntry("nextAssistant", resolvedShortcuts.jumpNextLlmMessage),
+            ].filter((shortcut): shortcut is { id: ScrollAwayShortcutId; shortcutLabel: string } => shortcut !== null),
+            onClickBottom: resolvedShortcuts.jumpChatBottom ? () => jumpChatToBottom(ctx) : undefined,
+          }
+        : undefined,
+      onEditorTextClick: (visualRow, visualCol) => positionEditorCursorAt(visualRow, visualCol),
       onCopySelection: (text) => copyTextToClipboard(ctx, text),
       getShowHardwareCursor: () => typeof tui.getShowHardwareCursor === "function" && tui.getShowHardwareCursor(),
       renderCluster: (width, terminalRows) => {
@@ -2803,16 +3002,18 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           return originalRender(width);
         }
 
+        // Border and prompt styling
         const bc = (s: string) => `${getFgAnsiCode("sep")}${s}${ansi.reset}`;
-        const promptGlyph = bashModeActive ? "$" : ">";
-        const prompt = `${ansi.getFgAnsi(200, 200, 200)}${promptGlyph}${ansi.reset}`;
-        const promptPrefix = ` ${prompt} `;
-        const contPrefix = "   ";
-        const contentWidth = Math.max(1, width - 3);
+        const accent = (s: string) => `${hexToAnsi(config.promptColor)}${s}${ansi.reset}`;
+        const promptGlyph = bashModeActive ? "$" : "❯";
+        const prompt = accent(promptGlyph);
+        const barW = Math.max(1, width - 4); // width for "─" between corners
+        const contentWidth = Math.max(1, width - 9); // " │ " (3) + " ❯ " (3) + " │" (2) = 8, +1 safe
         const lines = originalRender(contentWidth);
 
         if (lines.length === 0) return lines;
 
+        // Find the bottom border from original render (─ line)
         let bottomBorderIndex = lines.length - 1;
         for (let i = lines.length - 1; i >= 1; i--) {
           const stripped = lines[i]?.replace(/\x1b\[[0-9;]*m/g, "") || "";
@@ -2823,21 +3024,36 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         }
 
         const result: string[] = [];
-        result.push(" " + bc("─".repeat(width - 2)));
+        // Top border: ╭───╮
+        result.push(` ${bc("╭")}${bc("─".repeat(barW))}${bc("╮")}`);
 
+        // Content with side borders
         for (let i = 1; i < bottomBorderIndex; i++) {
-          const prefix = i === 1 ? promptPrefix : contPrefix;
-          result.push(`${prefix}${lines[i] || ""}`);
+          const isPrompt = i === 1;
+          const prefix = isPrompt ? ` ${prompt} ` : "   ";
+          const line = prefix + (lines[i] || "");
+          result.push(` ${bc("│")} ${line} ${bc("│")}`);
         }
 
+        // Empty prompt line if no content yet
         if (bottomBorderIndex === 1) {
-          result.push(`${promptPrefix}${" ".repeat(contentWidth)}`);
+          const pad = Math.max(0, width - 9);
+          result.push(` ${bc("│")} ${prompt} ${" ".repeat(pad)}${bc("│")}`);
         }
 
-        result.push(" " + bc("─".repeat(width - 2)));
+        // Bottom border: ╰───╯
+        result.push(` ${bc("╰")}${bc("─".repeat(barW))}${bc("╯")}`);
 
+        // Ghost suggestions / lines after border
         for (let i = bottomBorderIndex + 1; i < lines.length; i++) {
           result.push(lines[i] || "");
+        }
+
+        // Make the software cursor blink (reverse block → blinking reverse block)
+        if (config.editorCursorBlink) {
+          for (let i = 0; i < result.length; i++) {
+            result[i] = applyEditorCursorBlink(result[i] ?? "");
+          }
         }
 
         return result;

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,6 +1,7 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { BUILTIN_STATUS_LINE_SEGMENT_IDS } from "./types.ts";
-import type { ColorValue, CustomItemPosition, CustomStatusItem, PowerlinePlacement, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions } from "./types.ts";
+import { sanitizeColorOverrides } from "./theme.ts";
+import type { ColorScheme, ColorValue, CustomItemPosition, CustomStatusItem, PillTextColor, PowerlineCaps, PowerlinePlacement, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions, StatusLineSeparatorStyle } from "./types.ts";
 
 export interface PowerlineConfig {
   preset: StatusLinePreset;
@@ -10,6 +11,17 @@ export interface PowerlineConfig {
   layout: StatusLineLayout | null;
   invalidLayoutSegments: string[];
   segmentOptions: StatusLineSegmentOptions;
+  segmentStyle: "fg" | "pill";
+  separator: StatusLineSeparatorStyle | null;
+  caps: PowerlineCaps;
+  pillTextColor: PillTextColor;
+  pillBold: boolean;
+  promptColor: `#${string}`;
+  highlightBashCall: boolean;
+  scrollNavCard: boolean;
+  editorCursorBlink: boolean;
+  editorClickCursor: boolean;
+  colors: ColorScheme;
   mouseScroll: boolean;
   fixedEditor: boolean;
   placement: PowerlinePlacement;
@@ -26,6 +38,47 @@ function normalizePreset(value: unknown, presets: readonly StatusLinePreset[]): 
   if (typeof value !== "string") return null;
   const normalized = value.trim().toLowerCase();
   return (presets as readonly string[]).includes(normalized) ? (normalized as StatusLinePreset) : null;
+}
+
+const SEPARATOR_STYLES: readonly StatusLineSeparatorStyle[] = [
+  "powerline",
+  "powerline-thin",
+  "slash",
+  "pipe",
+  "block",
+  "none",
+  "ascii",
+  "dot",
+  "chevron",
+  "star",
+];
+
+function normalizeSeparator(value: unknown): StatusLineSeparatorStyle | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return (SEPARATOR_STYLES as readonly string[]).includes(normalized)
+    ? (normalized as StatusLineSeparatorStyle)
+    : null;
+}
+
+function normalizeCaps(value: unknown): PowerlineCaps {
+  if (value === "round" || value === "arrow" || value === "flat") return value;
+  return "round";
+}
+
+function normalizePillTextColor(value: unknown): PillTextColor {
+  if (value === "dark" || value === "light" || value === "contrast") return value;
+  if (typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value.trim())) {
+    return value.trim() as PillTextColor;
+  }
+  return "dark";
+}
+
+function normalizeHexColor(value: unknown, fallback: `#${string}`): `#${string}` {
+  if (typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value.trim())) {
+    return value.trim() as `#${string}`;
+  }
+  return fallback;
 }
 
 function normalizePlacement(value: unknown): { placement: PowerlinePlacement; invalidPlacement: string | null } {
@@ -232,6 +285,11 @@ function normalizeSegmentOptions(raw: Record<string, unknown>): StatusLineSegmen
     };
   }
 
+  if (isRecord(raw.context)
+    && (raw.context.format === "full" || raw.context.format === "percent")) {
+    options.context = { format: raw.context.format };
+  }
+
   return options;
 }
 
@@ -247,6 +305,9 @@ export function mergeSegmentOptions(
     git: { ...defaults.git, ...overrides.git },
     time: { ...defaults.time, ...overrides.time },
     cost: { ...defaults.cost, ...overrides.cost },
+    ...(defaults.context || overrides.context
+      ? { context: { ...defaults.context, ...overrides.context } }
+      : {}),
   };
 }
 
@@ -259,6 +320,17 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     layout: null,
     invalidLayoutSegments: [],
     segmentOptions: {},
+    segmentStyle: "fg",
+    separator: null,
+    caps: "round",
+    pillTextColor: "dark",
+    pillBold: true,
+    promptColor: "#cba6f7",
+    highlightBashCall: true,
+    scrollNavCard: false,
+    editorCursorBlink: true,
+    editorClickCursor: true,
+    colors: {},
     mouseScroll: true,
     fixedEditor: true,
     placement: "above",
@@ -285,6 +357,17 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     layout,
     invalidLayoutSegments,
     segmentOptions: normalizeSegmentOptions(value),
+    segmentStyle: value.segmentStyle === "pill" ? "pill" : "fg",
+    separator: normalizeSeparator(value.separator),
+    caps: normalizeCaps(value.caps),
+    pillTextColor: normalizePillTextColor(value.pillTextColor),
+    pillBold: value.pillBold !== false,
+    promptColor: normalizeHexColor(value.promptColor, "#cba6f7"),
+    highlightBashCall: value.highlightBashCall !== false,
+    scrollNavCard: value.scrollNavCard === true,
+    editorCursorBlink: value.editorCursorBlink !== false,
+    editorClickCursor: value.editorClickCursor !== false,
+    colors: sanitizeColorOverrides(value.colors),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,
     placement,

--- a/segments.ts
+++ b/segments.ts
@@ -3,10 +3,14 @@ import { basename } from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import type { BuiltinStatusLineSegmentId, RenderedSegment, SegmentContext, SemanticColor, StatusLineSegment, StatusLineSegmentId } from "./types.ts";
 import { normalizeCompactExtensionStatus, normalizeExtensionStatusValue } from "./powerline-config.ts";
-import { fg, rainbow, applyColor } from "./theme.ts";
+import { getGitRemoteUrl, isGitHubRemoteUrl } from "./git-status.ts";
+import { fg, bg, rainbow, applyColor, applyBgColor } from "./theme.ts";
 import { getIcons, SEP_DOT, getThinkingText } from "./icons.ts";
 
 function color(ctx: SegmentContext, semantic: SemanticColor, text: string): string {
+  if (ctx.segmentStyle === "pill") {
+    return bg(ctx.theme, semantic, text, ctx.colors, ctx.pillTextColor);
+  }
   return fg(ctx.theme, semantic, text, ctx.colors);
 }
 
@@ -127,6 +131,8 @@ const pathSegment: StatusLineSegment = {
   },
 };
 
+const GITHUB_ICON = "\uF09B"; // nf-fa-github (octocat)
+
 const gitSegment: StatusLineSegment = {
   id: "git",
   render(ctx) {
@@ -142,15 +148,50 @@ const gitSegment: StatusLineSegment = {
     const isDirty = gitStatus && (gitStatus.staged > 0 || gitStatus.unstaged > 0 || gitStatus.untracked > 0);
     const showBranch = opts.showBranch !== false;
     const branchColor: SemanticColor = isDirty ? "gitDirty" : "gitClean";
+    const isPill = ctx.segmentStyle === "pill";
 
-    // Build content - color branch separately from indicators
-    let content = "";
+    // Host-specific icon: GitHub octocat when the origin remote is github.com
+    const branchIcon = isGitHubRemoteUrl(getGitRemoteUrl()) ? GITHUB_ICON : icons.branch;
+
+    // Build text content (without pill wrap first)
+    let text = "";
     if (showBranch && branch) {
-      // Color just the branch name (icon + branch text)
-      content = color(ctx, branchColor, withIcon(icons.branch, branch));
+      text = withIcon(branchIcon, branch);
     }
 
-    // Add status indicators (each with their own color, not wrapped)
+    // Build indicator parts (fg-only for pill, full wrap for fg mode)
+    if (gitStatus) {
+      const indicators: string[] = [];
+      if (opts.showUnstaged !== false && gitStatus.unstaged > 0) {
+        const part = `*${gitStatus.unstaged}`;
+        indicators.push(isPill ? part : applyColor(ctx.theme, "warning", part));
+      }
+      if (opts.showStaged !== false && gitStatus.staged > 0) {
+        const part = `+${gitStatus.staged}`;
+        indicators.push(isPill ? part : applyColor(ctx.theme, "success", part));
+      }
+      if (opts.showUntracked !== false && gitStatus.untracked > 0) {
+        const part = `?${gitStatus.untracked}`;
+        indicators.push(isPill ? part : applyColor(ctx.theme, "muted", part));
+      }
+      if (indicators.length > 0) {
+        const indicatorText = indicators.join(" ");
+        text = text ? `${text} ${indicatorText}` : indicatorText;
+      }
+    }
+
+    if (!text) return { content: "", visible: false };
+
+    // In pill mode, wrap entire segment in one background pill
+    if (isPill) {
+      return { content: color(ctx, branchColor, text), visible: true };
+    }
+
+    // Fg mode: branch and indicators colored separately
+    let content = "";
+    if (showBranch && branch) {
+      content = color(ctx, branchColor, withIcon(branchIcon, branch));
+    }
     if (gitStatus) {
       const indicators: string[] = [];
       if (opts.showUnstaged !== false && gitStatus.unstaged > 0) {
@@ -165,15 +206,12 @@ const gitSegment: StatusLineSegment = {
       if (indicators.length > 0) {
         const indicatorText = indicators.join(" ");
         if (!content && showBranch === false) {
-          // No branch shown, color the git icon with branch color
           content = color(ctx, branchColor, icons.git ? `${icons.git} ` : "") + indicatorText;
         } else {
           content += content ? ` ${indicatorText}` : indicatorText;
         }
       }
     }
-
-    if (!content) return { content: "", visible: false };
 
     return { content, visible: true };
   },
@@ -297,17 +335,33 @@ const contextPctSegment: StatusLineSegment = {
     const icons = getIcons();
     const { contextTokens, contextPercent, contextWindow } = ctx;
 
-    const autoIcon = ctx.autoCompactEnabled && icons.auto ? ` ${icons.auto}` : "";
-    const text = `${formatTokens(contextTokens)}/${formatTokens(contextWindow)} (${contextPercent.toFixed(1)}%)${autoIcon}`;
+    // "percent" format (default): bare rounded percentage, no icons
+    const percentOnly = (ctx.options.context?.format ?? "percent") === "percent";
+    const autoIcon = !percentOnly && ctx.autoCompactEnabled && icons.auto ? ` ${icons.auto}` : "";
+    const text = percentOnly
+      ? `${Math.round(contextPercent)}%`
+      : `${formatTokens(contextTokens)}/${formatTokens(contextWindow)} (${contextPercent.toFixed(1)}%)${autoIcon}`;
 
     // Icon outside color, text inside - use semantic colors for thresholds
+    // In pill mode, wrap icon+text together so icon is inside the pill
     let content: string;
-    if (contextPercent > 90) {
-      content = withIcon(icons.context, color(ctx, "contextError", text));
-    } else if (contextPercent > 70) {
-      content = withIcon(icons.context, color(ctx, "contextWarn", text));
+    if (ctx.segmentStyle === "pill") {
+      const body = percentOnly ? text : withIcon(icons.context, text);
+      if (contextPercent > 90) {
+        content = color(ctx, "contextError", body);
+      } else if (contextPercent > 70) {
+        content = color(ctx, "contextWarn", body);
+      } else {
+        content = color(ctx, "context", body);
+      }
     } else {
-      content = withIcon(icons.context, color(ctx, "context", text));
+      if (contextPercent > 90) {
+        content = percentOnly ? color(ctx, "contextError", text) : withIcon(icons.context, color(ctx, "contextError", text));
+      } else if (contextPercent > 70) {
+        content = percentOnly ? color(ctx, "contextWarn", text) : withIcon(icons.context, color(ctx, "contextWarn", text));
+      } else {
+        content = percentOnly ? color(ctx, "context", text) : withIcon(icons.context, color(ctx, "context", text));
+      }
     }
 
     return { content, visible: true };
@@ -390,11 +444,14 @@ const cacheReadSegment: StatusLineSegment = {
   id: "cache_read",
   render(ctx) {
     const icons = getIcons();
-    const { cacheRead } = ctx.usageStats;
+    const { cacheRead, input } = ctx.usageStats;
     if (!cacheRead) return { content: "", visible: false };
 
-    const parts = [icons.cache, icons.input, formatTokens(cacheRead)].filter(Boolean);
-    const content = parts.join(" ");
+    // Show cache hit rate: cacheRead / (input + cacheRead)
+    const hitRate = input + cacheRead > 0
+      ? ((cacheRead / (input + cacheRead)) * 100).toFixed(0)
+      : "0";
+    const content = `${icons.cache} ${hitRate}%`;
     return { content: color(ctx, "tokens", content), visible: true };
   },
 };
@@ -477,11 +534,22 @@ function renderCustomSegment(id: `custom:${string}`, ctx: SegmentContext): Rende
   }
 
   let content = normalizedStatus;
+  // In pill mode, strip ANSI resets, bg codes, and fg codes from extension
+  // content so the pill's own background and text color are not broken
+  if (ctx.segmentStyle === "pill") {
+    content = content
+      .replace(/\x1b\[0m/g, "")
+      .replace(/\x1b\[48;[0-9;]*m/g, "")
+      .replace(/\x1b\[38;[0-9;]*m/g, "")
+      .replace(/\x1b\[(?:3[0-9]|9[0-7])m/g, "");
+  }
   if (custom.prefix) {
     content = `${custom.prefix}${SEP_DOT}${content}`;
   }
   if (custom.color) {
-    content = applyColor(ctx.theme, custom.color, content);
+    content = ctx.segmentStyle === "pill"
+      ? applyBgColor(ctx.theme, custom.color, content, ctx.pillTextColor)
+      : applyColor(ctx.theme, custom.color, content);
   }
 
   return { content, visible: true };

--- a/tests/context-git-display.test.ts
+++ b/tests/context-git-display.test.ts
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isGitHubRemoteUrl } from "../git-status.ts";
+import { renderSegment } from "../segments.ts";
+import { parsePowerlineConfig, mergeSegmentOptions } from "../powerline-config.ts";
+import { PRESETS } from "../presets.ts";
+import type { SegmentContext } from "../types.ts";
+
+const PRESET_NAMES = Object.keys(PRESETS) as Array<keyof typeof PRESETS>;
+
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function createCtx(overrides: Partial<SegmentContext> = {}): SegmentContext {
+  return {
+    model: { id: "k3", name: "Kimi K3" },
+    thinkingLevel: "off",
+    sessionId: undefined,
+    cwd: "/tmp/project",
+    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+    contextTokens: 296_000,
+    contextPercent: 28.2,
+    contextWindow: 1_000_000,
+    autoCompactEnabled: true,
+    customCompactionEnabled: false,
+    usingSubscription: false,
+    sessionStartTime: Date.now(),
+    shellModeActive: false,
+    shellRunning: false,
+    shellName: null,
+    shellCwd: null,
+    git: { branch: "main", staged: 0, unstaged: 0, untracked: 0 },
+    extensionStatuses: new Map(),
+    hiddenExtensionStatusKeys: new Set(),
+    customItemsById: new Map(),
+    options: {},
+    theme: { fg: (_c: string, t: string) => t },
+    colors: {},
+    segmentStyle: "fg",
+    ...overrides,
+  };
+}
+
+test("isGitHubRemoteUrl matches https and ssh remotes only", () => {
+  assert.equal(isGitHubRemoteUrl("https://github.com/andy/repo.git"), true);
+  assert.equal(isGitHubRemoteUrl("git@github.com:andy/repo.git"), true);
+  assert.equal(isGitHubRemoteUrl("ssh://git@github.com/andy/repo.git"), true);
+  assert.equal(isGitHubRemoteUrl("https://gitlab.com/andy/repo.git"), false);
+  assert.equal(isGitHubRemoteUrl("https://github.example.com/andy/repo.git"), false);
+  assert.equal(isGitHubRemoteUrl(null), false);
+  assert.equal(isGitHubRemoteUrl(undefined), false);
+});
+
+test("context_pct percent format shows a bare percentage without icons", () => {
+  // percent is the default format
+  const defaultFormat = renderSegment("context_pct", createCtx());
+  assert.equal(stripAnsi(defaultFormat.content), "28%");
+
+  const full = renderSegment("context_pct", createCtx({ options: { context: { format: "full" } } }));
+  assert.ok(stripAnsi(full.content).includes("296k/1.0M (28.2%)"));
+
+  const percent = renderSegment("context_pct", createCtx({ options: { context: { format: "percent" } } }));
+  const plain = stripAnsi(percent.content);
+  assert.equal(plain, "28%");
+  assert.ok(!plain.includes("/"), "no token ratio");
+});
+
+test("context format option is parsed and merged", () => {
+  const parsed = parsePowerlineConfig({ context: { format: "percent" } }, PRESET_NAMES);
+  assert.equal(parsed.segmentOptions.context?.format, "percent");
+
+  const merged = mergeSegmentOptions({ context: { format: "full" } }, parsed.segmentOptions);
+  assert.equal(merged.context?.format, "percent");
+
+  const invalid = parsePowerlineConfig({ context: { format: "tiny" } }, PRESET_NAMES);
+  assert.equal(invalid.segmentOptions.context?.format, undefined);
+});

--- a/tests/editor-cursor.test.ts
+++ b/tests/editor-cursor.test.ts
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { applyEditorCursorBlink, displayColumnToStringIndex } from "../index.ts";
+import { NERD_ICONS } from "../icons.ts";
+import { parsePowerlineConfig } from "../powerline-config.ts";
+import { PRESETS } from "../presets.ts";
+
+const PRESET_NAMES = Object.keys(PRESETS) as Array<keyof typeof PRESETS>;
+
+test("displayColumnToStringIndex maps display columns to string indices", () => {
+  // ASCII: display col == string index
+  assert.equal(displayColumnToStringIndex("hello world", 0, 7), 7);
+  assert.equal(displayColumnToStringIndex("hello", 0, 0), 0);
+  // past the end clamps to line end
+  assert.equal(displayColumnToStringIndex("hi", 0, 99), 2);
+  // CJK wide chars count double
+  // "你好ab": 你(2) 好(2) a(1) b(1) → col 3 lands after 好 → index 2? col 3 → consume 你(col2) 好(col4) stop at col4>=3 → i=2
+  assert.equal(displayColumnToStringIndex("你好ab", 0, 3), 2);
+  assert.equal(displayColumnToStringIndex("你好ab", 0, 4), 2);
+  assert.equal(displayColumnToStringIndex("你好ab", 0, 5), 3);
+  // fromIndex offset: start inside the line
+  assert.equal(displayColumnToStringIndex("abcdef", 3, 2), 5);
+});
+
+test("applyEditorCursorBlink turns the reverse-block cursor into a blinking one", () => {
+  const line = "text \x1b[7m \x1b[0m more";
+  assert.equal(applyEditorCursorBlink(line), "text \x1b[5;7m \x1b[0m more");
+  // cursor on a character
+  assert.equal(applyEditorCursorBlink("\x1b[7mx\x1b[0m"), "\x1b[5;7mx\x1b[0m");
+  // multi-char reverse sequences (selection etc.) are left alone
+  assert.equal(applyEditorCursorBlink("\x1b[7mabc\x1b[0m"), "\x1b[7mabc\x1b[0m");
+  // no cursor → unchanged
+  assert.equal(applyEditorCursorBlink("plain"), "plain");
+});
+
+test("editor cursor blink and click-to-position configs default on", () => {
+  const defaults = parsePowerlineConfig({}, PRESET_NAMES);
+  assert.equal(defaults.editorCursorBlink, true);
+  assert.equal(defaults.editorClickCursor, true);
+  const off = parsePowerlineConfig({ editorCursorBlink: false, editorClickCursor: false }, PRESET_NAMES);
+  assert.equal(off.editorCursorBlink, false);
+  assert.equal(off.editorClickCursor, false);
+});
+
+test("cache icon differs from context icon", () => {
+  assert.notEqual(NERD_ICONS.cache, NERD_ICONS.context);
+  assert.equal(NERD_ICONS.cache, "\uF0E7"); // bolt
+  assert.equal(NERD_ICONS.context, "\uF1C0"); // database
+});

--- a/tests/jump-shortcuts.test.ts
+++ b/tests/jump-shortcuts.test.ts
@@ -79,7 +79,7 @@ test("chat jump shortcuts are configurable and route through fixed editor scroll
   assert.match(source, /let resolvedShortcuts = resolveShortcutConfig\(startupSettings\)/);
   assert.match(source, /resolvedShortcuts = resolveShortcutConfig\(settings\)/);
   assert.match(source, /keyboardScrollShortcuts: \{\n\s+up: resolvedShortcuts\.scrollChatUp,\n\s+down: resolvedShortcuts\.scrollChatDown,/);
-  assert.match(source, /scrollAwayNavigationCard: \{/);
+  assert.match(source, /scrollAwayNavigationCard: config\.scrollNavCard/);
   assert.match(source, /shortcuts: \[/);
   assert.match(source, /scrollAwayShortcutEntry\("bottom", resolvedShortcuts\.jumpChatBottom\)/);
   assert.match(source, /onClickBottom: resolvedShortcuts\.jumpChatBottom \? \(\) => jumpChatToBottom\(ctx\) : undefined/);

--- a/tests/pill-bar.test.ts
+++ b/tests/pill-bar.test.ts
@@ -1,0 +1,251 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildContentFromParts, ensurePillBg, resolveSeparatorStyle } from "../index.ts";
+import { parsePowerlineConfig } from "../powerline-config.ts";
+import { getPreset, PRESETS } from "../presets.ts";
+import { applyBgColor, rainbow, resolveColor, setPillBold, setSettingsColors } from "../theme.ts";
+import { renderSegment } from "../segments.ts";
+import { getSeparatorChars } from "../icons.ts";
+
+const PRESET_NAMES = Object.keys(PRESETS) as Array<keyof typeof PRESETS>;
+const plainTheme = { fg: (_color: string, text: string) => text };
+
+const originalNerdFonts = process.env.POWERLINE_NERD_FONTS;
+process.env.POWERLINE_NERD_FONTS = "1";
+test.after(() => {
+  if (originalNerdFonts === undefined) {
+    delete process.env.POWERLINE_NERD_FONTS;
+  } else {
+    process.env.POWERLINE_NERD_FONTS = originalNerdFonts;
+  }
+});
+
+function bgAnsi(rgb: [number, number, number]): string {
+  return `\x1b[48;2;${rgb.join(";")}m`;
+}
+
+function fgAnsi(rgb: [number, number, number]): string {
+  return `\x1b[38;2;${rgb.join(";")}m`;
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace("#", "");
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+}
+
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+test("settings.json separator is parsed", () => {
+  const parsed = parsePowerlineConfig({ segmentStyle: "pill", separator: "powerline" }, PRESET_NAMES);
+  assert.equal(parsed.segmentStyle, "pill");
+  assert.equal(parsed.separator, "powerline");
+
+  const invalid = parsePowerlineConfig({ separator: "nope" }, PRESET_NAMES);
+  assert.equal(invalid.separator, null);
+
+  const missing = parsePowerlineConfig({ segmentStyle: "pill" }, PRESET_NAMES);
+  assert.equal(missing.separator, null);
+});
+
+test("resolveSeparatorStyle: explicit config wins, pill defaults to solid powerline", () => {
+  const defaultPreset = getPreset("default"); // preset separator: powerline-thin
+  assert.equal(resolveSeparatorStyle(defaultPreset, "pill", "powerline-thin"), "powerline-thin");
+  assert.equal(resolveSeparatorStyle(defaultPreset, "pill", null), "powerline");
+  assert.equal(resolveSeparatorStyle(defaultPreset, "fg", null), "powerline-thin");
+  assert.equal(resolveSeparatorStyle(getPreset("full"), "pill", null), "powerline");
+});
+
+test("ensurePillBg keeps existing pills and wraps fg-only content in a neutral pill", () => {
+  const pill = applyBgColor(plainTheme, "#d787af", "model");
+  assert.equal(ensurePillBg(pill), pill);
+
+  const wrapped = ensurePillBg(rainbow("think:high"));
+  assert.ok(wrapped.startsWith(bgAnsi(hexToRgb("#45475a"))));
+  assert.equal(stripAnsi(wrapped), " think:high ");
+});
+
+test("pill mode renders a seamless starship-style bar with transitions and end cap", () => {
+  const arrow = getSeparatorChars().powerlineLeft;
+  const modelRgb = hexToRgb("#d787af");
+  const pathRgb = hexToRgb("#00afaf");
+  const gitRgb = hexToRgb("#f9e2af");
+  const neutralRgb = hexToRgb("#45475a");
+
+  const parts = [
+    applyBgColor(plainTheme, "#d787af", " Kimi K3"),
+    rainbow("think:high"), // fg-only: must be wrapped, not break the chain
+    applyBgColor(plainTheme, "#00afaf", " project"),
+    applyBgColor(plainTheme, "#f9e2af", " main *1"),
+  ];
+
+  const out = buildContentFromParts(parts, "powerline", "pill", "arrow");
+
+  // Every boundary gets a colored transition arrow: bg=next, fg=current
+  const transition = (from: [number, number, number], to: [number, number, number]) =>
+    `${bgAnsi(to)}${fgAnsi(from)}${arrow}`;
+  assert.ok(out.includes(transition(modelRgb, neutralRgb)), "model → thinking transition");
+  assert.ok(out.includes(transition(neutralRgb, pathRgb)), "thinking → path transition");
+  assert.ok(out.includes(transition(pathRgb, gitRgb)), "path → git transition");
+
+  // No dark gaps: no reset inside the bar body (leading clean-slate reset is fine)
+  const body = out.slice("\x1b[0m ".length, out.lastIndexOf("\x1b[0m"));
+  assert.ok(!body.includes("\x1b[0m"), "bar body never resets to terminal background");
+
+  // End cap closes the bar in the last pill's color, drawn on the default background
+  assert.ok(out.endsWith(`${fgAnsi(gitRgb)}${arrow}\x1b[0m `), "end cap in last pill color");
+  assert.ok(
+    out.includes(`\x1b[49m${fgAnsi(gitRgb)}${arrow}`),
+    "end cap resets background first or it would be invisible (fg-on-same-bg)"
+  );
+
+  // Visible text unchanged (pills pad with one space per side, bar has leading/trailing space)
+  assert.equal(stripAnsi(out), `   Kimi K3 ${arrow} think:high ${arrow}  project ${arrow}  main *1 ${arrow} `);
+});
+
+test("pill mode with powerline-thin keeps thin arrows and end cap", () => {
+  const thin = getSeparatorChars().powerlineThinLeft;
+  const modelRgb = hexToRgb("#d787af");
+  const pathRgb = hexToRgb("#00afaf");
+  const parts = [
+    applyBgColor(plainTheme, "#d787af", "m"),
+    applyBgColor(plainTheme, "#00afaf", "p"),
+  ];
+  const out = buildContentFromParts(parts, "powerline-thin", "pill", "arrow");
+  assert.ok(out.includes(`${bgAnsi(pathRgb)}${fgAnsi(modelRgb)}${thin}`));
+  assert.ok(out.endsWith(`${fgAnsi(pathRgb)}${thin}\x1b[0m `));
+});
+
+test("fg mode rendering is unchanged", () => {
+  const out = buildContentFromParts(["aaa", "bbb"], "powerline-thin", "fg");
+  const thin = getSeparatorChars().powerlineThinLeft;
+  assert.equal(stripAnsi(out), ` aaa ${thin} bbb `);
+});
+
+test("non-arrow separators in pill mode get transitions but no end cap", () => {
+  const parts = [
+    applyBgColor(plainTheme, "#d787af", "m"),
+    applyBgColor(plainTheme, "#00afaf", "p"),
+  ];
+  const out = buildContentFromParts(parts, "dot", "pill");
+  assert.ok(out.includes("·"));
+  assert.ok(out.endsWith("\x1b[0m "));
+});
+
+test("round caps render half-circle ends in the edge pill colors", () => {
+  const modelRgb = hexToRgb("#d787af");
+  const pathRgb = hexToRgb("#00afaf");
+  const parts = [
+    applyBgColor(plainTheme, "#d787af", "m"),
+    applyBgColor(plainTheme, "#00afaf", "p"),
+  ];
+  const out = buildContentFromParts(parts, "powerline", "pill", "round");
+  assert.ok(out.startsWith(`\x1b[0m ${fgAnsi(modelRgb)}\uE0B6`), "left round cap in first pill color");
+  assert.ok(out.endsWith(`${fgAnsi(pathRgb)}\uE0B4\x1b[0m `), "right round cap in last pill color");
+  assert.ok(
+    out.includes(`\x1b[49m${fgAnsi(pathRgb)}\uE0B4`),
+    "right round cap resets background first or it would be invisible"
+  );
+  assert.equal(stripAnsi(out), ` \uE0B6 m ${getSeparatorChars().powerlineLeft} p \uE0B4 `);
+});
+
+test("flat caps render no end glyphs", () => {
+  const parts = [applyBgColor(plainTheme, "#d787af", "m")];
+  const out = buildContentFromParts(parts, "powerline", "pill", "flat");
+  assert.ok(out.endsWith("\x1b[0m "));
+  assert.ok(!out.includes("\uE0B6") && !out.includes("\uE0B4"));
+});
+
+test("pill text color: dark forces near-black, contrast follows luminance, hex passes through", () => {
+  const darkOnPink = applyBgColor(plainTheme, "#d787af", "m", "dark");
+  assert.ok(darkOnPink.includes(fgAnsi(hexToRgb("#1e1e2e"))));
+
+  const lightOnPink = applyBgColor(plainTheme, "#d787af", "m", "light");
+  assert.ok(lightOnPink.includes(fgAnsi(hexToRgb("#cdd6f4"))));
+
+  const autoOnPink = applyBgColor(plainTheme, "#d787af", "m", "contrast");
+  assert.ok(autoOnPink.includes(fgAnsi(hexToRgb("#1e1e2e"))), "light bg auto-gets dark text");
+
+  const autoOnGray = applyBgColor(plainTheme, "#45475a", "m", "contrast");
+  assert.ok(autoOnGray.includes(fgAnsi(hexToRgb("#cdd6f4"))), "dark bg auto-gets light text");
+
+  const custom = applyBgColor(plainTheme, "#d787af", "m", "#ff0000");
+  assert.ok(custom.includes(fgAnsi(hexToRgb("#ff0000"))));
+});
+
+test("settings.json powerline.colors overrides theme/preset/default resolution", () => {
+  try {
+    setSettingsColors({ model: "#112233" });
+    assert.equal(resolveColor("model", { model: "#445566" }), "#112233");
+    assert.equal(resolveColor("path", { path: "#445566" }), "#445566", "preset still works for unset keys");
+  } finally {
+    setSettingsColors({});
+  }
+});
+
+test("powerline config parses caps, pillTextColor, and colors", () => {
+  const parsed = parsePowerlineConfig({
+    segmentStyle: "pill",
+    caps: "round",
+    pillTextColor: "#000000",
+    colors: { model: "#112233", bogus: "#000000" },
+  }, PRESET_NAMES);
+  assert.equal(parsed.caps, "round");
+  assert.equal(parsed.pillTextColor, "#000000");
+  assert.deepEqual(parsed.colors, { model: "#112233" });
+
+  const defaults = parsePowerlineConfig({}, PRESET_NAMES);
+  assert.equal(defaults.caps, "round");
+  assert.equal(defaults.pillTextColor, "dark");
+  assert.deepEqual(defaults.colors, {});
+
+  const invalid = parsePowerlineConfig({ caps: "triangle", pillTextColor: "blueish" }, PRESET_NAMES);
+  assert.equal(invalid.caps, "round");
+  assert.equal(invalid.pillTextColor, "dark");
+});
+
+test("pill bold is on by default and can be disabled", () => {
+  try {
+    setPillBold(true);
+    assert.ok(applyBgColor(plainTheme, "#d787af", "m", "dark").includes("\x1b[1m"));
+    setPillBold(false);
+    assert.ok(!applyBgColor(plainTheme, "#d787af", "m", "dark").includes("\x1b[1m"));
+  } finally {
+    setPillBold(true);
+  }
+
+  assert.equal(parsePowerlineConfig({}, PRESET_NAMES).pillBold, true);
+  assert.equal(parsePowerlineConfig({ pillBold: false }, PRESET_NAMES).pillBold, false);
+});
+
+test("prompt color defaults to mocha mauve and accepts hex overrides", () => {
+  assert.equal(parsePowerlineConfig({}, PRESET_NAMES).promptColor, "#cba6f7");
+  assert.equal(parsePowerlineConfig({ promptColor: "#febc38" }, PRESET_NAMES).promptColor, "#febc38");
+  assert.equal(parsePowerlineConfig({ promptColor: "gold" }, PRESET_NAMES).promptColor, "#cba6f7");
+});
+
+test("custom segments strip extension fg colors in pill mode", () => {
+  const ctx: any = {
+    segmentStyle: "pill",
+    pillTextColor: "dark",
+    theme: plainTheme,
+    colors: {},
+    customItemsById: new Map([["tavily", {
+      id: "tavily",
+      statusKey: "tavily-status",
+      position: "right",
+      color: "#a6e3a1",
+      hideWhenMissing: true,
+      excludeFromExtensionStatuses: true,
+    }]]),
+    extensionStatuses: new Map([["tavily-status", "\x1b[38;2;205;214;244mTavily:0%\x1b[0m"]]),
+    hiddenExtensionStatusKeys: new Set(),
+    options: {},
+  };
+  const rendered = renderSegment("custom:tavily", ctx);
+  // extension's light fg is gone; pill dark text wins
+  assert.ok(!rendered.content.includes("38;2;205;214;244"));
+  assert.ok(rendered.content.includes(fgAnsi(hexToRgb("#1e1e2e"))));
+  assert.equal(stripAnsi(rendered.content), " Tavily:0% ");
+});

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -51,6 +51,7 @@ function createSegmentContext(overrides: Partial<SegmentContext> = {}): SegmentC
     options: {},
     theme: { fg: plainThemeText },
     colors: {},
+    segmentStyle: "fg",
     ...overrides,
   };
 }
@@ -95,11 +96,12 @@ test("cost segment supports subscription display modes", () => {
     options: { cost: { subscriptionDisplay: "both" } },
   }));
 
-  assert.deepEqual(subscription, { content: "(sub)", visible: true });
-  assert.deepEqual(reportedCost, { content: "$0.42", visible: true });
-  assert.deepEqual(both, { content: "$0.42 (sub)", visible: true });
-  assert.deepEqual(zeroReported, { content: "(sub)", visible: true });
-  assert.deepEqual(zeroBoth, { content: "(sub)", visible: true });
+  const plain = (r: { content: string; visible: boolean }) => ({ content: stripAnsi(r.content), visible: r.visible });
+  assert.deepEqual(plain(subscription), { content: "(sub)", visible: true });
+  assert.deepEqual(plain(reportedCost), { content: "$0.42", visible: true });
+  assert.deepEqual(plain(both), { content: "$0.42 (sub)", visible: true });
+  assert.deepEqual(plain(zeroReported), { content: "(sub)", visible: true });
+  assert.deepEqual(plain(zeroBoth), { content: "(sub)", visible: true });
 });
 
 test("context segment shows used tokens, maximum, and percentage", () => {
@@ -107,6 +109,7 @@ test("context segment shows used tokens, maximum, and percentage", () => {
     contextTokens: 4_500,
     contextPercent: 1.7,
     contextWindow: 272_000,
+    options: { context: { format: "full" } },
   }));
 
   assert.equal(stripAnsi(context.content), "◫ 4.5k/272k (1.7%) AC");

--- a/theme.ts
+++ b/theme.ts
@@ -11,7 +11,7 @@ import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ColorScheme, ColorValue, SemanticColor, ThemeLike } from "./types.ts";
+import type { ColorScheme, ColorValue, PillTextColor, SemanticColor, ThemeLike } from "./types.ts";
 
 export interface PowerlineThemeConfig {
   colors?: unknown;
@@ -21,21 +21,21 @@ export interface PowerlineThemeConfig {
 // Default color scheme (uses pi theme colors)
 const DEFAULT_COLORS: Required<ColorScheme> = {
   model: "#d787af",  // Pink/mauve (matching original colors.ts)
-  shellMode: "accent",
+  shellMode: "#fab387",  // Catppuccin Mocha peach
   path: "#00afaf",  // Teal/cyan (matching original colors.ts)
-  gitDirty: "warning",
-  gitClean: "success",
-  thinking: "thinkingOff",
-  thinkingMinimal: "thinkingMinimal",
-  thinkingLow: "thinkingLow",
-  thinkingMedium: "thinkingMedium",
-  context: "dim",
-  contextWarn: "warning",
-  contextError: "error",
-  cost: "text",
-  tokens: "muted",
-  separator: "dim",
-  border: "borderMuted",
+  gitDirty: "#fab387",  // Catppuccin peach (distinct from balance yellow)
+  gitClean: "#a6e3a1",  // success green
+  thinking: "#6c7086",  // dim gray
+  thinkingMinimal: "#89b4fa",  // blue
+  thinkingLow: "#74c7ec",  // light blue
+  thinkingMedium: "#f9e2af",  // yellow
+  context: "#6c7086",  // dim
+  contextWarn: "#f9e2af",  // warning
+  contextError: "#f38ba8",  // error red
+  cost: "#a6e3a1",  // green
+  tokens: "#bac2de",  // muted text (Catppuccin Mocha subtext1)
+  separator: "#585b70",  // surface0
+  border: "#45475a",  // surface1
 };
 
 // Rainbow colors for high thinking levels
@@ -79,6 +79,32 @@ function sanitizeUserThemeOverrides(value: unknown): ColorScheme {
   }
 
   return sanitized;
+}
+
+/** Sanitize a user-provided color override map (theme.json or settings.json powerline.colors) */
+export function sanitizeColorOverrides(value: unknown): ColorScheme {
+  return sanitizeUserThemeOverrides(value);
+}
+
+// Colors from settings.json powerline.colors (highest priority layer)
+let settingsColors: ColorScheme = {};
+
+/** Register color overrides coming from settings.json (powerline.colors) */
+export function setSettingsColors(colors: ColorScheme | undefined): void {
+  settingsColors = colors ?? {};
+}
+
+// Bold text inside pills (powerline.pillBold, default true)
+let pillBoldEnabled = true;
+
+/** Toggle bold text inside pills */
+export function setPillBold(enabled: boolean): void {
+  pillBoldEnabled = enabled;
+}
+
+/** Whether pill text is rendered bold */
+export function isPillBold(): boolean {
+  return pillBoldEnabled;
 }
 
 /**
@@ -138,8 +164,9 @@ export function resolveColor(
 ): ColorValue {
   const userTheme = loadUserTheme();
   
-  // Priority: user overrides > preset colors > defaults
-  return userTheme[semantic] 
+  // Priority: settings.json colors > theme.json overrides > preset colors > defaults
+  return settingsColors[semantic]
+    ?? userTheme[semantic] 
     ?? presetColors?.[semantic] 
     ?? DEFAULT_COLORS[semantic];
 }
@@ -152,14 +179,54 @@ function isHexColor(color: ColorValue): color is `#${string}` {
 }
 
 /**
- * Convert hex color to ANSI escape code
+ * Convert hex color to ANSI escape code (foreground)
  */
-function hexToAnsi(hex: string): string {
+export function hexToAnsi(hex: string): string {
   const h = hex.replace("#", "");
   const r = parseInt(h.slice(0, 2), 16);
   const g = parseInt(h.slice(2, 4), 16);
   const b = parseInt(h.slice(4, 6), 16);
   return `\x1b[38;2;${r};${g};${b}m`;
+}
+
+/**
+ * Convert hex color to ANSI background escape code
+ */
+export function hexToBgAnsi(hex: string): string {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `\x1b[48;2;${r};${g};${b}m`;
+}
+
+const PILL_DARK_FG = "#1e1e2e";   // Catppuccin base (near-black)
+const PILL_LIGHT_FG = "#cdd6f4"; // Catppuccin text
+
+/**
+ * Compute contrast foreground color for a given background hex.
+ * Light backgrounds get dark text, dark backgrounds get light text.
+ */
+function contrastFg(hex: string): string {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.slice(0, 2), 16) / 255;
+  const g = parseInt(h.slice(2, 4), 16) / 255;
+  const b = parseInt(h.slice(4, 6), 16) / 255;
+  // relative luminance
+  const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return lum > 0.5 ? PILL_DARK_FG : PILL_LIGHT_FG;
+}
+
+/**
+ * Resolve the pill text (foreground) color.
+ * "dark"/"light" force a fixed color, "contrast" picks by background luminance,
+ * a hex string is used as-is.
+ */
+export function resolvePillTextColor(bgHex: string, textColor?: PillTextColor): string {
+  if (!textColor || textColor === "contrast") return contrastFg(bgHex);
+  if (textColor === "dark") return PILL_DARK_FG;
+  if (textColor === "light") return PILL_LIGHT_FG;
+  return isHexColor(textColor) ? textColor : contrastFg(bgHex);
 }
 
 /**
@@ -190,6 +257,28 @@ export function applyColor(
 }
 
 /**
+ * Apply a background color pill to text.
+ * Uses background ANSI + pill text color for hex colors;
+ * falls back to applyColor for semantic/theme colors.
+ */
+export function applyBgColor(
+  theme: ThemeLike,
+  color: ColorValue,
+  text: string,
+  textColor?: PillTextColor
+): string {
+  if (isHexColor(color)) {
+    const fg = resolvePillTextColor(color, textColor);
+    const fgAnsi = hexToAnsi(fg);
+    const bgAnsi = hexToBgAnsi(color);
+    const bold = pillBoldEnabled ? "\x1b[1m" : "";
+    return `${bgAnsi}${fgAnsi}${bold} ${text} \x1b[0m`;
+  }
+  // semantic colors fall back to foreground-only
+  return applyColor(theme, color, text);
+}
+
+/**
  * Apply a semantic color to text
  */
 export function fg(
@@ -200,6 +289,20 @@ export function fg(
 ): string {
   const color = resolveColor(semantic, presetColors);
   return applyColor(theme, color, text);
+}
+
+/**
+ * Apply a semantic color as a background pill to text
+ */
+export function bg(
+  theme: ThemeLike,
+  semantic: SemanticColor,
+  text: string,
+  presetColors?: ColorScheme,
+  textColor?: PillTextColor
+): string {
+  const color = resolveColor(semantic, presetColors);
+  return applyBgColor(theme, color, text, textColor);
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -67,6 +67,12 @@ export type StatusLineSeparatorStyle =
   | "chevron"
   | "star";
 
+// Pill bar end-cap style (pill mode only)
+export type PowerlineCaps = "round" | "arrow" | "flat";
+
+// Pill text color: fixed dark/light, auto contrast, or a custom hex
+export type PillTextColor = "dark" | "light" | "contrast" | `#${string}`;
+
 // Preset names
 export type PowerlinePlacement = "above" | "below";
 
@@ -94,6 +100,7 @@ export interface StatusLineSegmentOptions {
   };
   time?: { format?: "12h" | "24h"; showSeconds?: boolean };
   cost?: { subscriptionDisplay?: "subscription" | "reported-cost" | "both" };
+  context?: { format?: "full" | "percent" };
 }
 
 export type CustomItemPosition = "left" | "right" | "secondary";
@@ -198,6 +205,12 @@ export interface SegmentContext {
   // Theming
   theme: ThemeLike;
   colors: ColorScheme;
+
+  // Rendering style
+  segmentStyle: "fg" | "pill";
+
+  // Text color inside pills (undefined = auto contrast)
+  pillTextColor?: PillTextColor;
 }
 
 // Rendered segment output


### PR DESCRIPTION
   ## Summary

   This PR adds a "pill" segment rendering mode inspired by Starship/Coralline, editor styling improvements, and several bug fixes.

   ### Pill Mode (`segmentStyle: "pill"`)


<img width="1168" height="90" alt="image" src="https://github.com/user-attachments/assets/7238ba29-c59a-47a2-a7ff-da9ad3c82773" />



Each segment renders as a colored background block with seamless powerline arrow transitions between adjacent pills. Round caps give the bar a polished look.

   **New config keys:**

   ```json
   {
     "powerline": {
       "segmentStyle": "pill",
       "separator": "powerline",
       "caps": "round",
       "pillTextColor": "dark",
       "pillBold": true,
       "promptColor": "#cba6f7",
       "editorCursorBlink": true,
       "editorClickCursor": true,
       "scrollNavCard": false,
       "colors": {
         "model": "#d787af",
         "path": "#00afaf"
       }
     }
   }
   ```

   - `segmentStyle`: `"pill"` | `"fg"` (default). Pill mode renders solid color backgrounds.
   - `separator`: Overrides preset separator. Pill mode defaults to `"powerline"`.
   - `caps`: `"round"` | `"arrow"` | `"flat"`. Auto-degrades to flat without Nerd Font.
   - `pillTextColor`: `"dark"` | `"light"` | `"contrast"` | custom `#rrggbb`.
   - `pillBold`: bold text in pills.
   - `colors`: Direct semantic color overrides from settings.json (no need to touch theme files).
   - `promptColor`: Configurable prompt arrow `❯` color.
   - `editorCursorBlink`: SGR blink on editor cursor.
   - `editorClickCursor`: Mouse click positions cursor in editor.
   - `scrollNavCard`: Toggle "Jump to bottom" card (default false).

   ### Editor Styling

   Rounded box with side borders and configurable prompt arrow color:

   ```
    ╭──────────────────────╮
    │ ❯ input text...      │
    ╰──────────────────────╯
   ```

   ### Performance Fixes

   - **Token count caching**: `buildSegmentContext` no longer re-scans all session events on every render (was O(n) per 250ms cycle).
   - **Git status flash fix**: `invalidateGitStatus()` now preserves stale cache values while background fetch runs, preventing the git segment from briefly disappearing.

   ### Other Changes

   - `cache_read` segment: shows hit rate percentage instead of raw token count
   - Git segment: GitHub octocat icon when origin is github.com
   - 13 new test cases for pill bar rendering

   ### Tests

   ```bash
   npm test  # 196 pass, 0 fail
   ```

   ## Breaking Changes

   None. All new features are opt-in. Default behavior unchanged.