### PR TITLE
perf: cache session token scan and serve-stale git invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Scroll-away card toggle** — Added `powerline.scrollAwayCard` and `/powerline scroll-away-card on|off|toggle` so the fixed editor and chat navigation shortcuts can remain enabled while the scroll-away hint card is hidden. Thanks to Alexander Gerdes (@Avg8888), Whisperfall, and Bruno Orsolon (@brunoorsolon) for #97/#108/#99.
 
 ### Changed
+- **Status render caching** — Caches session token aggregation between unchanged render inputs and keeps stale git segment values visible during background refreshes, reducing long-session redraw work and git flicker. Thanks to Andy8647 for #107.
 - **Fixed-editor scrolling performance** — Uses terminal row shifts, cached transcript lines, an 8 ms repaint cadence, and transient shortcut-card hiding during active wheel movement to cut scroll latency and terminal output churn.
 
 ### Fixed

--- a/git-status.ts
+++ b/git-status.ts
@@ -202,17 +202,20 @@ export function getGitStatus(providerBranch: string | null, pollingMode: GitPoll
 }
 
 /**
- * Force refresh git status (call when you know files changed)
+ * Force refresh git status (call when you know files changed).
+ * Serve-stale: keep the last known counts on screen while a background
+ * refresh runs, instead of blanking the segment to zeros (footer flicker).
  */
 export function invalidateGitStatus(): void {
-  cachedStatus = null;
+  if (cachedStatus) cachedStatus.timestamp = 0; // expire, but keep serving the stale value
   invalidationCounter++; // Increment to invalidate any pending fetches
 }
 
 /**
- * Force refresh git branch (call when you know branch might have changed)
+ * Force refresh git branch (call when you know branch might have changed).
+ * Serve-stale: keep showing the last known branch until the refresh lands.
  */
 export function invalidateGitBranch(): void {
-  cachedBranch = null;
+  if (cachedBranch) cachedBranch.timestamp = 0; // expire, but keep serving the stale value
   branchInvalidationCounter++;
 }

--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,7 @@ import { collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, mer
 import { getSeparator } from "./separators.ts";
 import { renderSegment } from "./segments.ts";
 import { getGitStatus, invalidateGitStatus, invalidateGitBranch } from "./git-status.ts";
+import { SessionTokenStatsCache } from "./token-stats.ts";
 import { ansi, getFgAnsiCode } from "./colors.ts";
 import { WelcomeComponent, WelcomeHeader, discoverLoadedCounts, getRecentSessions } from "./welcome.ts";
 import { createWelcomeDismissScheduler } from "./welcome-dismiss.ts";
@@ -1110,6 +1111,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   let forceNextLayoutRecompute = false;
   let lastEditorInputAt = 0;
 
+  // Cache for token counting: avoid re-scanning the full session event list
+  // on every render (250ms-1s cadence). Revalidates the trailing event's
+  // stats signature so in-place streaming updates are not served stale.
+  const tokenStatsCache = new SessionTokenStatsCache();
+
   const getShellPath = () => process.env.SHELL || "/bin/sh";
   const getShellCwd = () => shellSession?.state.cwd ?? currentCtx?.cwd ?? process.cwd();
   const welcomeDismissScheduler = createWelcomeDismissScheduler({
@@ -1131,6 +1137,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   const resetLayoutCache = () => {
     lastLayoutResult = null;
     layoutDirty = true;
+    tokenStatsCache.reset();
   };
 
   const requestStatusRender = (delayMs?: number) => {
@@ -2175,39 +2182,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const presetDef = getPreset(config.preset);
     const colors: ColorScheme = presetDef.colors ?? getDefaultColors();
 
-    // Build usage stats and get thinking level from session
-    let input = 0, output = 0, cacheRead = 0, cacheWrite = 0, cost = 0;
-    let lastAssistant: AssistantMessage | undefined;
-    let thinkingLevelFromSession: string | null = null;
-    
+    // Build usage stats and get thinking level from session (cached; the full
+    // event list is only re-scanned when events are appended or the trailing
+    // event's stats-relevant fields change, e.g. in-place streaming updates)
     const sessionEvents = ctx.sessionManager?.getBranch?.() ?? [];
-    for (const e of sessionEvents) {
-      if (!isRecord(e)) {
-        continue;
-      }
-
-      // Check for thinking level change entries
-      if (e.type === "thinking_level_change" && typeof e.thinkingLevel === "string") {
-        thinkingLevelFromSession = e.thinkingLevel;
-      }
-
-      if (e.type !== "message" || !isSessionAssistantMessage(e.message)) {
-        continue;
-      }
-
-      const m = e.message;
-      if (m.stopReason === "error" || m.stopReason === "aborted") {
-        continue;
-      }
-      input += m.usage.input;
-      output += m.usage.output;
-      cacheRead += m.usage.cacheRead;
-      cacheWrite += m.usage.cacheWrite;
-      cost += m.usage.cost.total;
-      if (getUsageTokenTotal(m.usage) > 0) {
-        lastAssistant = m;
-      }
-    }
+    const tokenStats = tokenStatsCache.get(sessionEvents);
+    const { input, output, cacheRead, cacheWrite, cost } = tokenStats;
+    const lastAssistant = tokenStats.lastAssistant;
+    const thinkingLevelFromSession = tokenStats.thinkingLevelFromSession;
 
     // Calculate context percentage.
     const latestUsage = isStreaming ? liveAssistantUsage ?? lastAssistant?.usage : lastAssistant?.usage;

--- a/tests/git-status.test.ts
+++ b/tests/git-status.test.ts
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { getGitStatus } from "../git-status.ts";
+import { getCurrentBranch, getGitStatus, invalidateGitBranch, invalidateGitStatus } from "../git-status.ts";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Background fetches spawn git with up to 500ms timeouts; give them room.
+const FETCH_SETTLE_MS = 1200;
 
 test("git status supports disabling extension git polling", () => {
   assert.deepEqual(getGitStatus("main", "off"), {
@@ -9,4 +14,32 @@ test("git status supports disabling extension git polling", () => {
     unstaged: 0,
     untracked: 0,
   });
+});
+
+test("invalidateGitStatus serves stale counts while refreshing (no flicker to zeros)", async () => {
+  getGitStatus("provider-branch"); // kick off the initial background fetch
+  await sleep(FETCH_SETTLE_MS);
+
+  const seeded = getGitStatus("provider-branch");
+
+  invalidateGitStatus();
+  const afterInvalidate = getGitStatus("provider-branch");
+  assert.deepEqual(afterInvalidate, seeded);
+
+  // The background refresh converges to real data again (repo is unchanged).
+  await sleep(FETCH_SETTLE_MS);
+  assert.deepEqual(getGitStatus("provider-branch"), seeded);
+});
+
+test("invalidateGitBranch keeps serving the last known branch while refreshing", async () => {
+  getGitStatus("provider-fallback"); // seed branch cache
+  await sleep(FETCH_SETTLE_MS);
+
+  const realBranch = getCurrentBranch("provider-fallback");
+  // Once fetched, the cached branch no longer falls back to the provider
+  // (null in non-git directories, the actual branch name inside a repo).
+  assert.notEqual(realBranch, "provider-fallback");
+
+  invalidateGitBranch();
+  assert.equal(getCurrentBranch("provider-fallback"), realBranch);
 });

--- a/tests/jump-shortcuts.test.ts
+++ b/tests/jump-shortcuts.test.ts
@@ -10,6 +10,7 @@ import {
 import { parseBashModeSettings, resolveShortcutConfig } from "../index.ts";
 
 const source = readFileSync(new URL("../index.ts", import.meta.url), "utf-8");
+const tokenStatsSource = readFileSync(new URL("../token-stats.ts", import.meta.url), "utf-8");
 
 const powerlineShortcutKeys = new Set([
   "stashHistory",
@@ -123,7 +124,8 @@ test("editor submits follow the fixed chat viewport to bottom", () => {
 test("thinking level changes invalidate powerline status rendering", () => {
   assert.match(source, /let currentThinkingLevel: string \| null = null/);
   assert.match(source, /pi\.on\("thinking_level_select", async \(event, ctx\) => \{\n\s+currentCtx = ctx;\n\s+currentThinkingLevel = getThinkingLevelFn\?\.\(\) \?\? \(typeof event\.level === "string" \? event\.level : null\);\n\s+requestImmediateStatusRender\(\{ deferDuringTyping: false \}\);\n\s+\}\);/);
-  assert.match(source, /if \(e\.type === "thinking_level_change" && typeof e\.thinkingLevel === "string"\) \{\n\s+thinkingLevelFromSession = e\.thinkingLevel;/);
+  assert.match(tokenStatsSource, /if \(e\.type === "thinking_level_change" && typeof e\.thinkingLevel === "string"\) \{\n\s+thinkingLevelFromSession = e\.thinkingLevel;/);
+  assert.match(source, /const thinkingLevelFromSession = tokenStats\.thinkingLevelFromSession/);
   assert.match(source, /const thinkingLevel = currentThinkingLevel \?\? thinkingLevelFromSession \?\? getThinkingLevelFn\?\.\(\) \?\? "off"/);
 });
 
@@ -141,7 +143,7 @@ test("context usage changes repaint from live streaming message usage", () => {
   assert.match(source, /pi\.on\("agent_end", async \(_event, ctx\) => \{\n\s+isStreaming = false;\n\s+liveAssistantUsage = null;\n\n\s+let hasUI = false;/);
   assert.match(source, /currentCtx = ctx;\n\s+try \{\n\s+if \(hasUI\)/);
   assert.match(source, /pi\.on\("session_tree", async \(_event, ctx\) => \{\n\s+currentCtx = ctx;\n\s+currentThinkingLevel = null;\n\s+liveAssistantUsage = null;\n\s+requestImmediateStatusRender\(\{ deferDuringTyping: false \}\);\n\s+\}\);/);
-  assert.match(source, /if \(getUsageTokenTotal\(m\.usage\) > 0\) \{\n\s+lastAssistant = m;\n\s+\}/);
+  assert.match(tokenStatsSource, /if \(getUsageTokenTotal\(m\.usage\) > 0\) \{\n\s+lastAssistant = m;\n\s+\}/);
   assert.match(source, /const coreContextUsage = isStreaming && liveAssistantUsage \? null : readCoreContextUsage\(ctx\)/);
   assert.match(source, /const contextTokens = coreContextUsage\?\.contextTokens \?\? \(latestUsage \? getUsageTokenTotal\(latestUsage\) : 0\)/);
 });

--- a/tests/token-stats.test.ts
+++ b/tests/token-stats.test.ts
@@ -1,0 +1,171 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { computeSessionTokenStats, SessionTokenStatsCache } from "../token-stats.ts";
+
+function makeUsage(input: number, output: number, cacheRead = 0, cacheWrite = 0, costPerToken = 0.001) {
+  return {
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    cost: { total: (input + output + cacheRead + cacheWrite) * costPerToken },
+  };
+}
+
+function assistantEvent(usage: ReturnType<typeof makeUsage>, stopReason: string = "stop") {
+  return {
+    type: "message",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "hi" }],
+      usage,
+      stopReason,
+    },
+  };
+}
+
+function userEvent() {
+  return {
+    type: "message",
+    message: { role: "user", content: [{ type: "text", text: "hello" }] },
+  };
+}
+
+test("computeSessionTokenStats aggregates usage and tracks thinking level", () => {
+  const events = [
+    userEvent(),
+    { type: "thinking_level_change", thinkingLevel: "high" },
+    assistantEvent(makeUsage(10, 5)),
+    assistantEvent(makeUsage(20, 7, 3, 2), "error"), // skipped: error
+    assistantEvent(makeUsage(30, 9, 4, 1), "aborted"), // skipped: aborted
+    assistantEvent(makeUsage(40, 11, 6, 2)),
+  ];
+
+  const stats = computeSessionTokenStats(events);
+
+  assert.equal(stats.input, 50);
+  assert.equal(stats.output, 16);
+  assert.equal(stats.cacheRead, 6);
+  assert.equal(stats.cacheWrite, 2);
+  assert.ok(Math.abs(stats.cost - 0.074) < 1e-12);
+  assert.equal(stats.lastAssistant, (events[5] as any).message);
+  assert.equal(stats.thinkingLevelFromSession, "high");
+});
+
+test("computeSessionTokenStats ignores assistant messages without tokens for lastAssistant", () => {
+  const events = [
+    assistantEvent(makeUsage(10, 5)),
+    assistantEvent(makeUsage(0, 0)),
+  ];
+
+  const stats = computeSessionTokenStats(events);
+  assert.equal(stats.lastAssistant, (events[0] as any).message);
+});
+
+test("cache reuses stats object while session is unchanged", () => {
+  const cache = new SessionTokenStatsCache();
+  const events = [userEvent(), assistantEvent(makeUsage(10, 5))];
+
+  const first = cache.get(events);
+  const second = cache.get(events);
+
+  assert.equal(second, first);
+});
+
+test("cache recomputes when events are appended", () => {
+  const cache = new SessionTokenStatsCache();
+  const events = [assistantEvent(makeUsage(10, 5))];
+
+  const first = cache.get(events);
+  events.push(assistantEvent(makeUsage(20, 7)));
+  const second = cache.get(events);
+
+  assert.notEqual(second, first);
+  assert.equal(second.input, 30);
+  assert.equal(second.output, 12);
+});
+
+test("cache recomputes when the last event is updated in place (streaming)", () => {
+  const cache = new SessionTokenStatsCache();
+  const tail = assistantEvent(makeUsage(10, 5), "streaming");
+  const events = [userEvent(), tail];
+
+  const first = cache.get(events);
+  assert.equal(first.output, 5);
+
+  // Streaming updates the trailing assistant message in place: same event
+  // count, same object references, fresh usage numbers.
+  tail.message.usage = makeUsage(10, 42);
+  tail.message.stopReason = "stop";
+
+  const second = cache.get(events);
+  assert.notEqual(second, first);
+  assert.equal(second.output, 42);
+  assert.equal(second.lastAssistant, tail.message);
+});
+
+test("cache recomputes when the last event turns into an error in place", () => {
+  const cache = new SessionTokenStatsCache();
+  const tail = assistantEvent(makeUsage(10, 5));
+  const events = [assistantEvent(makeUsage(1, 1)), tail];
+
+  const first = cache.get(events);
+  assert.equal(first.input, 11);
+
+  tail.message.stopReason = "error";
+
+  const second = cache.get(events);
+  assert.notEqual(second, first);
+  assert.equal(second.input, 1);
+});
+
+test("cache recomputes when the last event is replaced with a same-sized list", () => {
+  const cache = new SessionTokenStatsCache();
+  const events = [userEvent(), assistantEvent(makeUsage(10, 5))];
+
+  const first = cache.get(events);
+  events[1] = assistantEvent(makeUsage(10, 5));
+  const second = cache.get(events);
+
+  assert.notEqual(second, first);
+  assert.deepEqual(
+    { input: second.input, output: second.output },
+    { input: first.input, output: first.output },
+  );
+});
+
+test("cache does not rescan for in-place changes to non-trailing events", () => {
+  const cache = new SessionTokenStatsCache();
+  const head = assistantEvent(makeUsage(10, 5));
+  const events = [head, assistantEvent(makeUsage(20, 7))];
+
+  const first = cache.get(events);
+
+  // Historical events are treated as immutable; only the trailing event is
+  // re-validated. This documents the cache's correctness boundary.
+  head.message.usage = makeUsage(999, 999);
+  const second = cache.get(events);
+
+  assert.equal(second, first);
+  assert.equal(second.input, 30);
+});
+
+test("reset forces recomputation", () => {
+  const cache = new SessionTokenStatsCache();
+  const events = [assistantEvent(makeUsage(10, 5))];
+
+  const first = cache.get(events);
+  cache.reset();
+  const second = cache.get(events);
+
+  assert.notEqual(second, first);
+  assert.equal(second.input, first.input);
+});
+
+test("index.ts wires the token stats cache into buildSegmentContext", () => {
+  const source = readFileSync(new URL("../index.ts", import.meta.url), "utf-8");
+  assert.match(source, /import \{ SessionTokenStatsCache \} from "\.\/token-stats\.ts";/);
+  assert.match(source, /tokenStatsCache\.get\(sessionEvents\)/);
+  assert.match(source, /tokenStatsCache\.reset\(\)/);
+});

--- a/token-stats.ts
+++ b/token-stats.ts
@@ -1,0 +1,157 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+
+type SessionAssistantUsage = AssistantMessage["usage"];
+
+export interface SessionTokenStats {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  cost: number;
+  lastAssistant: AssistantMessage | undefined;
+  thinkingLevelFromSession: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasSessionAssistantUsage(value: unknown): value is SessionAssistantUsage {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (
+    typeof value.input !== "number" ||
+    typeof value.output !== "number" ||
+    typeof value.cacheRead !== "number" ||
+    typeof value.cacheWrite !== "number"
+  ) {
+    return false;
+  }
+
+  return isRecord(value.cost) && typeof value.cost.total === "number";
+}
+
+function isSessionAssistantMessage(value: unknown): value is AssistantMessage {
+  return isRecord(value)
+    && value.role === "assistant"
+    && hasSessionAssistantUsage(value.usage)
+    && (value.stopReason === undefined || typeof value.stopReason === "string");
+}
+
+function getUsageTokenTotal(usage: SessionAssistantUsage): number {
+  const totalTokens = "totalTokens" in usage && typeof usage.totalTokens === "number" ? usage.totalTokens : 0;
+  return totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+}
+
+/**
+ * Fingerprint of the fields on a session event that influence the aggregated
+ * stats. Comparing only the event count is not enough: while streaming, pi
+ * may update the trailing assistant message in place (usage grows, stopReason
+ * flips), so the same event reference can carry fresh numbers.
+ */
+function eventStatsSignature(event: unknown): string {
+  if (!isRecord(event)) {
+    return "?";
+  }
+
+  if (event.type === "thinking_level_change") {
+    return `t:${typeof event.thinkingLevel === "string" ? event.thinkingLevel : ""}`;
+  }
+
+  if (event.type === "message" && isRecord(event.message)) {
+    const message = event.message;
+    const role = typeof message.role === "string" ? message.role : "";
+    const stopReason = typeof message.stopReason === "string" ? message.stopReason : "";
+    if (role === "assistant" && hasSessionAssistantUsage(message.usage)) {
+      const usage = message.usage;
+      return `a:${stopReason}:${usage.input}/${usage.output}/${usage.cacheRead}/${usage.cacheWrite}/${usage.cost.total}`;
+    }
+    return `m:${role}:${stopReason}`;
+  }
+
+  return `e:${typeof event.type === "string" ? event.type : "?"}`;
+}
+
+export function computeSessionTokenStats(sessionEvents: readonly unknown[]): SessionTokenStats {
+  let input = 0, output = 0, cacheRead = 0, cacheWrite = 0, cost = 0;
+  let lastAssistant: AssistantMessage | undefined;
+  let thinkingLevelFromSession: string | null = null;
+
+  for (const e of sessionEvents) {
+    if (!isRecord(e)) {
+      continue;
+    }
+
+    // Check for thinking level change entries
+    if (e.type === "thinking_level_change" && typeof e.thinkingLevel === "string") {
+      thinkingLevelFromSession = e.thinkingLevel;
+    }
+
+    if (e.type !== "message" || !isSessionAssistantMessage(e.message)) {
+      continue;
+    }
+
+    const m = e.message;
+    if (m.stopReason === "error" || m.stopReason === "aborted") {
+      continue;
+    }
+    input += m.usage.input;
+    output += m.usage.output;
+    cacheRead += m.usage.cacheRead;
+    cacheWrite += m.usage.cacheWrite;
+    cost += m.usage.cost.total;
+    if (getUsageTokenTotal(m.usage) > 0) {
+      lastAssistant = m;
+    }
+  }
+
+  return { input, output, cacheRead, cacheWrite, cost, lastAssistant, thinkingLevelFromSession };
+}
+
+/**
+ * Cache for token counting: avoid re-scanning the full session event list on
+ * every render (250ms-1s cadence while streaming). Reuses the aggregated
+ * totals while the session hasn't changed.
+ *
+ * An event-count-only check would go stale when streaming updates the last
+ * event in place, so validity requires all of:
+ *   1. same event count,
+ *   2. same last-event reference,
+ *   3. same last-event stats signature (usage/stopReason/thinking level).
+ */
+export class SessionTokenStatsCache {
+  private eventCount = -1;
+  private lastEvent: unknown;
+  private lastSignature = "";
+  private stats: SessionTokenStats | null = null;
+
+  get(sessionEvents: readonly unknown[]): SessionTokenStats {
+    const eventCount = sessionEvents.length;
+    const lastEvent = eventCount > 0 ? sessionEvents[eventCount - 1] : undefined;
+
+    if (
+      this.stats !== null
+      && this.eventCount === eventCount
+      && this.lastEvent === lastEvent
+      && this.lastSignature === eventStatsSignature(lastEvent)
+    ) {
+      return this.stats;
+    }
+
+    const stats = computeSessionTokenStats(sessionEvents);
+    this.eventCount = eventCount;
+    this.lastEvent = lastEvent;
+    this.lastSignature = eventStatsSignature(lastEvent);
+    this.stats = stats;
+    return stats;
+  }
+
+  reset(): void {
+    this.eventCount = -1;
+    this.lastEvent = undefined;
+    this.lastSignature = "";
+    this.stats = null;
+  }
+}


### PR DESCRIPTION
## What

Two perf/stability fixes for the status bar render path, both fixing pre-existing upstream issues. No new config keys, no behavior change in the reported numbers.

### 1. Cache the session event scan in `buildSegmentContext`

`buildSegmentContext` walks the **entire** session event list to aggregate token usage on every redraw — which happens every 250ms–1s while streaming, plus on every editor keystroke/status update. In long sessions this is a growing O(n) scan per render and a prime suspect for UI jank/freeze during heavy agent output.

The aggregation is extracted into `token-stats.ts` and cached. The cache is invalidated when:

1. the event count changes, **or**
2. the trailing event's reference changes, **or**
3. a signature of the trailing event's stats-relevant fields (usage numbers, `stopReason`, thinking level) changes

Checks 2+3 matter: while streaming, pi may update the last assistant message **in place**, so an event-count-only cache would serve stale token totals until the next event arrived. Historical events are treated as immutable (only the trailing event is re-validated), which keeps the hot path O(1).

### 2. Serve-stale git invalidation (fixes git segment flicker)

`invalidateGitStatus()` / `invalidateGitBranch()` cleared the caches outright, so the render right after any file edit or branch-changing command showed **zeroed counts / the provider fallback branch** until the background fetch landed — a visible flicker of the git segment on every `write`/`edit` tool result.

Now invalidation just expires the timestamp: the last known values keep rendering while the background refresh runs, and the in-flight-guard (`pendingFetch` + invalidation counter) semantics are unchanged.

## Tests

- New `tests/token-stats.test.ts` (11 cases): aggregation correctness (error/aborted skipped, thinking level, `lastAssistant`), cache hit semantics, recompute on append / trailing-event in-place update / trailing-event replacement / reset, and the documented "historical events are immutable" boundary.
- `tests/git-status.test.ts`: new cases asserting invalidation serves the stale counts and last known branch instead of flickering to zeros/provider fallback.
- Two source-level assertions in `tests/jump-shortcuts.test.ts` updated to point at the extracted `token-stats.ts`.

Full suite: 186 pass.

Note: touches `index.ts` only in `buildSegmentContext` + cache declaration, so conflicts with #105/#106 are minimal; happy to rebase whichever lands second.
