### PR TITLE
feat: pill segment style with seamless color transitions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@ import { isKeyRelease, type AutocompleteProvider, type SelectItem, SelectList, t
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 
-import type { ColorScheme, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
+import type { ColorScheme, PowerlineCaps, SegmentContext, StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "./types.ts";
 import type { PowerlineConfig } from "./powerline-config.ts";
 import { BashTranscriptStore } from "./bash-mode/transcript.ts";
 import {
@@ -27,6 +27,7 @@ import { getPreset, PRESETS } from "./presets.ts";
 import { getAgentPath } from "./paths.ts";
 import { collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, mergeSegmentOptions, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, parsePowerlineConfig } from "./powerline-config.ts";
 import { getSeparator } from "./separators.ts";
+import { hasNerdFonts } from "./icons.ts";
 import { renderSegment } from "./segments.ts";
 import { getGitStatus, invalidateGitStatus, invalidateGitBranch } from "./git-status.ts";
 import { ansi, getFgAnsiCode } from "./colors.ts";
@@ -39,7 +40,7 @@ import { isStaleExtensionContextError, shouldResetExtendedKeyboardModesOnShutdow
 import { renderFixedEditorCluster } from "./fixed-editor/cluster.ts";
 import { DEFAULT_SCROLL_REPAINT_THROTTLE_MS, emergencyTerminalModeReset, TerminalSplitCompositor } from "./fixed-editor/terminal-split.ts";
 import { inlineEditorQuitCursorRestore } from "./terminal-cursor.ts";
-import { getDefaultColors } from "./theme.ts";
+import { bgAnsiToFgAnsi, extractBgAnsi, getDefaultColors, hexToBgAnsi, isPillBold, setPillBold, setSettingsColors } from "./theme.ts";
 import {
   isSupportedSuperShortcut,
   matchesConfiguredShortcut,
@@ -76,6 +77,12 @@ let config: PowerlineConfig = {
   layout: null,
   invalidLayoutSegments: [],
   segmentOptions: {},
+  segmentStyle: "fg",
+  separator: null,
+  caps: "round",
+  pillTextColor: "dark",
+  pillBold: true,
+  colors: {},
   mouseScroll: true,
   fixedEditor: true,
   placement: "above",
@@ -951,16 +958,99 @@ function renderSegmentWithWidth(
   return { content: rendered.content, width: visibleWidth(rendered.content), visible: true };
 }
 
+/** Neutral background for segments that render fg-only content (e.g. rainbow thinking) */
+const NEUTRAL_PILL_BG = "#45475a"; // Catppuccin surface1
+
+/** Wrap a segment that produced no background in a neutral pill so the bar stays seamless. */
+export function ensurePillBg(content: string): string {
+  if (extractBgAnsi(content)) return content;
+  const stripped = content.replace(/\x1b\[0m$/, "");
+  const bold = isPillBold() ? "\x1b[1m" : "";
+  return `${hexToBgAnsi(NEUTRAL_PILL_BG)}${bold} ${stripped} \x1b[0m`;
+}
+
+/**
+ * Resolve which separator style to use.
+ * Explicit settings.json "separator" wins; pill mode needs solid powerline
+ * arrows for the color transitions, so it defaults to "powerline" instead of
+ * the preset's (often thin) separator.
+ */
+export function resolveSeparatorStyle(
+  presetDef: ReturnType<typeof getPreset>,
+  segmentStyle: "fg" | "pill",
+  configured: StatusLineSeparatorStyle | null = config.separator
+): StatusLineSeparatorStyle {
+  if (configured) return configured;
+  if (segmentStyle === "pill") return "powerline";
+  return presetDef.separator;
+}
+
+const ROUND_LEFT_CAP = "\uE0B6";  //  rounded bar start
+const ROUND_RIGHT_CAP = "\uE0B4"; //  rounded bar end
+
+/** Round caps need Nerd Font glyphs; without them fall back to flat ends. */
+function effectiveCaps(caps: PowerlineCaps): PowerlineCaps {
+  return caps === "round" && !hasNerdFonts() ? "flat" : caps;
+}
+
 /** Build content string from pre-rendered parts */
-function buildContentFromParts(
+export function buildContentFromParts(
   parts: string[],
-  presetDef: ReturnType<typeof getPreset>
+  separatorStyle: StatusLineSeparatorStyle,
+  segmentStyle: "fg" | "pill" = "fg",
+  caps: PowerlineCaps = "flat"
 ): string {
   if (parts.length === 0) return "";
-  const separatorDef = getSeparator(presetDef.separator);
-  const sepAnsi = getFgAnsiCode("sep");
+  const separatorDef = getSeparator(separatorStyle);
   const sep = separatorDef.left;
-  return " " + parts.join(` ${sepAnsi}${sep}${ansi.reset} `) + ansi.reset + " ";
+
+  // Original behavior: dim separator between segments
+  if (segmentStyle !== "pill") {
+    const sepAnsi = getFgAnsiCode("sep");
+    return " " + parts.join(` ${sepAnsi}${sep}${ansi.reset} `) + ansi.reset + " ";
+  }
+
+  // Pill mode: seamless powerline bar (starship style).
+  // Every segment must carry a background (fg-only segments get a neutral one).
+  // Transition arrows and caps reuse each pill's background SGR sequence
+  // (48 -> 38 for the foreground counterpart), so both truecolor hex colors
+  // and theme-key colors (any color mode) chain seamlessly.
+  const pills = parts.map(ensurePillBg);
+  const bgSequences = pills.map((p) => extractBgAnsi(p) as string);
+  const capsStyle = effectiveCaps(caps);
+
+  // Start from a clean slate so no background/attribute leaks into the bar
+  let result = "\x1b[0m ";
+
+  // Left cap: rounded start in the first pill's color (bg is terminal default here)
+  if (capsStyle === "round") {
+    result += `${bgAnsiToFgAnsi(bgSequences[0])}${ROUND_LEFT_CAP}`;
+  }
+
+  for (let i = 0; i < pills.length; i++) {
+    // Strip trailing reset so the transition ANSI can chain directly
+    result += pills[i].replace(/\x1b\[0m$/, "");
+
+    if (i < pills.length - 1) {
+      result += `${bgSequences[i + 1]}${bgAnsiToFgAnsi(bgSequences[i])}${sep}`;
+    }
+  }
+
+  // Right cap: rounded end, or closing arrow for powerline separators.
+  // The last pill's bg is still active at this point — reset it to the default
+  // background (\x1b[49m) first or the cap would be drawn fg-on-same-bg (invisible).
+  const lastBgFg = bgAnsiToFgAnsi(bgSequences[bgSequences.length - 1]);
+  if (capsStyle === "round") {
+    result += `\x1b[49m${lastBgFg}${ROUND_RIGHT_CAP}`;
+  } else if (
+    capsStyle === "arrow" &&
+    (separatorStyle === "powerline" || separatorStyle === "powerline-thin")
+  ) {
+    result += `\x1b[49m${lastBgFg}${sep}`;
+  }
+
+  result += ansi.reset + " ";
+  return result;
 }
 
 /**
@@ -973,8 +1063,11 @@ function computeResponsiveLayout(
   presetDef: ReturnType<typeof getPreset>,
   availableWidth: number
 ): { topContent: string; secondaryContent: string } {
-  const separatorDef = getSeparator(presetDef.separator);
-  const sepWidth = visibleWidth(separatorDef.left) + 2; // separator + spaces around it
+  const separatorStyle = resolveSeparatorStyle(presetDef, ctx.segmentStyle);
+  const separatorDef = getSeparator(separatorStyle);
+  const capsStyle = ctx.segmentStyle === "pill" ? effectiveCaps(config.caps) : "flat";
+  // fg mode pads separators with spaces; pill transitions are flush
+  const sepWidth = visibleWidth(separatorDef.left) + (ctx.segmentStyle === "pill" ? 0 : 2);
   
   // Get all segments: primary first, then secondary
   const mergedSegments = mergeSegmentsWithCustomItems(presetDef, config.customItems, {
@@ -999,8 +1092,9 @@ function computeResponsiveLayout(
   }
   
   // Calculate how many segments fit in top bar
-  // Account for: leading space (1) + trailing space (1) = 2 chars overhead
-  const baseOverhead = 2;
+  // Overhead: leading + trailing space (2) plus end caps (round: 2, arrow: 1)
+  const capsWidth = capsStyle === "round" ? 2 : capsStyle === "arrow" ? 1 : 0;
+  const baseOverhead = 2 + (ctx.segmentStyle === "pill" ? capsWidth : 0);
   let currentWidth = baseOverhead;
   let topSegments: string[] = [];
   let overflowSegments: { content: string; width: number }[] = [];
@@ -1034,8 +1128,8 @@ function computeResponsiveLayout(
   }
   
   return {
-    topContent: buildContentFromParts(topSegments, presetDef),
-    secondaryContent: buildContentFromParts(secondarySegments, presetDef),
+    topContent: buildContentFromParts(topSegments, separatorStyle, ctx.segmentStyle, capsStyle),
+    secondaryContent: buildContentFromParts(secondarySegments, separatorStyle, ctx.segmentStyle, capsStyle),
   };
 }
 
@@ -1068,6 +1162,8 @@ function warnInvalidSegmentSettings(ctx: any): void {
 export default function powerlineFooter(pi: ExtensionAPI) {
   const startupSettings = readSettings();
   config = parsePowerlineConfig(startupSettings.powerline, PRESET_NAMES);
+  setSettingsColors(config.colors);
+  setPillBold(config.pillBold);
   let resolvedShortcuts = resolveShortcutConfig(startupSettings);
   let bashModeSettings = parseBashModeSettings(startupSettings, resolvedShortcuts);
 
@@ -1335,6 +1431,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     bashModeSettings = parseBashModeSettings(settings, resolvedShortcuts);
     showLastPrompt = settings.showLastPrompt !== false;
     config = parsePowerlineConfig(settings.powerline, PRESET_NAMES);
+    setSettingsColors(config.colors);
+    setPillBold(config.pillBold);
     warnInvalidSegmentSettings(ctx);
     stashedPromptHistory = readPersistedStashHistory();
     bashModeActive = false;
@@ -2239,6 +2337,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       options: segmentOptions,
       theme,
       colors,
+      segmentStyle: config.segmentStyle ?? "fg",
+      pillTextColor: config.pillTextColor,
     };
   }
 

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,6 +1,7 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
+import { sanitizeColorOverrides } from "./theme.ts";
 import { BUILTIN_STATUS_LINE_SEGMENT_IDS } from "./types.ts";
-import type { ColorValue, CustomItemPosition, CustomStatusItem, PowerlinePlacement, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions } from "./types.ts";
+import type { ColorScheme, ColorValue, CustomItemPosition, CustomStatusItem, PillTextColor, PowerlineCaps, PowerlinePlacement, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions, StatusLineSeparatorStyle } from "./types.ts";
 
 export interface PowerlineConfig {
   preset: StatusLinePreset;
@@ -10,6 +11,12 @@ export interface PowerlineConfig {
   layout: StatusLineLayout | null;
   invalidLayoutSegments: string[];
   segmentOptions: StatusLineSegmentOptions;
+  segmentStyle: "fg" | "pill";
+  separator: StatusLineSeparatorStyle | null;
+  caps: PowerlineCaps;
+  pillTextColor: PillTextColor;
+  pillBold: boolean;
+  colors: ColorScheme;
   mouseScroll: boolean;
   fixedEditor: boolean;
   placement: PowerlinePlacement;
@@ -26,6 +33,40 @@ function normalizePreset(value: unknown, presets: readonly StatusLinePreset[]): 
   if (typeof value !== "string") return null;
   const normalized = value.trim().toLowerCase();
   return (presets as readonly string[]).includes(normalized) ? (normalized as StatusLinePreset) : null;
+}
+
+const SEPARATOR_STYLES: readonly StatusLineSeparatorStyle[] = [
+  "powerline",
+  "powerline-thin",
+  "slash",
+  "pipe",
+  "block",
+  "none",
+  "ascii",
+  "dot",
+  "chevron",
+  "star",
+];
+
+function normalizeSeparator(value: unknown): StatusLineSeparatorStyle | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return (SEPARATOR_STYLES as readonly string[]).includes(normalized)
+    ? (normalized as StatusLineSeparatorStyle)
+    : null;
+}
+
+function normalizeCaps(value: unknown): PowerlineCaps {
+  if (value === "round" || value === "arrow" || value === "flat") return value;
+  return "round";
+}
+
+function normalizePillTextColor(value: unknown): PillTextColor {
+  if (value === "dark" || value === "light" || value === "contrast") return value;
+  if (typeof value === "string" && /^#[0-9a-fA-F]{6}$/.test(value.trim())) {
+    return value.trim() as PillTextColor;
+  }
+  return "dark";
 }
 
 function normalizePlacement(value: unknown): { placement: PowerlinePlacement; invalidPlacement: string | null } {
@@ -259,6 +300,12 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     layout: null,
     invalidLayoutSegments: [],
     segmentOptions: {},
+    segmentStyle: "fg",
+    separator: null,
+    caps: "round",
+    pillTextColor: "dark",
+    pillBold: true,
+    colors: {},
     mouseScroll: true,
     fixedEditor: true,
     placement: "above",
@@ -285,6 +332,12 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     layout,
     invalidLayoutSegments,
     segmentOptions: normalizeSegmentOptions(value),
+    segmentStyle: value.segmentStyle === "pill" ? "pill" : "fg",
+    separator: normalizeSeparator(value.separator),
+    caps: normalizeCaps(value.caps),
+    pillTextColor: normalizePillTextColor(value.pillTextColor),
+    pillBold: value.pillBold !== false,
+    colors: sanitizeColorOverrides(value.colors),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,
     placement,

--- a/segments.ts
+++ b/segments.ts
@@ -3,10 +3,13 @@ import { basename } from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import type { BuiltinStatusLineSegmentId, RenderedSegment, SegmentContext, SemanticColor, StatusLineSegment, StatusLineSegmentId } from "./types.ts";
 import { normalizeCompactExtensionStatus, normalizeExtensionStatusValue } from "./powerline-config.ts";
-import { fg, rainbow, applyColor } from "./theme.ts";
+import { fg, bg, rainbow, applyColor, applyBgColor } from "./theme.ts";
 import { getIcons, SEP_DOT, getThinkingText } from "./icons.ts";
 
 function color(ctx: SegmentContext, semantic: SemanticColor, text: string): string {
+  if (ctx.segmentStyle === "pill") {
+    return bg(ctx.theme, semantic, text, ctx.colors, ctx.pillTextColor);
+  }
   return fg(ctx.theme, semantic, text, ctx.colors);
 }
 
@@ -142,6 +145,23 @@ const gitSegment: StatusLineSegment = {
     const isDirty = gitStatus && (gitStatus.staged > 0 || gitStatus.unstaged > 0 || gitStatus.untracked > 0);
     const showBranch = opts.showBranch !== false;
     const branchColor: SemanticColor = isDirty ? "gitDirty" : "gitClean";
+
+    // In pill mode the whole segment is wrapped in a single background pill,
+    // so indicators stay plain text (per-part ANSI resets would break the pill).
+    if (ctx.segmentStyle === "pill") {
+      let text = showBranch && branch ? withIcon(icons.branch, branch) : "";
+      if (gitStatus) {
+        const indicators: string[] = [];
+        if (opts.showUnstaged !== false && gitStatus.unstaged > 0) indicators.push(`*${gitStatus.unstaged}`);
+        if (opts.showStaged !== false && gitStatus.staged > 0) indicators.push(`+${gitStatus.staged}`);
+        if (opts.showUntracked !== false && gitStatus.untracked > 0) indicators.push(`?${gitStatus.untracked}`);
+        if (indicators.length > 0) {
+          text = text ? `${text} ${indicators.join(" ")}` : indicators.join(" ");
+        }
+      }
+      if (!text) return { content: "", visible: false };
+      return { content: color(ctx, branchColor, text), visible: true };
+    }
 
     // Build content - color branch separately from indicators
     let content = "";
@@ -300,15 +320,12 @@ const contextPctSegment: StatusLineSegment = {
     const autoIcon = ctx.autoCompactEnabled && icons.auto ? ` ${icons.auto}` : "";
     const text = `${formatTokens(contextTokens)}/${formatTokens(contextWindow)} (${contextPercent.toFixed(1)}%)${autoIcon}`;
 
-    // Icon outside color, text inside - use semantic colors for thresholds
-    let content: string;
-    if (contextPercent > 90) {
-      content = withIcon(icons.context, color(ctx, "contextError", text));
-    } else if (contextPercent > 70) {
-      content = withIcon(icons.context, color(ctx, "contextWarn", text));
-    } else {
-      content = withIcon(icons.context, color(ctx, "context", text));
-    }
+    // Icon outside color, text inside - use semantic colors for thresholds.
+    // In pill mode the icon goes inside the pill so the background is unbroken.
+    const semantic: SemanticColor = contextPercent > 90 ? "contextError" : contextPercent > 70 ? "contextWarn" : "context";
+    const content = ctx.segmentStyle === "pill"
+      ? color(ctx, semantic, withIcon(icons.context, text))
+      : withIcon(icons.context, color(ctx, semantic, text));
 
     return { content, visible: true };
   },
@@ -480,8 +497,19 @@ function renderCustomSegment(id: `custom:${string}`, ctx: SegmentContext): Rende
   if (custom.prefix) {
     content = `${custom.prefix}${SEP_DOT}${content}`;
   }
+  // In pill mode, strip ANSI resets and color codes from extension content
+  // so the pill's own background and text color are not broken.
+  if (ctx.segmentStyle === "pill") {
+    content = content
+      .replace(/\x1b\[0m/g, "")
+      .replace(/\x1b\[48;[0-9;]*m/g, "")
+      .replace(/\x1b\[38;[0-9;]*m/g, "")
+      .replace(/\x1b\[(?:3[0-9]|9[0-7])m/g, "");
+  }
   if (custom.color) {
-    content = applyColor(ctx.theme, custom.color, content);
+    content = ctx.segmentStyle === "pill"
+      ? applyBgColor(ctx.theme, custom.color, content, ctx.pillTextColor)
+      : applyColor(ctx.theme, custom.color, content);
   }
 
   return { content, visible: true };

--- a/tests/pill-bar.test.ts
+++ b/tests/pill-bar.test.ts
@@ -1,0 +1,326 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildContentFromParts, ensurePillBg, resolveSeparatorStyle } from "../index.ts";
+import { parsePowerlineConfig } from "../powerline-config.ts";
+import { getPreset, PRESETS } from "../presets.ts";
+import { applyBgColor, bgAnsiToRgb, rainbow, resolveColor, setPillBold, setSettingsColors } from "../theme.ts";
+import { renderSegment } from "../segments.ts";
+import { getSeparatorChars } from "../icons.ts";
+
+const PRESET_NAMES = Object.keys(PRESETS) as Array<keyof typeof PRESETS>;
+const plainTheme = { fg: (_color: string, text: string) => text };
+
+const originalNerdFonts = process.env.POWERLINE_NERD_FONTS;
+process.env.POWERLINE_NERD_FONTS = "1";
+test.after(() => {
+  if (originalNerdFonts === undefined) {
+    delete process.env.POWERLINE_NERD_FONTS;
+  } else {
+    process.env.POWERLINE_NERD_FONTS = originalNerdFonts;
+  }
+});
+
+function bgAnsi(rgb: [number, number, number]): string {
+  return `\x1b[48;2;${rgb.join(";")}m`;
+}
+
+function fgAnsi(rgb: [number, number, number]): string {
+  return `\x1b[38;2;${rgb.join(";")}m`;
+}
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace("#", "");
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+}
+
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+test("settings.json separator is parsed", () => {
+  const parsed = parsePowerlineConfig({ segmentStyle: "pill", separator: "powerline" }, PRESET_NAMES);
+  assert.equal(parsed.segmentStyle, "pill");
+  assert.equal(parsed.separator, "powerline");
+
+  const invalid = parsePowerlineConfig({ separator: "nope" }, PRESET_NAMES);
+  assert.equal(invalid.separator, null);
+
+  const missing = parsePowerlineConfig({ segmentStyle: "pill" }, PRESET_NAMES);
+  assert.equal(missing.separator, null);
+});
+
+test("resolveSeparatorStyle: explicit config wins, pill defaults to solid powerline", () => {
+  const defaultPreset = getPreset("default"); // preset separator: powerline-thin
+  assert.equal(resolveSeparatorStyle(defaultPreset, "pill", "powerline-thin"), "powerline-thin");
+  assert.equal(resolveSeparatorStyle(defaultPreset, "pill", null), "powerline");
+  assert.equal(resolveSeparatorStyle(defaultPreset, "fg", null), "powerline-thin");
+  assert.equal(resolveSeparatorStyle(getPreset("full"), "pill", null), "powerline");
+});
+
+test("ensurePillBg keeps existing pills and wraps fg-only content in a neutral pill", () => {
+  const pill = applyBgColor(plainTheme, "#d787af", "model");
+  assert.equal(ensurePillBg(pill), pill);
+
+  const wrapped = ensurePillBg(rainbow("think:high"));
+  assert.ok(wrapped.startsWith(bgAnsi(hexToRgb("#45475a"))));
+  assert.equal(stripAnsi(wrapped), " think:high ");
+});
+
+test("pill mode renders a seamless starship-style bar with transitions and end cap", () => {
+  const arrow = getSeparatorChars().powerlineLeft;
+  const modelRgb = hexToRgb("#d787af");
+  const pathRgb = hexToRgb("#00afaf");
+  const gitRgb = hexToRgb("#f9e2af");
+  const neutralRgb = hexToRgb("#45475a");
+
+  const parts = [
+    applyBgColor(plainTheme, "#d787af", " Kimi K3"),
+    rainbow("think:high"), // fg-only: must be wrapped, not break the chain
+    applyBgColor(plainTheme, "#00afaf", " project"),
+    applyBgColor(plainTheme, "#f9e2af", " main *1"),
+  ];
+
+  const out = buildContentFromParts(parts, "powerline", "pill", "arrow");
+
+  // Every boundary gets a colored transition arrow: bg=next, fg=current
+  const transition = (from: [number, number, number], to: [number, number, number]) =>
+    `${bgAnsi(to)}${fgAnsi(from)}${arrow}`;
+  assert.ok(out.includes(transition(modelRgb, neutralRgb)), "model → thinking transition");
+  assert.ok(out.includes(transition(neutralRgb, pathRgb)), "thinking → path transition");
+  assert.ok(out.includes(transition(pathRgb, gitRgb)), "path → git transition");
+
+  // No dark gaps: no reset inside the bar body (leading clean-slate reset is fine)
+  const body = out.slice("\x1b[0m ".length, out.lastIndexOf("\x1b[0m"));
+  assert.ok(!body.includes("\x1b[0m"), "bar body never resets to terminal background");
+
+  // End cap closes the bar in the last pill's color, drawn on the default background
+  assert.ok(out.endsWith(`${fgAnsi(gitRgb)}${arrow}\x1b[0m `), "end cap in last pill color");
+  assert.ok(
+    out.includes(`\x1b[49m${fgAnsi(gitRgb)}${arrow}`),
+    "end cap resets background first or it would be invisible (fg-on-same-bg)"
+  );
+
+  // Visible text unchanged (pills pad with one space per side, bar has leading/trailing space)
+  assert.equal(stripAnsi(out), `   Kimi K3 ${arrow} think:high ${arrow}  project ${arrow}  main *1 ${arrow} `);
+});
+
+test("pill mode with powerline-thin keeps thin arrows and end cap", () => {
+  const thin = getSeparatorChars().powerlineThinLeft;
+  const modelRgb = hexToRgb("#d787af");
+  const pathRgb = hexToRgb("#00afaf");
+  const parts = [
+    applyBgColor(plainTheme, "#d787af", "m"),
+    applyBgColor(plainTheme, "#00afaf", "p"),
+  ];
+  const out = buildContentFromParts(parts, "powerline-thin", "pill", "arrow");
+  assert.ok(out.includes(`${bgAnsi(pathRgb)}${fgAnsi(modelRgb)}${thin}`));
+  assert.ok(out.endsWith(`${fgAnsi(pathRgb)}${thin}\x1b[0m `));
+});
+
+test("fg mode rendering is unchanged", () => {
+  const out = buildContentFromParts(["aaa", "bbb"], "powerline-thin", "fg");
+  const thin = getSeparatorChars().powerlineThinLeft;
+  assert.equal(stripAnsi(out), ` aaa ${thin} bbb `);
+});
+
+test("non-arrow separators in pill mode get transitions but no end cap", () => {
+  const parts = [
+    applyBgColor(plainTheme, "#d787af", "m"),
+    applyBgColor(plainTheme, "#00afaf", "p"),
+  ];
+  const out = buildContentFromParts(parts, "dot", "pill");
+  assert.ok(out.includes("·"));
+  assert.ok(out.endsWith("\x1b[0m "));
+});
+
+test("round caps render half-circle ends in the edge pill colors", () => {
+  const modelRgb = hexToRgb("#d787af");
+  const pathRgb = hexToRgb("#00afaf");
+  const parts = [
+    applyBgColor(plainTheme, "#d787af", "m"),
+    applyBgColor(plainTheme, "#00afaf", "p"),
+  ];
+  const out = buildContentFromParts(parts, "powerline", "pill", "round");
+  assert.ok(out.startsWith(`\x1b[0m ${fgAnsi(modelRgb)}\uE0B6`), "left round cap in first pill color");
+  assert.ok(out.endsWith(`${fgAnsi(pathRgb)}\uE0B4\x1b[0m `), "right round cap in last pill color");
+  assert.ok(
+    out.includes(`\x1b[49m${fgAnsi(pathRgb)}\uE0B4`),
+    "right round cap resets background first or it would be invisible"
+  );
+  assert.equal(stripAnsi(out), ` \uE0B6 m ${getSeparatorChars().powerlineLeft} p \uE0B4 `);
+});
+
+test("flat caps render no end glyphs", () => {
+  const parts = [applyBgColor(plainTheme, "#d787af", "m")];
+  const out = buildContentFromParts(parts, "powerline", "pill", "flat");
+  assert.ok(out.endsWith("\x1b[0m "));
+  assert.ok(!out.includes("\uE0B6") && !out.includes("\uE0B4"));
+});
+
+test("pill text color: dark forces near-black, contrast follows luminance, hex passes through", () => {
+  const darkOnPink = applyBgColor(plainTheme, "#d787af", "m", "dark");
+  assert.ok(darkOnPink.includes(fgAnsi(hexToRgb("#1e1e2e"))));
+
+  const lightOnPink = applyBgColor(plainTheme, "#d787af", "m", "light");
+  assert.ok(lightOnPink.includes(fgAnsi(hexToRgb("#cdd6f4"))));
+
+  const autoOnPink = applyBgColor(plainTheme, "#d787af", "m", "contrast");
+  assert.ok(autoOnPink.includes(fgAnsi(hexToRgb("#1e1e2e"))), "light bg auto-gets dark text");
+
+  const autoOnGray = applyBgColor(plainTheme, "#45475a", "m", "contrast");
+  assert.ok(autoOnGray.includes(fgAnsi(hexToRgb("#cdd6f4"))), "dark bg auto-gets light text");
+
+  const custom = applyBgColor(plainTheme, "#d787af", "m", "#ff0000");
+  assert.ok(custom.includes(fgAnsi(hexToRgb("#ff0000"))));
+});
+
+test("settings.json powerline.colors overrides theme/preset/default resolution", () => {
+  try {
+    setSettingsColors({ model: "#112233" });
+    assert.equal(resolveColor("model", { model: "#445566" }), "#112233");
+    assert.equal(resolveColor("path", { path: "#445566" }), "#445566", "preset still works for unset keys");
+  } finally {
+    setSettingsColors({});
+  }
+});
+
+test("powerline config parses caps, pillTextColor, and colors", () => {
+  const parsed = parsePowerlineConfig({
+    segmentStyle: "pill",
+    caps: "round",
+    pillTextColor: "#000000",
+    colors: { model: "#112233", bogus: "#000000" },
+  }, PRESET_NAMES);
+  assert.equal(parsed.caps, "round");
+  assert.equal(parsed.pillTextColor, "#000000");
+  assert.deepEqual(parsed.colors, { model: "#112233" });
+
+  const defaults = parsePowerlineConfig({}, PRESET_NAMES);
+  assert.equal(defaults.caps, "round");
+  assert.equal(defaults.pillTextColor, "dark");
+  assert.deepEqual(defaults.colors, {});
+
+  const invalid = parsePowerlineConfig({ caps: "triangle", pillTextColor: "blueish" }, PRESET_NAMES);
+  assert.equal(invalid.caps, "round");
+  assert.equal(invalid.pillTextColor, "dark");
+});
+
+test("pill bold is on by default and can be disabled", () => {
+  try {
+    setPillBold(true);
+    assert.ok(applyBgColor(plainTheme, "#d787af", "m", "dark").includes("\x1b[1m"));
+    setPillBold(false);
+    assert.ok(!applyBgColor(plainTheme, "#d787af", "m", "dark").includes("\x1b[1m"));
+  } finally {
+    setPillBold(true);
+  }
+
+  assert.equal(parsePowerlineConfig({}, PRESET_NAMES).pillBold, true);
+  assert.equal(parsePowerlineConfig({ pillBold: false }, PRESET_NAMES).pillBold, false);
+});
+
+test("custom segments strip extension fg colors in pill mode", () => {
+  const ctx: any = {
+    segmentStyle: "pill",
+    pillTextColor: "dark",
+    theme: plainTheme,
+    colors: {},
+    customItemsById: new Map([["tavily", {
+      id: "tavily",
+      statusKey: "tavily-status",
+      position: "right",
+      color: "#a6e3a1",
+      hideWhenMissing: true,
+      excludeFromExtensionStatuses: true,
+    }]]),
+    extensionStatuses: new Map([["tavily-status", "\x1b[38;2;205;214;244mTavily:0%\x1b[0m"]]),
+    hiddenExtensionStatusKeys: new Set(),
+    options: {},
+  };
+  const rendered = renderSegment("custom:tavily", ctx);
+  // extension's light fg is gone; pill dark text wins
+  assert.ok(!rendered.content.includes("38;2;205;214;244"));
+  assert.ok(rendered.content.includes(fgAnsi(hexToRgb("#1e1e2e"))));
+  assert.equal(stripAnsi(rendered.content), " Tavily:0% ");
+});
+
+test("theme-key colors render as pills via the runtime theme background", () => {
+  // Truecolor theme: accent resolves to a 48;2 background sequence
+  const truecolorTheme = {
+    fg: (_color: string, text: string) => text,
+    getBgAnsi: (color: string) => {
+      if (color === "accent") return "\x1b[48;2;250;179;135m"; // Catppuccin peach
+      throw new Error(`Unknown theme color: ${color}`);
+    },
+  };
+
+  const pill = applyBgColor(truecolorTheme, "accent" as any, "m");
+  assert.ok(pill.startsWith("\x1b[48;2;250;179;135m"), "uses the theme's resolved bg sequence");
+  assert.ok(pill.includes(fgAnsi(hexToRgb("#1e1e2e"))), "light bg auto-gets dark text");
+  assert.equal(stripAnsi(pill), " m ");
+});
+
+test("theme-key pills chain seamlessly with 256-palette sequences", () => {
+  // 256-color theme: colors resolve to 48;5 background sequences
+  const paletteTheme = {
+    fg: (_color: string, text: string) => text,
+    getBgAnsi: (color: string) => {
+      if (color === "accent") return "\x1b[48;5;173m";
+      if (color === "success") return "\x1b[48;5;114m";
+      throw new Error(`Unknown theme color: ${color}`);
+    },
+  };
+
+  const parts = [
+    applyBgColor(paletteTheme, "accent" as any, "m"),
+    applyBgColor(paletteTheme, "success" as any, "p"),
+  ];
+  const out = buildContentFromParts(parts, "powerline", "pill", "arrow");
+  const arrow = getSeparatorChars().powerlineLeft;
+
+  // Transition reuses the raw sequences with 48->38 swapped: bg=next, fg=current
+  assert.ok(out.includes(`\x1b[48;5;114m\x1b[38;5;173m${arrow}`), "256-palette transition");
+  assert.ok(out.endsWith(`\x1b[38;5;114m${arrow}\x1b[0m `), "end cap in last pill color");
+});
+
+test("bgAnsiToRgb parses truecolor and approximates palette indexes", () => {
+  assert.deepEqual(bgAnsiToRgb("\x1b[48;2;255;0;0m"), [255, 0, 0]);
+  assert.deepEqual(bgAnsiToRgb("\x1b[48;5;196m"), [255, 0, 0], "cube index 196 is pure red");
+  assert.deepEqual(bgAnsiToRgb("\x1b[48;5;238m"), [68, 68, 68], "grayscale ramp");
+  assert.equal(bgAnsiToRgb("\x1b[31m"), null);
+});
+
+test("theme-key contrast text follows luminance recovered from the bg sequence", () => {
+  const paletteTheme = {
+    fg: (_color: string, text: string) => text,
+    getBgAnsi: (color: string) => {
+      if (color === "dark") return "\x1b[48;5;16m";  // cube black
+      if (color === "light") return "\x1b[48;5;231m"; // cube white
+      throw new Error(`Unknown theme color: ${color}`);
+    },
+  };
+
+  const onBlack = applyBgColor(paletteTheme, "dark" as any, "m", "contrast");
+  assert.ok(onBlack.includes(fgAnsi(hexToRgb("#cdd6f4"))), "dark bg auto-gets light text");
+
+  const onWhite = applyBgColor(paletteTheme, "light" as any, "m", "contrast");
+  assert.ok(onWhite.includes(fgAnsi(hexToRgb("#1e1e2e"))), "light bg auto-gets dark text");
+});
+
+test("themes without getBgAnsi fall back to fg-only, neutral-wrapped downstream", () => {
+  // plainTheme has no getBgAnsi: semantic colors render fg-only...
+  const fgOnly = applyBgColor(plainTheme, "accent" as any, "think:high");
+  assert.equal(fgOnly, "think:high");
+
+  // ...and the bar wraps them in a neutral pill so the chain stays seamless
+  const wrapped = ensurePillBg(fgOnly);
+  assert.ok(wrapped.startsWith(bgAnsi(hexToRgb("#45475a"))));
+  assert.equal(stripAnsi(wrapped), " think:high ");
+
+  // Same fallback when getBgAnsi throws for an unknown key
+  const throwingTheme = {
+    fg: (_color: string, text: string) => text,
+    getBgAnsi: () => { throw new Error("nope"); },
+  };
+  assert.equal(applyBgColor(throwingTheme, "accent" as any, "x"), "x");
+});

--- a/theme.ts
+++ b/theme.ts
@@ -11,7 +11,7 @@ import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ColorScheme, ColorValue, SemanticColor, ThemeLike } from "./types.ts";
+import type { ColorScheme, ColorValue, PillTextColor, SemanticColor, ThemeLike } from "./types.ts";
 
 export interface PowerlineThemeConfig {
   colors?: unknown;
@@ -81,6 +81,32 @@ function sanitizeUserThemeOverrides(value: unknown): ColorScheme {
   return sanitized;
 }
 
+/** Sanitize a user-provided color override map (theme.json or settings.json powerline.colors) */
+export function sanitizeColorOverrides(value: unknown): ColorScheme {
+  return sanitizeUserThemeOverrides(value);
+}
+
+// Colors from settings.json powerline.colors (highest priority layer)
+let settingsColors: ColorScheme = {};
+
+/** Register color overrides coming from settings.json (powerline.colors) */
+export function setSettingsColors(colors: ColorScheme | undefined): void {
+  settingsColors = colors ?? {};
+}
+
+// Bold text inside pills (powerline.pillBold, default true)
+let pillBoldEnabled = true;
+
+/** Toggle bold text inside pills */
+export function setPillBold(enabled: boolean): void {
+  pillBoldEnabled = enabled;
+}
+
+/** Whether pill text is rendered bold */
+export function isPillBold(): boolean {
+  return pillBoldEnabled;
+}
+
 /**
  * Get the path to the theme.json file
  */
@@ -138,8 +164,9 @@ export function resolveColor(
 ): ColorValue {
   const userTheme = loadUserTheme();
   
-  // Priority: user overrides > preset colors > defaults
-  return userTheme[semantic] 
+  // Priority: settings.json colors > theme.json overrides > preset colors > defaults
+  return settingsColors[semantic]
+    ?? userTheme[semantic] 
     ?? presetColors?.[semantic] 
     ?? DEFAULT_COLORS[semantic];
 }
@@ -152,14 +179,132 @@ function isHexColor(color: ColorValue): color is `#${string}` {
 }
 
 /**
- * Convert hex color to ANSI escape code
+ * Convert hex color to ANSI escape code (foreground)
  */
-function hexToAnsi(hex: string): string {
+export function hexToAnsi(hex: string): string {
   const h = hex.replace("#", "");
   const r = parseInt(h.slice(0, 2), 16);
   const g = parseInt(h.slice(2, 4), 16);
   const b = parseInt(h.slice(4, 6), 16);
   return `\x1b[38;2;${r};${g};${b}m`;
+}
+
+/**
+ * Convert hex color to ANSI background escape code
+ */
+export function hexToBgAnsi(hex: string): string {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `\x1b[48;2;${r};${g};${b}m`;
+}
+
+// Standard xterm palette for the 16 base colors (used to approximate
+// luminance when a theme color resolves to a 256-palette index; users can
+// remap 0-15 in their terminal, so those are best-effort).
+const XTERM_BASE16: Array<[number, number, number]> = [
+  [0, 0, 0], [205, 0, 0], [0, 205, 0], [205, 205, 0],
+  [0, 0, 238], [205, 0, 205], [0, 205, 205], [229, 229, 229],
+  [127, 127, 127], [255, 0, 0], [0, 255, 0], [255, 255, 0],
+  [92, 92, 255], [255, 0, 255], [0, 255, 255], [255, 255, 255],
+];
+
+const XTERM_CUBE_STEPS = [0, 95, 135, 175, 215, 255];
+
+/** Approximate RGB of an xterm 256-palette index. */
+function paletteIndexToRgb(index: number): [number, number, number] | null {
+  if (index < 0 || index > 255) return null;
+  if (index < 16) return XTERM_BASE16[index];
+  if (index < 232) {
+    const n = index - 16;
+    return [
+      XTERM_CUBE_STEPS[Math.floor(n / 36) % 6],
+      XTERM_CUBE_STEPS[Math.floor(n / 6) % 6],
+      XTERM_CUBE_STEPS[n % 6],
+    ];
+  }
+  const level = 8 + (index - 232) * 10;
+  return [level, level, level];
+}
+
+/**
+ * Parse an SGR background sequence (`\x1b[48;2;r;g;bm` or `\x1b[48;5;Nm`)
+ * back into an approximate RGB triple. Returns null when unparseable.
+ */
+export function bgAnsiToRgb(bgAnsi: string): [number, number, number] | null {
+  const truecolor = bgAnsi.match(/^\x1b\[48;2;(\d+);(\d+);(\d+)m$/);
+  if (truecolor) {
+    return [parseInt(truecolor[1]), parseInt(truecolor[2]), parseInt(truecolor[3])];
+  }
+  const palette = bgAnsi.match(/^\x1b\[48;5;(\d+)m$/);
+  if (palette) {
+    return paletteIndexToRgb(parseInt(palette[1]));
+  }
+  return null;
+}
+
+/**
+ * Derive the matching foreground SGR sequence for a background SGR sequence
+ * (`48` -> `38`), so separators/caps can reuse a pill's background color
+ * without knowing its RGB. Works for both truecolor and 256-palette forms.
+ */
+export function bgAnsiToFgAnsi(bgAnsi: string): string {
+  return bgAnsi.replace("\x1b[48", "\x1b[38");
+}
+
+/** Extract the leading background SGR sequence of a pill segment, if any. */
+export function extractBgAnsi(content: string): string | null {
+  const match = content.match(/^\x1b\[48;(?:2;\d+;\d+;\d+|5;\d+)m/);
+  return match ? match[0] : null;
+}
+
+const PILL_DARK_FG = "#1e1e2e";   // Catppuccin base (near-black)
+const PILL_LIGHT_FG = "#cdd6f4"; // Catppuccin text
+
+/** Relative luminance pick: light backgrounds get dark text and vice versa. */
+function contrastFgForRgb(r: number, g: number, b: number): string {
+  const lum = 0.2126 * (r / 255) + 0.7152 * (g / 255) + 0.0722 * (b / 255);
+  return lum > 0.5 ? PILL_DARK_FG : PILL_LIGHT_FG;
+}
+
+/**
+ * Compute contrast foreground color for a given background hex.
+ * Light backgrounds get dark text, dark backgrounds get light text.
+ */
+function contrastFg(hex: string): string {
+  const h = hex.replace("#", "");
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return contrastFgForRgb(r, g, b);
+}
+
+/**
+ * Resolve the pill text (foreground) color for a hex background.
+ * "dark"/"light" force a fixed color, "contrast" picks by background luminance,
+ * a hex string is used as-is.
+ */
+export function resolvePillTextColor(bgHex: string, textColor?: PillTextColor): string {
+  if (!textColor || textColor === "contrast") return contrastFg(bgHex);
+  if (textColor === "dark") return PILL_DARK_FG;
+  if (textColor === "light") return PILL_LIGHT_FG;
+  return isHexColor(textColor) ? textColor : contrastFg(bgHex);
+}
+
+/**
+ * Resolve the pill text (foreground) color for a background given as an SGR
+ * sequence (theme-key colors included). "contrast" uses the RGB recovered
+ * from the sequence (exact for truecolor, approximate for 256-palette) and
+ * falls back to dark text when the sequence is unparseable.
+ */
+export function resolvePillTextColorForBgAnsi(bgAnsi: string, textColor?: PillTextColor): string {
+  const rgb = bgAnsiToRgb(bgAnsi);
+  const contrast = rgb ? contrastFgForRgb(rgb[0], rgb[1], rgb[2]) : PILL_DARK_FG;
+  if (!textColor || textColor === "contrast") return contrast;
+  if (textColor === "dark") return PILL_DARK_FG;
+  if (textColor === "light") return PILL_LIGHT_FG;
+  return isHexColor(textColor) ? textColor : contrast;
 }
 
 /**
@@ -190,6 +335,38 @@ export function applyColor(
 }
 
 /**
+ * Apply a background color pill to text.
+ *
+ * Hex colors emit a truecolor background directly. Theme-key colors reuse
+ * the runtime theme's resolved background sequence (truecolor or 256-palette
+ * depending on the terminal), so pills follow the user's pi theme. When the
+ * theme cannot provide a background sequence the text falls back to
+ * foreground-only rendering (the bar wraps it in a neutral pill downstream).
+ */
+export function applyBgColor(
+  theme: ThemeLike,
+  color: ColorValue,
+  text: string,
+  textColor?: PillTextColor
+): string {
+  const bold = pillBoldEnabled ? "\x1b[1m" : "";
+  if (isHexColor(color)) {
+    const fg = resolvePillTextColor(color, textColor);
+    return `${hexToBgAnsi(color)}${hexToAnsi(fg)}${bold} ${text} \x1b[0m`;
+  }
+  if (typeof theme.getBgAnsi === "function") {
+    try {
+      const bgAnsi = theme.getBgAnsi(color as string);
+      const fgAnsi = hexToAnsi(resolvePillTextColorForBgAnsi(bgAnsi, textColor));
+      return `${bgAnsi}${fgAnsi}${bold} ${text} \x1b[0m`;
+    } catch {
+      // Unknown theme key for this theme: fall through to foreground-only.
+    }
+  }
+  return applyColor(theme, color, text);
+}
+
+/**
  * Apply a semantic color to text
  */
 export function fg(
@@ -200,6 +377,20 @@ export function fg(
 ): string {
   const color = resolveColor(semantic, presetColors);
   return applyColor(theme, color, text);
+}
+
+/**
+ * Apply a semantic color as a background pill to text
+ */
+export function bg(
+  theme: ThemeLike,
+  semantic: SemanticColor,
+  text: string,
+  presetColors?: ColorScheme,
+  textColor?: PillTextColor
+): string {
+  const color = resolveColor(semantic, presetColors);
+  return applyBgColor(theme, color, text, textColor);
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -2,7 +2,14 @@ import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
 
 // Theme color - either a pi theme color name or a custom hex color
 export type ColorValue = ThemeColor | `#${string}`;
-export type ThemeLike = Pick<Theme, "fg">;
+
+// Extensions only rely on fg rendering; pill mode additionally uses the raw
+// background ANSI sequence (when the runtime theme exposes it) so that both
+// hex and theme-key colors can render as seamless background pills.
+export type ThemeLike = Pick<Theme, "fg"> & {
+  getBgAnsi?: (color: string) => string;
+  getColorMode?: () => string;
+};
 
 // Semantic color names for segments
 export type SemanticColor =
@@ -66,6 +73,12 @@ export type StatusLineSeparatorStyle =
   | "dot"
   | "chevron"
   | "star";
+
+// Pill bar end-cap style (pill mode only)
+export type PowerlineCaps = "round" | "arrow" | "flat";
+
+// Pill text color: fixed dark/light, auto contrast, or a custom hex
+export type PillTextColor = "dark" | "light" | "contrast" | `#${string}`;
 
 // Preset names
 export type PowerlinePlacement = "above" | "below";
@@ -198,6 +211,12 @@ export interface SegmentContext {
   // Theming
   theme: ThemeLike;
   colors: ColorScheme;
+
+  // Rendering style
+  segmentStyle: "fg" | "pill";
+
+  // Text color inside pills (undefined = auto contrast)
+  pillTextColor?: PillTextColor;
 }
 
 // Rendered segment output


### PR DESCRIPTION
## What

<img width="2930" height="53" alt="image" src="https://github.com/user-attachments/assets/1c89e5cf-c8b3-4c65-b22a-718246d4fc24" />


Adds an opt-in `powerline.segmentStyle: "pill"` rendering mode: segments become colored background blocks (Starship/Coralline style) with seamless powerline arrow transitions between them. `segmentStyle: "fg"` (default) is byte-for-byte the current rendering.

```
[bg=pink] model [bg=teal][fg=pink][fg=dark] path [bg=next][fg=teal] ...
```

## Design: pills follow the user's pi theme

Instead of requiring hex colors, theme-key colors (e.g. `"accent"`, `"warning"`) reuse the **runtime theme's resolved background SGR sequence** via `theme.getBgAnsi()` (works in both truecolor and 256-color mode; hex colors still emit truecolor directly). Transition arrows and end caps derive the matching foreground by swapping `48` → `38` in the sequence, so no RGB extraction is needed and any terminal color mode chains seamlessly.

- Default color scheme is **unchanged** (still theme keys) — pill mode renders them as-is, fg mode is untouched
- Pill text color: `pillTextColor: "dark" (default) | "light" | "contrast" | #rrggbb`; `contrast` computes luminance from the resolved background (palette indexes approximated via the standard xterm table)
- `pillBold` (default `true`)
- Fg-only segments (e.g. rainbow thinking) are wrapped in a neutral `#45475a` pill so the bar never breaks
- Themes without `getBgAnsi` (or unknown keys) degrade to fg-only rendering + neutral wrap — never a broken bar

## New config keys (`powerline.*`)

| key | default | notes |
|-----|---------|-------|
| `segmentStyle` | `"fg"` | `"pill"` enables the new mode |
| `separator` | preset's | explicit override; pill mode defaults to solid `powerline` |
| `caps` | `"round"` | bar end caps: `round` (Nerd Font) / `arrow` / `flat` |
| `pillTextColor` | `"dark"` | see above |
| `pillBold` | `true` | bold text inside pills |
| `colors` | `{}` | settings-level color overrides, priority: settings.json > theme.json > preset > defaults |

## Segment handling in pill mode

- git segment: indicators become plain text and the whole segment gets one pill (per-part ANSI resets would break the background)
- context_pct: icon moves inside the pill
- custom (extension) segments: embedded fg/bg/reset codes are stripped so extensions can't break the pill background; `custom.color` works as pill background

## Tests

19 new cases in `tests/pill-bar.test.ts`: config parsing, separator resolution, seamless transitions (truecolor + 256-palette), end caps (round/arrow/flat), contrast text color, neutral wrapping, settings color layer, custom segment stripping, fg-mode regression. Full suite: 193 pass.

Note: touches `powerline-config.ts` and `index.ts`, so it will trivially conflict with #105 whichever lands second — happy to rebase.