### PR TITLE
feat: opt-in display formats for context_pct and cache_read segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Segment display formats** — Added opt-in `powerline.context.format` and `powerline.cache_read.format` settings for compact percentage-style context and cache-read segments. Thanks to Andy8647 for #109.
 - **copyOnSelect toggle** — Added `powerline.copyOnSelect` (default `true`) to control whether mouse text selection auto-copies to clipboard on release. Set to `false` to disable auto-copy; the selection then stays highlighted with a `N characters selected, ctrl+c to copy` hint, and copies explicitly via `ctrl+c` or right-click. Thanks to Andy8647 for #105.
 - **Scroll-away card toggle** — Added `powerline.scrollAwayCard` and `/powerline scroll-away-card on|off|toggle` so the fixed editor and chat navigation shortcuts can remain enabled while the scroll-away hint card is hidden. Thanks to Alexander Gerdes (@Avg8888), Whisperfall, and Bruno Orsolon (@brunoorsolon) for #97/#108/#99.
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,22 @@ Subscription cost display accepts:
 | `reported-cost` | `$0.12` | `(sub)` |
 | `both` | `$0.12 (sub)` | `(sub)` |
 
+Segment display formats (opt-in; defaults match the historical rendering):
+
+| Segment option | Values | Default | Effect |
+|---|---|---|---|
+| `"context": { "format" }` | `"full"` / `"percent"` | `"full"` | `"percent"` shows a bare rounded `83%` (threshold-colored, no icon) instead of `12k/200k (6.2%)` |
+| `"cache_read": { "format" }` | `"tokens"` / `"percent"` | `"tokens"` | `"percent"` shows the cache hit rate `cacheRead / (input + cacheRead)` instead of the raw token count |
+
+```json
+{
+  "powerline": {
+    "context": { "format": "percent" },
+    "cache_read": { "format": "percent" }
+  }
+}
+```
+
 ## Bash mode
 
 Toggle bash mode with either:

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -235,6 +235,18 @@ function normalizeSegmentOptions(raw: Record<string, unknown>): StatusLineSegmen
     };
   }
 
+  if (isRecord(raw.context)) {
+    options.context = {
+      ...(raw.context.format === "full" || raw.context.format === "percent" ? { format: raw.context.format } : {}),
+    };
+  }
+
+  if (isRecord(raw.cache_read)) {
+    options.cache_read = {
+      ...(raw.cache_read.format === "tokens" || raw.cache_read.format === "percent" ? { format: raw.cache_read.format } : {}),
+    };
+  }
+
   return options;
 }
 
@@ -250,6 +262,8 @@ export function mergeSegmentOptions(
     git: { ...defaults.git, ...overrides.git },
     time: { ...defaults.time, ...overrides.time },
     cost: { ...defaults.cost, ...overrides.cost },
+    context: { ...defaults.context, ...overrides.context },
+    cache_read: { ...defaults.cache_read, ...overrides.cache_read },
   };
 }
 

--- a/segments.ts
+++ b/segments.ts
@@ -298,16 +298,23 @@ const contextPctSegment: StatusLineSegment = {
     const { contextTokens, contextPercent, contextWindow } = ctx;
 
     const autoIcon = ctx.autoCompactEnabled && icons.auto ? ` ${icons.auto}` : "";
-    const text = `${formatTokens(contextTokens)}/${formatTokens(contextWindow)} (${contextPercent.toFixed(1)}%)${autoIcon}`;
+    const percentOnly = ctx.options.context?.format === "percent";
+    // "full" (default): tokens/window + one-decimal percentage + auto-compact icon.
+    // "percent": bare rounded percentage, threshold-colored, no icons.
+    const text = percentOnly
+      ? `${Math.round(contextPercent)}%`
+      : `${formatTokens(contextTokens)}/${formatTokens(contextWindow)} (${contextPercent.toFixed(1)}%)${autoIcon}`;
 
     // Icon outside color, text inside - use semantic colors for thresholds
     let content: string;
+    const colored = (semantic: "context" | "contextWarn" | "contextError") =>
+      percentOnly ? color(ctx, semantic, text) : withIcon(icons.context, color(ctx, semantic, text));
     if (contextPercent > 90) {
-      content = withIcon(icons.context, color(ctx, "contextError", text));
+      content = colored("contextError");
     } else if (contextPercent > 70) {
-      content = withIcon(icons.context, color(ctx, "contextWarn", text));
+      content = colored("contextWarn");
     } else {
-      content = withIcon(icons.context, color(ctx, "context", text));
+      content = colored("context");
     }
 
     return { content, visible: true };
@@ -390,11 +397,21 @@ const cacheReadSegment: StatusLineSegment = {
   id: "cache_read",
   render(ctx) {
     const icons = getIcons();
-    const { cacheRead } = ctx.usageStats;
+    const { cacheRead, input } = ctx.usageStats;
     if (!cacheRead) return { content: "", visible: false };
 
-    const parts = [icons.cache, icons.input, formatTokens(cacheRead)].filter(Boolean);
-    const content = parts.join(" ");
+    let content: string;
+    if (ctx.options.cache_read?.format === "percent") {
+      // Cache hit rate: cacheRead / (input + cacheRead)
+      const hitRate = input + cacheRead > 0
+        ? ((cacheRead / (input + cacheRead)) * 100).toFixed(0)
+        : "0";
+      content = [icons.cache, `${hitRate}%`].filter(Boolean).join(" ");
+    } else {
+      // "tokens" (default): raw cache-read token count
+      const parts = [icons.cache, icons.input, formatTokens(cacheRead)].filter(Boolean);
+      content = parts.join(" ");
+    }
     return { content: color(ctx, "tokens", content), visible: true };
   },
 };

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -175,6 +175,8 @@ test("mergeSegmentOptions lets user config override preset segment defaults", ()
       git: { showBranch: true, showUntracked: false },
       time: {},
       cost: { subscriptionDisplay: "reported-cost" },
+      context: {},
+      cache_read: {},
     },
   );
 });

--- a/tests/usage-display.test.ts
+++ b/tests/usage-display.test.ts
@@ -1,0 +1,165 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renderSegment } from "../segments.ts";
+import { mergeSegmentOptions, parsePowerlineConfig } from "../powerline-config.ts";
+import type { SegmentContext, StatusLineSegmentOptions } from "../types.ts";
+
+const PRESET_NAMES = ["default", "compact"];
+
+const originalNerdFonts = process.env.POWERLINE_NERD_FONTS;
+process.env.POWERLINE_NERD_FONTS = "0";
+
+test.after(() => {
+  if (originalNerdFonts === undefined) {
+    delete process.env.POWERLINE_NERD_FONTS;
+  } else {
+    process.env.POWERLINE_NERD_FONTS = originalNerdFonts;
+  }
+});
+
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function plainTheme(): any {
+  return {
+    fg: (_color: string, text: string) => text,
+    bg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  };
+}
+
+function createSegmentContext(options: StatusLineSegmentOptions = {}, overrides: Partial<SegmentContext> = {}): SegmentContext {
+  return {
+    model: undefined,
+    thinkingLevel: "off",
+    sessionId: undefined,
+    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+    contextTokens: 0,
+    contextPercent: 0,
+    contextWindow: 0,
+    autoCompactEnabled: true,
+    customCompactionEnabled: false,
+    usingSubscription: false,
+    sessionStartTime: Date.now(),
+    shellModeActive: false,
+    shellRunning: false,
+    shellName: null,
+    shellCwd: null,
+    git: { branch: null, staged: 0, unstaged: 0, untracked: 0 },
+    extensionStatuses: new Map(),
+    hiddenExtensionStatusKeys: new Set(),
+    customItemsById: new Map(),
+    options,
+    theme: plainTheme(),
+    colors: {},
+    ...overrides,
+  };
+}
+
+// ── context_pct format ──────────────────────────────────────────────────────
+
+test("context_pct defaults to the full tokens/window rendering", () => {
+  const ctx = createSegmentContext({}, {
+    contextTokens: 12300,
+    contextWindow: 200000,
+    contextPercent: 6.15,
+  });
+
+  const rendered = renderSegment("context_pct", ctx);
+  assert.equal(stripAnsi(rendered.content), "◫ 12k/200k (6.2%) AC");
+});
+
+test("context_pct percent format renders a bare rounded percentage", () => {
+  const ctx = createSegmentContext({ context: { format: "percent" } }, {
+    contextTokens: 12300,
+    contextWindow: 200000,
+    contextPercent: 6.15,
+  });
+
+  const rendered = renderSegment("context_pct", ctx);
+  assert.equal(stripAnsi(rendered.content), "6%");
+});
+
+test("context_pct percent format keeps threshold colors and drops icons", () => {
+  for (const [percent, expected] of [[69, "69%"], [85, "85%"], [95, "95%"]] as const) {
+    const ctx = createSegmentContext({ context: { format: "percent" } }, {
+      contextTokens: percent,
+      contextWindow: 100,
+      contextPercent: percent,
+    });
+    const rendered = renderSegment("context_pct", ctx);
+    assert.equal(stripAnsi(rendered.content), expected);
+    assert.ok(!rendered.content.includes("◫"), "no context icon in percent mode");
+    assert.ok(!rendered.content.includes("AC"), "no auto-compact icon in percent mode");
+  }
+});
+
+// ── cache_read format ───────────────────────────────────────────────────────
+
+test("cache_read defaults to raw token count", () => {
+  const ctx = createSegmentContext({}, {
+    usageStats: { input: 1000, output: 0, cacheRead: 12300, cacheWrite: 0, cost: 0 },
+  });
+
+  const rendered = renderSegment("cache_read", ctx);
+  assert.equal(stripAnsi(rendered.content), "cache in: 12k");
+});
+
+test("cache_read percent format renders the cache hit rate", () => {
+  const ctx = createSegmentContext({ cache_read: { format: "percent" } }, {
+    usageStats: { input: 2000, output: 0, cacheRead: 8000, cacheWrite: 0, cost: 0 },
+  });
+
+  const rendered = renderSegment("cache_read", ctx);
+  assert.equal(stripAnsi(rendered.content), "cache 80%");
+});
+
+test("cache_read percent format handles zero total without NaN", () => {
+  const ctx = createSegmentContext({ cache_read: { format: "percent" } }, {
+    usageStats: { input: 0, output: 0, cacheRead: 5, cacheWrite: 0, cost: 0 },
+  });
+  assert.equal(stripAnsi(renderSegment("cache_read", ctx).content), "cache 100%");
+
+  // cacheRead = 0 hides the segment entirely in both formats
+  const hidden = createSegmentContext({ cache_read: { format: "percent" } });
+  assert.deepEqual(renderSegment("cache_read", hidden), { content: "", visible: false });
+});
+
+// ── config parsing / merging ────────────────────────────────────────────────
+
+test("parsePowerlineConfig accepts context and cache_read formats", () => {
+  const config = parsePowerlineConfig({
+    context: { format: "percent" },
+    cache_read: { format: "percent" },
+  }, PRESET_NAMES);
+
+  assert.equal(config.segmentOptions.context?.format, "percent");
+  assert.equal(config.segmentOptions.cache_read?.format, "percent");
+});
+
+test("parsePowerlineConfig ignores invalid format values", () => {
+  const config = parsePowerlineConfig({
+    context: { format: "bogus" },
+    cache_read: { format: 42 },
+  }, PRESET_NAMES);
+
+  assert.equal(config.segmentOptions.context?.format, undefined);
+  assert.equal(config.segmentOptions.cache_read?.format, undefined);
+});
+
+test("parsePowerlineConfig defaults to upstream rendering when options are absent", () => {
+  const config = parsePowerlineConfig({}, PRESET_NAMES);
+  assert.equal(config.segmentOptions.context, undefined);
+  assert.equal(config.segmentOptions.cache_read, undefined);
+});
+
+test("mergeSegmentOptions merges context and cache_read per key", () => {
+  const merged = mergeSegmentOptions(
+    { context: { format: "percent" }, cache_read: { format: "percent" } },
+    { context: { format: "full" } },
+  );
+
+  assert.equal(merged.context?.format, "full");
+  assert.equal(merged.cache_read?.format, "percent");
+});

--- a/types.ts
+++ b/types.ts
@@ -94,6 +94,8 @@ export interface StatusLineSegmentOptions {
   };
   time?: { format?: "12h" | "24h"; showSeconds?: boolean };
   cost?: { subscriptionDisplay?: "subscription" | "reported-cost" | "both" };
+  context?: { format?: "full" | "percent" };
+  cache_read?: { format?: "tokens" | "percent" };
 }
 
 export type CustomItemPosition = "left" | "right" | "secondary";


### PR DESCRIPTION
## What

Adds two opt-in segment display formats. **Defaults are byte-for-byte the current rendering** — this only adds choices.

### `powerline.context.format`

| value | rendering |
|---|---|
| `"full"` (default) | `◫ 12k/200k (6.2%) ⚡` — unchanged |
| `"percent"` | `83%` — bare rounded percentage, still threshold-colored (`context`/`contextWarn`/`contextError`), no icons |

For minimal/compact layouts where the full `tokens/window` string is too wide.

### `powerline.cache_read.format`

| value | rendering |
|---|---|
| `"tokens"` (default) | `cache in: 12k` — unchanged |
| `"percent"` | `cache 80%` — cache hit rate `cacheRead / (input + cacheRead)` |

The hit rate is usually the more actionable signal than the raw cache-read count (prompt caching effectiveness at a glance).

```json
{
  "powerline": {
    "context": { "format": "percent" },
    "cache_read": { "format": "percent" }
  }
}
```

Both keys go through `normalizeSegmentOptions` (invalid values ignored) and `mergeSegmentOptions` (per-key merge with preset defaults), same as the existing `time.format` / `cost.subscriptionDisplay` options.

## Tests

New `tests/usage-display.test.ts` (10 cases): default renderings unchanged, percent renderings, threshold colors kept / icons dropped in percent mode, zero-total hit-rate edge case, config parsing (valid/invalid/absent), per-key merge. One existing `mergeSegmentOptions` deep-equal updated for the two new (empty-by-default) keys. Full suite: 184 pass.

Note: touches `segments.ts` / `powerline-config.ts` / `types.ts`, all in small additive hunks — conflicts with #105/#106/#107 are unlikely; happy to rebase if needed.
