### PR TITLE
feat: editor click-to-position, cursor style, and scroll-nav-card toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,21 @@ You can also set it in the agent settings file (`~/.pi/agent/settings.json` by d
     "fixedEditor": false,
     "placement": "below",
     "welcome": true,
-    "mouseScroll": true
+    "mouseScroll": true,
+    "editorCursor": "block",
+    "editorClickCursor": false,
+    "scrollNavCard": true
   }
 }
 ```
 
-Use `"fixedEditor": true` to enable it again. `"placement"` accepts `"above"` (default) or `"below"` in both fixed and regular editor modes. It moves only the primary powerline row; notifications and Pi working status stay above, while responsive overflow, bash transcript, and the last-prompt reminder stay below. Set `"welcome": false` to skip the startup welcome overlay/header while leaving powerline itself enabled. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling. In Herdr, tmux, and other terminal multiplexers, fixed-editor scrolling is Pi-owned while fixed-editor mode is on; keep mouse scrolling enabled for the fixed-editor viewport, or use `/powerline fixed-editor off` when you want the host multiplexer scrollback to own the experience. While fixed-editor mouse reporting is enabled, hold Shift during your terminal’s normal modifier-click to bypass capture for OSC 8 links; otherwise use `/powerline mouse-scroll off` or `/powerline fixed-editor off` for native link handling.
+Use `"fixedEditor": true` to enable it again. `"placement"` accepts `"above"` (default) or `"below"` in both fixed and regular editor modes. It moves only the primary powerline row; notifications and Pi working status stay above, while responsive overflow, bash transcript, and the last-prompt reminder stay below. Set `"welcome": false` to skip the startup welcome overlay/header while leaving powerline itself enabled. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling.
+
+The fixed editor exposes a few input tweaks (all default to Pi's current behavior):
+
+- `"editorCursor"` — how the text cursor is drawn. `"block"` (default) keeps Pi's reverse-video block; `"underline"` draws it as an underline instead; `"terminal"` hides the software cursor so the real terminal cursor shows through, letting its shape and blinking follow your terminal's own configuration (e.g. a blinking bar).
+- `"editorClickCursor"` — when `true`, a plain left click inside the input moves the text cursor there. Dragging still selects text for copying, unaffected.
+- `"scrollNavCard"` — the "jump back to bottom" card shown after you scroll up. `true` (default) keeps it; set `false` to hide it. In Herdr, tmux, and other terminal multiplexers, fixed-editor scrolling is Pi-owned while fixed-editor mode is on; keep mouse scrolling enabled for the fixed-editor viewport, or use `/powerline fixed-editor off` when you want the host multiplexer scrollback to own the experience. While fixed-editor mouse reporting is enabled, hold Shift during your terminal’s normal modifier-click to bypass capture for OSC 8 links; otherwise use `/powerline mouse-scroll off` or `/powerline fixed-editor off` for native link handling.
 
 | Preset | Description |
 |--------|-------------|

--- a/fixed-editor/cluster.ts
+++ b/fixed-editor/cluster.ts
@@ -20,9 +20,25 @@ export interface FixedEditorCursor {
   col: number;
 }
 
+/**
+ * Where the editor's own lines ended up inside the rendered cluster, so
+ * callers can map a screen position back to a position in the editor render.
+ */
+export interface FixedEditorRegion {
+  /** Row in `lines` holding the first editor line. */
+  startRow: number;
+  /** How many leading editor lines were dropped to fit the viewport. */
+  lineOffset: number;
+  /** How many editor lines are present in `lines`. */
+  lineCount: number;
+}
+
 export interface FixedEditorClusterRender {
   lines: string[];
   cursor: FixedEditorCursor | null;
+  /** Absent when a caller assembles cluster lines without going through
+   * `renderFixedEditorCluster`; editor click targeting is then unavailable. */
+  editorRegion?: FixedEditorRegion;
 }
 
 function normalizeLines(lines: string[] | undefined, width: number): string[] {
@@ -38,26 +54,26 @@ function takeTail(lines: string[], count: number): string[] {
   return lines.length <= count ? lines : lines.slice(lines.length - count);
 }
 
-function capEditorLines(lines: string[], count: number): string[] {
-  if (count <= 0) return [];
-  if (lines.length <= count) return lines;
+function capEditorLines(lines: string[], count: number): { lines: string[]; offset: number } {
+  if (count <= 0) return { lines: [], offset: 0 };
+  if (lines.length <= count) return { lines, offset: 0 };
 
   const cursorRow = lines.findIndex((line) => line.includes(CURSOR_MARKER));
   if (cursorRow !== -1) {
     const start = Math.max(0, Math.min(cursorRow - count + 1, lines.length - count));
-    return lines.slice(start, start + count);
+    return { lines: lines.slice(start, start + count), offset: start };
   }
 
   const selectedRow = lines.findIndex((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimStart().startsWith("→ "));
   if (selectedRow === -1) {
-    return lines.slice(0, count);
+    return { lines: lines.slice(0, count), offset: 0 };
   }
 
   const start = Math.max(0, Math.min(selectedRow - Math.floor(count / 2), lines.length - count));
-  return lines.slice(start, start + count);
+  return { lines: lines.slice(start, start + count), offset: start };
 }
 
-function extractCursor(lines: string[]): FixedEditorClusterRender {
+function extractCursor(lines: string[], editorRegion: FixedEditorRegion): FixedEditorClusterRender {
   let cursor: FixedEditorCursor | null = null;
   const cleaned = lines.map((line, row) => {
     const markerIndex = line.indexOf(CURSOR_MARKER);
@@ -73,7 +89,7 @@ function extractCursor(lines: string[]): FixedEditorClusterRender {
     return line.slice(0, markerIndex) + line.slice(markerIndex + CURSOR_MARKER.length);
   });
 
-  return { lines: cleaned, cursor };
+  return { lines: cleaned, cursor, editorRegion };
 }
 
 export function renderFixedEditorCluster(input: FixedEditorClusterInput): FixedEditorClusterRender {
@@ -87,7 +103,7 @@ export function renderFixedEditorCluster(input: FixedEditorClusterInput): FixedE
   const transcriptLines = normalizeLines(input.transcriptLines, width);
   const lastPromptLines = normalizeLines(input.lastPromptLines, width);
 
-  const editorLines = capEditorLines(editorSource, maxRows);
+  const { lines: editorLines, offset: editorLineOffset } = capEditorLines(editorSource, maxRows);
   let remaining = maxRows - editorLines.length;
 
   const primary = takeTail(primaryLines, remaining);
@@ -104,21 +120,32 @@ export function renderFixedEditorCluster(input: FixedEditorClusterInput): FixedE
 
   const transcript = takeTail(transcriptLines, remaining);
 
-  return extractCursor(input.placement === "above"
-    ? [
-      ...status,
-      ...primary,
-      ...editorLines,
-      ...secondary,
-      ...transcript,
-      ...lastPrompt,
-    ]
-    : [
-      ...status,
-      ...editorLines,
-      ...primary,
-      ...secondary,
-      ...transcript,
-      ...lastPrompt,
-    ]);
+  const editorRegion: FixedEditorRegion = {
+    startRow: input.placement === "above"
+      ? status.length + primary.length
+      : status.length,
+    lineOffset: editorLineOffset,
+    lineCount: editorLines.length,
+  };
+
+  return extractCursor(
+    input.placement === "above"
+      ? [
+        ...status,
+        ...primary,
+        ...editorLines,
+        ...secondary,
+        ...transcript,
+        ...lastPrompt,
+      ]
+      : [
+        ...status,
+        ...editorLines,
+        ...primary,
+        ...secondary,
+        ...transcript,
+        ...lastPrompt,
+      ],
+    editorRegion,
+  );
 }

--- a/fixed-editor/terminal-split.ts
+++ b/fixed-editor/terminal-split.ts
@@ -897,7 +897,16 @@ export class TerminalSplitCompositor {
     }
 
     const keyboardDelta = parseKeyboardScrollDelta(data, this.keyboardScrollShortcuts);
-    if (keyboardDelta === 0) return undefined;
+    if (keyboardDelta === 0) {
+      // Any other keystroke goes to the editor. The drag highlight is only a
+      // copy selection, not a live editor selection, so dismiss it instead of
+      // letting it linger over text that is being edited underneath.
+      if (this.selectionArea) {
+        this.clearSelection();
+        this.requestRender();
+      }
+      return undefined;
+    }
 
     this.flushQueuedScroll();
     this.scrollBy(keyboardDelta);

--- a/fixed-editor/terminal-split.ts
+++ b/fixed-editor/terminal-split.ts
@@ -1,6 +1,6 @@
 import { deleteAllKittyImages, isKeyRelease, matchesKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { matchesConfiguredShortcut } from "../shortcuts.ts";
-import type { FixedEditorClusterRender } from "./cluster.ts";
+import type { FixedEditorClusterRender, FixedEditorRegion } from "./cluster.ts";
 
 export interface TerminalLike {
   columns: number;
@@ -35,6 +35,14 @@ interface TerminalSplitCompositorOptions {
   keyboardScrollShortcuts?: KeyboardScrollShortcuts;
   scrollAwayNavigationCard?: ScrollAwayNavigationCardOptions;
   onCopySelection?: (text: string) => void;
+  /**
+   * Called when a left click lands on the editor without dragging, so the
+   * host can move the text cursor there. Coordinates are into the editor's
+   * own render (line index including its borders, screen column), because
+   * only the host knows how it laid the editor out. Dragging is unaffected
+   * and still produces a normal selection.
+   */
+  onEditorTextClick?: (editorLine: number, editorCol: number) => boolean;
   scrollRepaintThrottleMs?: number;
 }
 
@@ -546,6 +554,7 @@ export class TerminalSplitCompositor {
   private readonly keyboardScrollShortcuts: KeyboardScrollShortcuts;
   private readonly scrollAwayNavigationCard: ScrollAwayNavigationCardOptions | null;
   private readonly onCopySelection: ((text: string) => void) | null;
+  private readonly onEditorTextClick: ((editorLine: number, editorCol: number) => boolean) | null;
   private readonly scrollRepaintThrottleMs: number;
   private extendedKeyboardMode: ExtendedKeyboardMode | null = null;
   private readonly rowsDescriptor: PropertyDescriptor | undefined;
@@ -576,6 +585,7 @@ export class TerminalSplitCompositor {
   private visibleScrollableRows = 0;
   private visibleRootLines: string[] = [];
   private visibleClusterLines: string[] = [];
+  private visibleEditorRegion: FixedEditorRegion | null = null;
   private selectionArea: SelectionArea | null = null;
   private selectionAnchor: SelectionPoint | null = null;
   private selectionFocus: SelectionPoint | null = null;
@@ -594,6 +604,7 @@ export class TerminalSplitCompositor {
     this.keyboardScrollShortcuts = options.keyboardScrollShortcuts ?? DEFAULT_KEYBOARD_SCROLL_SHORTCUTS;
     this.scrollAwayNavigationCard = options.scrollAwayNavigationCard ?? null;
     this.onCopySelection = options.onCopySelection ?? null;
+    this.onEditorTextClick = options.onEditorTextClick ?? null;
     this.scrollRepaintThrottleMs = Math.max(0, options.scrollRepaintThrottleMs ?? 0);
     this.rowsDescriptor = descriptorForRows(options.terminal);
     this.originalWrite = options.terminal.write.bind(options.terminal);
@@ -1030,6 +1041,19 @@ export class TerminalSplitCompositor {
     return null;
   }
 
+  /**
+   * Map a row in the rendered cluster back to a line index in the editor's
+   * own render, or null when the row belongs to the status bar or a widget.
+   */
+  private editorLineForClusterRow(clusterRow: number): number | null {
+    const region = this.visibleEditorRegion;
+    if (!region || !this.onEditorTextClick) return null;
+
+    const offsetInRegion = clusterRow - region.startRow;
+    if (offsetInRegion < 0 || offsetInRegion >= region.lineCount) return null;
+    return region.lineOffset + offsetInRegion;
+  }
+
   private finishSelection(packet: SgrMousePacket, location: SelectionLocation | null): void {
     if (!this.preserveSelectionFocusOnRelease) {
       this.selectionFocus = location?.area === this.selectionArea
@@ -1044,7 +1068,16 @@ export class TerminalSplitCompositor {
       this.lastLeftPress = null;
       this.onCopySelection?.(selectedText);
     } else {
+      // Releasing without having dragged is a plain click. Inside the editor
+      // text that means "put the cursor here"; the selection is resolved on
+      // release rather than on press so dragging still selects text.
+      const clickArea = this.selectionArea;
+      const clickPoint = this.selectionAnchor;
       this.clearSelection();
+      if (clickArea === "cluster" && clickPoint) {
+        const editorLine = this.editorLineForClusterRow(clickPoint.line);
+        if (editorLine !== null) this.onEditorTextClick?.(editorLine, clickPoint.col);
+      }
     }
     this.requestRender();
   }
@@ -1481,6 +1514,7 @@ export class TerminalSplitCompositor {
 
     const cluster = this.withClusterRender(() => this.renderCluster(width, terminalRows));
     this.visibleClusterLines = cluster.lines;
+    this.visibleEditorRegion = cluster.editorRegion ?? null;
     if (this.renderPassActive) {
       this.renderPassCluster = { width, terminalRows, cluster };
     }

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@ import { isKeyRelease, type AutocompleteProvider, type SelectItem, SelectList, t
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 
-import type { ColorScheme, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
+import type { ColorScheme, EditorCursorStyle, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
 import type { PowerlineConfig } from "./powerline-config.ts";
 import { BashTranscriptStore } from "./bash-mode/transcript.ts";
 import {
@@ -82,6 +82,9 @@ let config: PowerlineConfig = {
   invalidPlacement: null,
   welcome: true,
   stashSharpSShortcut: false,
+  editorCursor: "block",
+  editorClickCursor: false,
+  scrollNavCard: true,
 };
 
 const CUSTOM_COMPACTION_STATUS_KEY = "compact-policy";
@@ -933,6 +936,44 @@ export function parseBashModeSettings(settings: Record<string, unknown>, powerli
     transcriptMaxLines,
     transcriptMaxBytes,
   };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Editor Cursor
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Column where editor text starts: one space, the prompt glyph, one space.
+ * Continuation rows are padded to match.
+ */
+const EDITOR_TEXT_COLUMN = 3;
+
+/**
+ * Convert a display column inside a logical line to a string index, walking
+ * code points from `fromIndex` and accumulating display widths so wide
+ * characters count as the columns they actually occupy.
+ */
+export function displayColumnToStringIndex(line: string, fromIndex: number, targetCol: number): number {
+  let col = 0;
+  let i = Math.max(0, Math.min(fromIndex, line.length));
+  while (i < line.length && col < targetCol) {
+    const ch = String.fromCodePoint(line.codePointAt(i) ?? 0);
+    col += Math.max(1, visibleWidth(ch));
+    i += ch.length;
+  }
+  return i;
+}
+
+/**
+ * Restyle the editor's software cursor, which pi-tui draws as reverse video.
+ * "block" keeps it as-is, "underline" trades the reverse block for an
+ * underline, and "terminal" removes it entirely so the real terminal cursor
+ * (already parked on the same cell) is what the user sees.
+ */
+export function applyEditorCursorStyle(line: string, style: EditorCursorStyle): string {
+  if (style === "block") return line;
+  const replacement = style === "underline" ? "\x1b[4m$1\x1b[0m" : "$1";
+  return line.replace(/\x1b\[7m([\s\S]{1,2}?)\x1b\[0m/g, replacement);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -2393,6 +2434,53 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     return { container: children[index], index };
   }
 
+  /**
+   * "terminal" cursor mode drops the software cursor, so the real terminal
+   * cursor has to be visible for anything to mark the caret position. The
+   * other modes leave pi's own default alone.
+   */
+  function applyEditorCursorMode(tui: any): void {
+    if (config.editorCursor !== "terminal") return;
+    tui?.setShowHardwareCursor?.(true);
+  }
+
+  /**
+   * Move the editor's text cursor to a point the user clicked. Coordinates
+   * come from the compositor as a line index into this extension's editor
+   * render, so the box borders and prompt prefix are undone here.
+   */
+  function positionEditorCursorAt(tui: any, editorLine: number, editorCol: number): boolean {
+    if (!config.editorClickCursor) return false;
+
+    // Line 0 is the top border; every text row carries a 3-column prefix.
+    const visualRow = editorLine - 1;
+    const visualCol = editorCol - EDITOR_TEXT_COLUMN;
+    if (visualRow < 0 || visualCol < 0) return false;
+
+    const editor: any = currentEditor;
+    if (!editor?.state || typeof editor.buildVisualLineMap !== "function") return false;
+
+    try {
+      const width = Math.max(1, editor.lastWidth ?? 80);
+      const visualLines = editor.buildVisualLineMap(width) as Array<{ logicalLine: number; startCol: number; length: number }>;
+      const row = visualRow + (editor.scrollOffset ?? 0);
+      const visualLine = visualLines[row];
+      if (!visualLine) return false;
+
+      const text: string = editor.state.lines[visualLine.logicalLine] ?? "";
+      const index = displayColumnToStringIndex(text, visualLine.startCol, visualCol);
+      editor.state.cursorLine = visualLine.logicalLine;
+      editor.state.cursorCol = Math.max(visualLine.startCol, Math.min(index, visualLine.startCol + visualLine.length));
+      editor.preferredVisualCol = null;
+      editor.snappedFromCursorCol = null;
+      tui?.requestRender?.();
+      return true;
+    } catch (error) {
+      console.debug("[powerline-footer] editor click cursor failed:", error);
+      return false;
+    }
+  }
+
   function installFixedEditorCompositor(ctx: any, tui: any) {
     teardownFixedEditorCompositor();
 
@@ -2441,17 +2529,20 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         down: resolvedShortcuts.scrollChatDown,
       },
       scrollRepaintThrottleMs: DEFAULT_SCROLL_REPAINT_THROTTLE_MS,
-      scrollAwayNavigationCard: {
-        shortcuts: [
-          scrollAwayShortcutEntry("bottom", resolvedShortcuts.jumpChatBottom),
-          scrollAwayShortcutEntry("previousUser", resolvedShortcuts.jumpPreviousUserMessage),
-          scrollAwayShortcutEntry("nextUser", resolvedShortcuts.jumpNextUserMessage),
-          scrollAwayShortcutEntry("previousAssistant", resolvedShortcuts.jumpPreviousLlmMessage),
-          scrollAwayShortcutEntry("nextAssistant", resolvedShortcuts.jumpNextLlmMessage),
-        ].filter((shortcut): shortcut is { id: ScrollAwayShortcutId; shortcutLabel: string } => shortcut !== null),
-        onClickBottom: resolvedShortcuts.jumpChatBottom ? () => jumpChatToBottom(ctx) : undefined,
-      },
+      scrollAwayNavigationCard: config.scrollNavCard
+        ? {
+          shortcuts: [
+            scrollAwayShortcutEntry("bottom", resolvedShortcuts.jumpChatBottom),
+            scrollAwayShortcutEntry("previousUser", resolvedShortcuts.jumpPreviousUserMessage),
+            scrollAwayShortcutEntry("nextUser", resolvedShortcuts.jumpNextUserMessage),
+            scrollAwayShortcutEntry("previousAssistant", resolvedShortcuts.jumpPreviousLlmMessage),
+            scrollAwayShortcutEntry("nextAssistant", resolvedShortcuts.jumpNextLlmMessage),
+          ].filter((shortcut): shortcut is { id: ScrollAwayShortcutId; shortcutLabel: string } => shortcut !== null),
+          onClickBottom: resolvedShortcuts.jumpChatBottom ? () => jumpChatToBottom(ctx) : undefined,
+        }
+        : undefined,
       onCopySelection: (text) => copyTextToClipboard(ctx, text),
+      onEditorTextClick: (editorLine, editorCol) => positionEditorCursorAt(tui, editorLine, editorCol),
       getShowHardwareCursor: () => typeof tui.getShowHardwareCursor === "function" && tui.getShowHardwareCursor(),
       renderCluster: (width, terminalRows) => {
         const theme = readRenderTheme();
@@ -2840,6 +2931,12 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           result.push(lines[i] || "");
         }
 
+        if (config.editorCursor !== "block") {
+          for (let i = 0; i < result.length; i++) {
+            result[i] = applyEditorCursorStyle(result[i] ?? "", config.editorCursor);
+          }
+        }
+
         return result;
       };
 
@@ -2851,6 +2948,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     ctx.ui.setFooter((tui: any, _theme: Theme, footerData: ReadonlyFooterDataProvider) => {
       footerDataRef = footerData;
       tuiRef = tui;
+      applyEditorCursorMode(tui);
       installFooterStatusRepaintHook(footerData);
       const unsub = footerData.onBranchChange(() => requestStatusRender());
 

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,6 +1,6 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { BUILTIN_STATUS_LINE_SEGMENT_IDS } from "./types.ts";
-import type { ColorValue, CustomItemPosition, CustomStatusItem, PowerlinePlacement, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions } from "./types.ts";
+import type { ColorValue, CustomItemPosition, CustomStatusItem, EditorCursorStyle, PowerlinePlacement, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions } from "./types.ts";
 
 export interface PowerlineConfig {
   preset: StatusLinePreset;
@@ -16,6 +16,9 @@ export interface PowerlineConfig {
   invalidPlacement: string | null;
   welcome: boolean;
   stashSharpSShortcut: boolean;
+  editorCursor: EditorCursorStyle;
+  editorClickCursor: boolean;
+  scrollNavCard: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -40,6 +43,14 @@ function normalizePlacement(value: unknown): { placement: PowerlinePlacement; in
     placement: "above",
     invalidPlacement: typeof value === "string" ? value.trim() : String(value),
   };
+}
+
+function normalizeEditorCursor(value: unknown): EditorCursorStyle | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "block" || normalized === "underline" || normalized === "terminal"
+    ? normalized
+    : null;
 }
 
 function normalizeCustomItemId(value: unknown): string | null {
@@ -265,6 +276,9 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     invalidPlacement: null,
     welcome: true,
     stashSharpSShortcut: false,
+    editorCursor: "block",
+    editorClickCursor: false,
+    scrollNavCard: true,
   };
 
   const directPreset = normalizePreset(value, presets);
@@ -291,6 +305,9 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     invalidPlacement,
     welcome: value.welcome !== false,
     stashSharpSShortcut: value.stashSharpSShortcut === true,
+    editorCursor: normalizeEditorCursor(value.editorCursor) ?? defaultConfig.editorCursor,
+    editorClickCursor: value.editorClickCursor === true,
+    scrollNavCard: value.scrollNavCard !== false,
   };
 }
 

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -130,6 +130,34 @@ test("parsePowerlineConfig supports welcome and legacy sharp-S toggles", () => {
   assert.equal(shorthand.stashSharpSShortcut, false);
 });
 
+test("parsePowerlineConfig defaults editor mouse options to upstream behavior", () => {
+  const config = parsePowerlineConfig({ preset: "compact" }, ["default", "compact"]);
+
+  assert.equal(config.editorCursor, "block");
+  assert.equal(config.editorClickCursor, false);
+  assert.equal(config.scrollNavCard, true);
+});
+
+test("parsePowerlineConfig parses editor mouse options", () => {
+  const config = parsePowerlineConfig(
+    { preset: "compact", editorCursor: "terminal", editorClickCursor: true, scrollNavCard: false },
+    ["default", "compact"],
+  );
+
+  assert.equal(config.editorCursor, "terminal");
+  assert.equal(config.editorClickCursor, true);
+  assert.equal(config.scrollNavCard, false);
+});
+
+test("parsePowerlineConfig rejects an unknown editor cursor style", () => {
+  const config = parsePowerlineConfig(
+    { preset: "compact", editorCursor: "beam" },
+    ["default", "compact"],
+  );
+
+  assert.equal(config.editorCursor, "block");
+});
+
 test("parsePowerlineConfig extracts supported segment options", () => {
   const config = parsePowerlineConfig(
     {

--- a/tests/editor-cursor.test.ts
+++ b/tests/editor-cursor.test.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { applyEditorCursorStyle, displayColumnToStringIndex } from "../index.ts";
+
+const REVERSE_CURSOR = "> hello \x1b[7m \x1b[0m";
+
+test("applyEditorCursorStyle leaves the block cursor untouched", () => {
+  assert.equal(applyEditorCursorStyle(REVERSE_CURSOR, "block"), REVERSE_CURSOR);
+});
+
+test("applyEditorCursorStyle swaps the reverse block for an underline", () => {
+  assert.equal(applyEditorCursorStyle(REVERSE_CURSOR, "underline"), "> hello \x1b[4m \x1b[0m");
+});
+
+test("applyEditorCursorStyle drops the software cursor for terminal mode", () => {
+  assert.equal(applyEditorCursorStyle(REVERSE_CURSOR, "terminal"), "> hello  ");
+});
+
+test("applyEditorCursorStyle restyles a cursor sitting on a character", () => {
+  assert.equal(applyEditorCursorStyle("ab\x1b[7mc\x1b[0md", "terminal"), "abcd");
+  assert.equal(applyEditorCursorStyle("ab\x1b[7mc\x1b[0md", "underline"), "ab\x1b[4mc\x1b[0md");
+});
+
+test("displayColumnToStringIndex counts wide characters by display width", () => {
+  // Two-column CJK glyphs: display column 4 lands after the second glyph.
+  assert.equal(displayColumnToStringIndex("你好x", 0, 4), 2);
+  // Within the ASCII tail, columns map one to one from the given offset.
+  assert.equal(displayColumnToStringIndex("你好xyz", 2, 2), 4);
+});

--- a/tests/fixed-editor.test.ts
+++ b/tests/fixed-editor.test.ts
@@ -64,6 +64,8 @@ test("fixed cluster keeps the editor visible before optional rows", () => {
 
   assert.deepEqual(rendered.lines, ["top", "edit-a", "edit-b ", "edit-c", "secondary"]);
   assert.deepEqual(rendered.cursor, { row: 2, col: 7 });
+  // Editor rows sit after the primary powerline row, none dropped.
+  assert.deepEqual(rendered.editorRegion, { startRow: 1, lineOffset: 0, lineCount: 3 });
 });
 
 test("fixed cluster places only the primary powerline below the editor", () => {
@@ -81,6 +83,8 @@ test("fixed cluster places only the primary powerline below the editor", () => {
 
   assert.deepEqual(rendered.lines, ["notification", "working", "edit ", "primary", "overflow", "transcript", "last"]);
   assert.deepEqual(rendered.cursor, { row: 2, col: 5 });
+  // Below placement puts the editor right after the status lines.
+  assert.deepEqual(rendered.editorRegion, { startRow: 2, lineOffset: 0, lineCount: 1 });
 });
 
 test("fixed cluster keeps primary and overflow priority when placement is below", () => {
@@ -112,6 +116,21 @@ test("fixed cluster caps oversized editor around the cursor", () => {
 
   assert.deepEqual(rendered.lines, ["edit-a", "edit-b", "edit-c "]);
   assert.deepEqual(rendered.cursor, { row: 2, col: 7 });
+  // Two trailing editor lines were dropped to keep the cursor row visible, but
+  // no leading lines, so the region still starts at offset 0.
+  assert.deepEqual(rendered.editorRegion, { startRow: 0, lineOffset: 0, lineCount: 3 });
+});
+
+test("fixed cluster reports the dropped leading editor lines as an offset", () => {
+  const rendered = renderFixedEditorCluster({
+    width: 80,
+    terminalRows: 4,
+    placement: "above",
+    editorLines: ["edit-a", "edit-b", "edit-c", `edit-d ${CURSOR_MARKER}`, "edit-e"],
+  });
+
+  assert.deepEqual(rendered.lines, ["edit-b", "edit-c", "edit-d "]);
+  assert.deepEqual(rendered.editorRegion, { startRow: 0, lineOffset: 1, lineCount: 3 });
 });
 
 test("fixed cluster caps selector-style editor replacements around the selected row", () => {
@@ -1214,6 +1233,115 @@ test("terminal split pauses mouse reporting on right click for the terminal cont
   assert.deepEqual(inputListener?.("\x1b[<0;5;5m"), { consume: true });
   assert.deepEqual(copied, []);
   assert.deepEqual(renderRequests, [undefined, undefined, undefined, undefined]);
+
+  compositor.dispose();
+});
+
+function editorClickHarness(editorRegion: { startRow: number; lineOffset: number; lineCount: number }) {
+  const terminal = new FakeTerminal();
+  let inputListener: ((data: string) => { consume?: boolean; data?: string } | undefined) | null = null;
+  const copied: string[] = [];
+  const clicks: Array<{ editorLine: number; editorCol: number }> = [];
+  const tui = {
+    terminal,
+    addInputListener(listener: (data: string) => { consume?: boolean; data?: string } | undefined) {
+      inputListener = listener;
+      return () => {
+        inputListener = null;
+      };
+    },
+    requestRender() {},
+    render() {
+      return Array.from({ length: 20 }, (_, index) => `line-${index}`);
+    },
+  };
+
+  const compositor = new TerminalSplitCompositor({
+    tui,
+    terminal,
+    onCopySelection: (text) => copied.push(text),
+    onEditorTextClick: (editorLine, editorCol) => {
+      clicks.push({ editorLine, editorCol });
+      return true;
+    },
+    renderCluster: () => ({
+      lines: ["editor-top", "editor-body-a", "editor-body-b"],
+      cursor: null,
+      editorRegion,
+    }),
+  });
+
+  compositor.install();
+  tui.render(40);
+  // 12 terminal rows minus 3 cluster lines leaves a 9-row root viewport, so the
+  // first cluster row is packet row 10.
+  const clusterRowPacket = (clusterRow: number) => 10 + clusterRow;
+  return { inputListener: () => inputListener!, compositor, copied, clicks, clusterRowPacket };
+}
+
+test("terminal split moves the editor cursor on a plain click without selecting", () => {
+  const { inputListener, compositor, copied, clicks, clusterRowPacket } = editorClickHarness({
+    startRow: 0,
+    lineOffset: 0,
+    lineCount: 3,
+  });
+
+  const row = clusterRowPacket(1);
+  assert.deepEqual(inputListener()(`\x1b[<0;7;${row}M`), { consume: true });
+  assert.deepEqual(inputListener()(`\x1b[<0;7;${row}m`), { consume: true });
+
+  assert.deepEqual(clicks, [{ editorLine: 1, editorCol: 6 }]);
+  assert.deepEqual(copied, []);
+
+  compositor.dispose();
+});
+
+test("terminal split applies the editor line offset when mapping clicks", () => {
+  const { inputListener, compositor, clicks, clusterRowPacket } = editorClickHarness({
+    startRow: 0,
+    lineOffset: 4,
+    lineCount: 3,
+  });
+
+  const row = clusterRowPacket(2);
+  assert.deepEqual(inputListener()(`\x1b[<0;3;${row}M`), { consume: true });
+  assert.deepEqual(inputListener()(`\x1b[<0;3;${row}m`), { consume: true });
+
+  assert.deepEqual(clicks, [{ editorLine: 6, editorCol: 2 }]);
+
+  compositor.dispose();
+});
+
+test("terminal split still selects editor text on drag instead of clicking", () => {
+  const { inputListener, compositor, copied, clicks, clusterRowPacket } = editorClickHarness({
+    startRow: 0,
+    lineOffset: 0,
+    lineCount: 3,
+  });
+
+  const row = clusterRowPacket(1);
+  assert.deepEqual(inputListener()(`\x1b[<0;3;${row}M`), { consume: true });
+  assert.deepEqual(inputListener()(`\x1b[<32;9;${row}M`), { consume: true });
+  assert.deepEqual(inputListener()(`\x1b[<0;9;${row}m`), { consume: true });
+
+  assert.deepEqual(clicks, []);
+  assert.equal(copied.length, 1);
+
+  compositor.dispose();
+});
+
+test("terminal split ignores clicks outside the editor region", () => {
+  const { inputListener, compositor, clicks, clusterRowPacket } = editorClickHarness({
+    startRow: 1,
+    lineOffset: 0,
+    lineCount: 2,
+  });
+
+  const row = clusterRowPacket(0);
+  assert.deepEqual(inputListener()(`\x1b[<0;5;${row}M`), { consume: true });
+  assert.deepEqual(inputListener()(`\x1b[<0;5;${row}m`), { consume: true });
+
+  assert.deepEqual(clicks, []);
 
   compositor.dispose();
 });

--- a/tests/fixed-editor.test.ts
+++ b/tests/fixed-editor.test.ts
@@ -1330,6 +1330,27 @@ test("terminal split still selects editor text on drag instead of clicking", () 
   compositor.dispose();
 });
 
+test("terminal split dismisses the drag highlight when the editor is typed into", () => {
+  const { inputListener, compositor, copied, clusterRowPacket } = editorClickHarness({
+    startRow: 0,
+    lineOffset: 0,
+    lineCount: 3,
+  });
+
+  const row = clusterRowPacket(1);
+  assert.deepEqual(inputListener()(`\x1b[<0;3;${row}M`), { consume: true });
+  assert.deepEqual(inputListener()(`\x1b[<32;9;${row}M`), { consume: true });
+  assert.deepEqual(inputListener()(`\x1b[<0;9;${row}m`), { consume: true });
+
+  // A backspace goes to the editor (not consumed) and clears the selection.
+  assert.equal(inputListener()("\x7f"), undefined);
+  // With the selection gone, ctrl+c no longer copies anything.
+  assert.equal(inputListener()("\x03"), undefined);
+  assert.equal(copied.length, 1);
+
+  compositor.dispose();
+});
+
 test("terminal split ignores clicks outside the editor region", () => {
   const { inputListener, compositor, clicks, clusterRowPacket } = editorClickHarness({
     startRow: 1,

--- a/tests/jump-shortcuts.test.ts
+++ b/tests/jump-shortcuts.test.ts
@@ -79,7 +79,7 @@ test("chat jump shortcuts are configurable and route through fixed editor scroll
   assert.match(source, /let resolvedShortcuts = resolveShortcutConfig\(startupSettings\)/);
   assert.match(source, /resolvedShortcuts = resolveShortcutConfig\(settings\)/);
   assert.match(source, /keyboardScrollShortcuts: \{\n\s+up: resolvedShortcuts\.scrollChatUp,\n\s+down: resolvedShortcuts\.scrollChatDown,/);
-  assert.match(source, /scrollAwayNavigationCard: \{/);
+  assert.match(source, /scrollAwayNavigationCard: config\.scrollNavCard\n\s+\? \{/);
   assert.match(source, /shortcuts: \[/);
   assert.match(source, /scrollAwayShortcutEntry\("bottom", resolvedShortcuts\.jumpChatBottom\)/);
   assert.match(source, /onClickBottom: resolvedShortcuts\.jumpChatBottom \? \(\) => jumpChatToBottom\(ctx\) : undefined/);

--- a/types.ts
+++ b/types.ts
@@ -70,6 +70,15 @@ export type StatusLineSeparatorStyle =
 // Preset names
 export type PowerlinePlacement = "above" | "below";
 
+/**
+ * How the editor's text cursor is drawn.
+ * - "block": pi-tui's software cursor (reverse video), the default
+ * - "underline": software cursor drawn as an underline instead
+ * - "terminal": hide the software cursor and let the real terminal cursor
+ *   show through, so its shape and blinking follow the terminal's own config
+ */
+export type EditorCursorStyle = "block" | "underline" | "terminal";
+
 export type StatusLinePreset =
   | "default"
   | "minimal"


### PR DESCRIPTION
## What

Three opt-in fixed-editor input tweaks, plus a fix for mouse-drag selection inside the editor. All defaults reproduce the current behavior byte-for-byte, so foreground output is unchanged unless a user opts in.

## New config keys (`powerline.*`)

| key | default | notes |
|-----|---------|-------|
| `editorCursor` | `"block"` | `"block"` keeps pi's reverse-video software cursor; `"underline"` draws it as an underline; `"terminal"` hides the software cursor and shows the real terminal cursor, so its shape and blinking follow the terminal's own config (e.g. a blinking bar) |
| `editorClickCursor` | `false` | when `true`, a plain left click inside the input moves the text cursor there |
| `scrollNavCard` | `true` | keeps (default) or hides the "jump back to bottom" card shown after scrolling up — opt-out, since upstream always shows it |

## Behavior

**Drag-select is preserved.** Click-to-position resolves the click on mouse **release** rather than on press: a press always starts a selection, and only a press with no drag is treated as a click. So dragging inside the editor still selects text for copying (Ctrl+C), while a plain click moves the cursor. A drag highlight is a copy selection, not a live editor selection, so it is also dismissed on the first editing keystroke instead of lingering over text being edited.

**Click mapping.** Instead of pattern-matching the editor's box borders, `renderFixedEditorCluster` now returns an `editorRegion` recording where the editor's own lines landed in the cluster (including any leading lines dropped to fit the viewport). The compositor maps a clicked cluster row back to an editor render line through that region; the extension then undoes the border/prompt offset and calls `editor.buildVisualLineMap`.

**Terminal cursor mode.** `"terminal"` calls `tui.setShowHardwareCursor(true)` and strips the reverse-video software cursor from the render, leaving the real terminal cursor as the only caret (no double cursor).

## Tests

New cases in `tests/editor-cursor.test.ts` (cursor restyling + display-column mapping) and `tests/fixed-editor.test.ts` (`editorRegion` placement/offset, click-to-position on release, drag-still-selects, click outside the editor, highlight dismissed on keystroke), plus config parsing in `tests/custom-items.test.ts`. Full suite: 188 pass.

Note: touches `fixed-editor/terminal-split.ts`, so it will conflict with #105 (explicit copy paths) whichever lands second — happy to rebase.
