### PR TITLE
perf(fixed-editor): repaint inline custom UI without rerendering chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Scroll-away card toggle** — Added `powerline.scrollAwayCard` and `/powerline scroll-away-card on|off|toggle` so the fixed editor and chat navigation shortcuts can remain enabled while the scroll-away hint card is hidden. Thanks to Alexander Gerdes (@Avg8888), Whisperfall, and Bruno Orsolon (@brunoorsolon) for #97/#108/#99.
 
 ### Changed
+- **Inline custom UI repainting** — Avoids rerendering static chat while fixed-editor inline custom UI clusters repaint with unchanged viewport geometry. Thanks to JMHSV for #111.
 - **Status render caching** — Caches session token aggregation between unchanged render inputs and keeps stale git segment values visible during background refreshes, reducing long-session redraw work and git flicker. Thanks to Andy8647 for #107.
 - **Fixed-editor scrolling performance** — Uses terminal row shifts, cached transcript lines, an 8 ms repaint cadence, and transient shortcut-card hiding during active wheel movement to cut scroll latency and terminal output churn.
 

--- a/fixed-editor/terminal-split.ts
+++ b/fixed-editor/terminal-split.ts
@@ -30,6 +30,7 @@ interface TerminalSplitCompositorOptions {
   tui: any;
   terminal: TerminalLike;
   renderCluster: (width: number, terminalRows: number) => FixedEditorClusterRender;
+  canRepaintClusterOnly?: () => boolean;
   getShowHardwareCursor?: () => boolean;
   mouseScroll?: boolean;
   keyboardScrollShortcuts?: KeyboardScrollShortcuts;
@@ -557,6 +558,7 @@ export class TerminalSplitCompositor {
   private readonly tui: any;
   private readonly terminal: TerminalLike;
   private readonly renderCluster: (width: number, terminalRows: number) => FixedEditorClusterRender;
+  private readonly canRepaintClusterOnly: () => boolean;
   private readonly getShowHardwareCursor: () => boolean;
   private readonly mouseScroll: boolean;
   private readonly keyboardScrollShortcuts: KeyboardScrollShortcuts;
@@ -591,6 +593,7 @@ export class TerminalSplitCompositor {
   private rootLines: string[] = [];
   private visibleRootStart = 0;
   private visibleScrollableRows = 0;
+  private visibleRootWidth = 0;
   private visibleRootLines: string[] = [];
   private visibleClusterLines: string[] = [];
   private selectionArea: SelectionArea | null = null;
@@ -607,6 +610,7 @@ export class TerminalSplitCompositor {
     this.tui = options.tui;
     this.terminal = options.terminal;
     this.renderCluster = options.renderCluster;
+    this.canRepaintClusterOnly = options.canRepaintClusterOnly ?? (() => false);
     this.getShowHardwareCursor = options.getShowHardwareCursor ?? (() => false);
     this.mouseScroll = options.mouseScroll !== false;
     this.keyboardScrollShortcuts = options.keyboardScrollShortcuts ?? DEFAULT_KEYBOARD_SCROLL_SHORTCUTS;
@@ -657,6 +661,10 @@ export class TerminalSplitCompositor {
     this.terminal.write = (data: string) => this.write(data);
     if (this.originalDoRender) {
       this.tui.doRender = () => {
+        if (this.canRepaintClusterOnly() && this.repaintClusterOnlyIfStable()) {
+          return;
+        }
+
         this.renderPassActive = true;
         this.renderPassCluster = null;
         try {
@@ -757,6 +765,41 @@ export class TerminalSplitCompositor {
     this.updateScrollBounds(Math.max(1, rawRows - cluster.lines.length));
     if (cluster.lines.length === 0) return;
 
+    this.paintCluster(cluster, rawRows, width);
+  }
+
+  private repaintClusterOnlyIfStable(): boolean {
+    if (
+      this.disposed
+      || this.hasVisibleOverlay()
+      || this.rootLines.length === 0
+      || Reflect.get(this.tui, "renderRequested") === true
+    ) {
+      return false;
+    }
+
+    const rawRows = this.getRawRows();
+    const width = Math.max(1, this.terminal.columns || 80);
+    const previousLineCount = this.visibleClusterLines.length;
+    const cluster = this.getCluster(width, rawRows);
+    const scrollableRows = Math.max(1, rawRows - cluster.lines.length);
+    const maxScrollOffset = Math.max(0, this.rootLines.length - scrollableRows);
+    if (
+      cluster.lines.length === 0
+      || cluster.lines.length !== previousLineCount
+      || this.visibleRootWidth !== width
+      || this.visibleScrollableRows !== scrollableRows
+      || this.visibleRootLines.length !== scrollableRows
+      || this.maxScrollOffset !== maxScrollOffset
+    ) {
+      return false;
+    }
+
+    this.paintCluster(cluster, rawRows, width);
+    return true;
+  }
+
+  private paintCluster(cluster: FixedEditorClusterRender, rawRows: number, width: number): void {
     this.originalWrite(
       beginSynchronizedOutput()
       + disableAutoWrap()
@@ -996,6 +1039,7 @@ export class TerminalSplitCompositor {
   }
 
   private renderVisibleRootLines(start: number, width: number, scrollableRows: number): string[] {
+    this.visibleRootWidth = width;
     const renderedLines = this.visibleRootLines.map((line, index) => {
       return this.renderSelectionHighlight(line, start + index, "root");
     });

--- a/index.ts
+++ b/index.ts
@@ -2436,6 +2436,13 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     compositor = new TerminalSplitCompositor({
       tui,
       terminal: tui.terminal,
+      canRepaintClusterOnly: () => {
+        const children = fixedEditorContainer?.children;
+        return Array.isArray(children)
+          && children.length > 0
+          && currentEditor !== null
+          && !children.includes(currentEditor);
+      },
       mouseScroll: config.mouseScroll,
       keyboardScrollShortcuts: {
         up: resolvedShortcuts.scrollChatUp,

--- a/tests/fixed-editor.test.ts
+++ b/tests/fixed-editor.test.ts
@@ -2359,6 +2359,95 @@ test("terminal split can disable mouse reporting for normal selection", () => {
   assert.ok(!terminal.writes.at(-1)?.includes("\x1b[?1002l"));
 });
 
+test("terminal split cluster-only repaint falls back when root render width changes", () => {
+  const terminal = new FakeTerminal();
+  terminal.columns = 40;
+  let appRenderCalls = 0;
+  const rootRenderWidths: number[] = [];
+  const tui = {
+    terminal,
+    render(width: number) {
+      rootRenderWidths.push(width);
+      return [`root:${width}`, "root-b"];
+    },
+    doRender() {
+      appRenderCalls += 1;
+      this.render(this.terminal.columns);
+      this.terminal.write("body");
+    },
+  };
+
+  const compositor = new TerminalSplitCompositor({
+    tui,
+    terminal,
+    canRepaintClusterOnly: () => true,
+    renderCluster: (width) => ({ lines: [`cluster:${width}`], cursor: null }),
+  });
+
+  compositor.install();
+  tui.doRender();
+  assert.equal(appRenderCalls, 1);
+  assert.deepEqual(rootRenderWidths, [40]);
+
+  terminal.writes = [];
+  tui.doRender();
+  assert.equal(appRenderCalls, 1);
+  assert.equal(rootRenderWidths.length, 1);
+  assert.ok(terminal.writes.at(-1)?.includes("cluster:40"));
+  assert.ok(!terminal.writes.at(-1)?.includes("body"));
+
+  terminal.columns = 30;
+  terminal.writes = [];
+  tui.doRender();
+  assert.equal(appRenderCalls, 2);
+  assert.deepEqual(rootRenderWidths, [40, 30]);
+  assert.ok(terminal.writes.some((write) => write.includes("body")));
+  assert.ok(terminal.writes.at(-1)?.includes("cluster:30"));
+
+  compositor.dispose();
+});
+
+test("terminal split cluster-only repaint falls back when root render is requested", () => {
+  const terminal = new FakeTerminal();
+  let rootLines = ["old-root", "root-b"];
+  let appRenderCalls = 0;
+  const tui = {
+    terminal,
+    renderRequested: false,
+    render() {
+      return rootLines;
+    },
+    doRender() {
+      appRenderCalls += 1;
+      this.renderRequested = false;
+      this.render(this.terminal.columns);
+      this.terminal.write("body");
+    },
+  };
+
+  const compositor = new TerminalSplitCompositor({
+    tui,
+    terminal,
+    canRepaintClusterOnly: () => true,
+    renderCluster: () => ({ lines: ["cluster"], cursor: null }),
+  });
+
+  compositor.install();
+  tui.doRender();
+  assert.equal(appRenderCalls, 1);
+
+  terminal.writes = [];
+  rootLines = ["new-root", "root-b"];
+  tui.renderRequested = true;
+  tui.doRender();
+
+  assert.equal(appRenderCalls, 2);
+  assert.equal(tui.renderRequested, false);
+  assert.ok(terminal.writes.some((write) => write.includes("body")));
+
+  compositor.dispose();
+});
+
 test("terminal split reuses the fixed cluster during one render pass", () => {
   const terminal = new FakeTerminal();
   let renderClusterCount = 0;


### PR DESCRIPTION
## Summary

Optimize fixed-editor rendering while an inline `ctx.ui.custom()` component replaces the normal editor.

- Repaint only the fixed cluster when its height is unchanged.
- Reuse the cached scrollable transcript.
- Fall back to the normal full render when:
  - no transcript has been rendered yet,
  - an overlay is visible, or
  - the fixed cluster changes height.
- Keep the existing rendering path unchanged for the normal Pi editor.

## Problem

Inline custom components are mounted inside Pi's editor container. While one is active, every input event currently runs the original root renderer before repainting the fixed cluster.

This makes typing latency proportional to conversation size, even though the transcript is static while a tool waits for user input.

The issue is especially noticeable in question tools with free-form answer fields and long sessions.

## Implementation

`TerminalSplitCompositor` now accepts an optional `canRepaintClusterOnly` callback.

When permitted and the cluster height is stable, the compositor paints the fixed cluster directly instead of invoking Pi's full root render.

The Powerline integration enables this only when the editor container contains an inline custom component rather than the normal editor.

## Verification

- `node --experimental-strip-types --test tests/fixed-editor.test.ts` — 53 passed.
- `npm test` — 173 passed, with one pre-existing unrelated failure: `bash editor runs copied Pi app action handlers for alt-enter`.
- Manually verified with an inline `ask_user` prompt in a long session:
  - responsive typing,
  - animated loading indicator remains active,
  - chat remains visible,
  - growing/wrapping input falls back to full layout correctly.