### PR TITLE
feat: opt-in git host icon (GitHub/GitLab/Bitbucket)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Git host icon** — Added opt-in `powerline.git.hostIcon` to replace the git branch icon with a detected GitHub, GitLab, Bitbucket, or generic git host icon when an origin remote is available. Thanks to Andy8647 for #113.
 - **Segment display formats** — Added opt-in `powerline.context.format` and `powerline.cache_read.format` settings for compact percentage-style context and cache-read segments. Thanks to Andy8647 for #109.
 - **copyOnSelect toggle** — Added `powerline.copyOnSelect` (default `true`) to control whether mouse text selection auto-copies to clipboard on release. Set to `false` to disable auto-copy; the selection then stays highlighted with a `N characters selected, ctrl+c to copy` hint, and copies explicitly via `ctrl+c` or right-click. Thanks to Andy8647 for #105.
 - **Scroll-away card toggle** — Added `powerline.scrollAwayCard` and `/powerline scroll-away-card on|off|toggle` so the fixed editor and chat navigation shortcuts can remain enabled while the scroll-away hint card is hidden. Thanks to Alexander Gerdes (@Avg8888), Whisperfall, and Bruno Orsolon (@brunoorsolon) for #97/#108/#99.

--- a/README.md
+++ b/README.md
@@ -432,6 +432,20 @@ By default the git segment polls both branch and dirty state. If background `git
 
 Use `"off"` to disable extension-owned git polling entirely and only show the branch reported by Pi when available.
 
+## Git host icon
+
+Set `git.hostIcon` to replace the branch icon with the origin remote's host logo:
+
+```json
+{
+  "powerline": {
+    "git": { "hostIcon": true }
+  }
+}
+```
+
+The origin remote is detected (SSH or HTTPS) and mapped to an icon: GitHub (), GitLab (), Bitbucket (), or a generic git logo () for any other remote (self-hosted, Gitea, Codeberg, …). Repositories without an origin remote keep the plain branch icon (), as do ASCII (non–Nerd Font) setups. The remote is read once and cached, so this adds no per-render cost. Default is `false` (branch icon unchanged).
+
 ## Segments
 
 `model` · `thinking` · `shell_mode` · `path` · `git` · `subagents` · `token_in` · `token_out` · `token_total` · `cost` · `context_pct` · `context_total` · `time_spent` · `time` · `session` · `hostname` · `cache_read` · `cache_write` · `extension_statuses`

--- a/git-status.ts
+++ b/git-status.ts
@@ -15,10 +15,21 @@ interface CachedBranch {
 
 export type GitPollingMode = "full" | "branch" | "off";
 
+/** Known git hosting providers we render a dedicated icon for. */
+export type GitHost = "github" | "gitlab" | "bitbucket" | "other";
+
+interface CachedRemoteHost {
+  host: GitHost | null;
+  timestamp: number;
+}
+
 const CACHE_TTL_MS = 1000; // 1 second for file status
 const BRANCH_TTL_MS = 500; // Shorter TTL so branch updates quickly after invalidation
+const REMOTE_TTL_MS = 60_000; // Origin remote almost never changes within a session
 let cachedStatus: CachedGitStatus | null = null;
 let cachedBranch: CachedBranch | null = null;
+let cachedRemoteHost: CachedRemoteHost | null = null;
+let pendingRemoteFetch: Promise<void> | null = null;
 let pendingFetch: Promise<void> | null = null;
 let pendingBranchFetch: Promise<void> | null = null;
 let invalidationCounter = 0; // Track invalidations to prevent stale updates
@@ -108,6 +119,71 @@ async function fetchGitBranch(): Promise<string | null> {
 
   const sha = await runGit(["rev-parse", "--short", "HEAD"]);
   return sha ? `${sha} (detached)` : "detached";
+}
+
+/**
+ * Classify an origin remote URL into a known hosting provider. Handles both
+ * SSH (`git@host:owner/repo`, `ssh://git@host/…`) and HTTP(S) forms, and
+ * treats sub-domains (e.g. `www.github.com`) and any non-empty remote we
+ * don't recognize as a generic git host.
+ */
+export function detectGitHost(remoteUrl: string | null): GitHost | null {
+  if (!remoteUrl) return null;
+  const trimmed = remoteUrl.trim();
+  if (!trimmed) return null;
+
+  let host: string;
+  const scpLike = /^[^/@]+@([^:/]+):/.exec(trimmed);
+  if (scpLike) {
+    host = scpLike[1]!;
+  } else {
+    try {
+      host = new URL(trimmed).hostname;
+    } catch {
+      return "other";
+    }
+  }
+
+  host = host.toLowerCase().replace(/^www\./, "");
+  if (host === "github.com" || host.endsWith(".github.com")) return "github";
+  if (host === "gitlab.com" || host.endsWith(".gitlab.com")) return "gitlab";
+  if (host === "bitbucket.org" || host.endsWith(".bitbucket.org")) return "bitbucket";
+  return "other";
+}
+
+/**
+ * Fetch the origin remote host asynchronously and cache the result.
+ */
+async function fetchRemoteHost(): Promise<GitHost | null> {
+  const url = await runGit(["remote", "get-url", "origin"]);
+  return detectGitHost(url);
+}
+
+/**
+ * Get the origin remote's hosting provider with a long TTL cache. Returns the
+ * cached value immediately (or null before the first fetch completes) and
+ * refreshes in the background, matching the branch/status caching pattern.
+ */
+export function getGitRemoteHost(): GitHost | null {
+  const now = Date.now();
+  if (cachedRemoteHost && now - cachedRemoteHost.timestamp < REMOTE_TTL_MS) {
+    return cachedRemoteHost.host;
+  }
+
+  if (!pendingRemoteFetch) {
+    pendingRemoteFetch = fetchRemoteHost()
+      .then((host) => {
+        cachedRemoteHost = { host, timestamp: Date.now() };
+      })
+      .catch(() => {
+        cachedRemoteHost = { host: null, timestamp: Date.now() };
+      })
+      .finally(() => {
+        pendingRemoteFetch = null;
+      });
+  }
+
+  return cachedRemoteHost ? cachedRemoteHost.host : null;
 }
 
 /**
@@ -218,4 +294,7 @@ export function invalidateGitStatus(): void {
 export function invalidateGitBranch(): void {
   if (cachedBranch) cachedBranch.timestamp = 0; // expire, but keep serving the stale value
   branchInvalidationCounter++;
+  // The origin remote is repo-scoped, so a branch/cwd change may mean a
+  // different repo; drop the host cache so it re-detects.
+  cachedRemoteHost = null;
 }

--- a/icons.ts
+++ b/icons.ts
@@ -6,6 +6,9 @@ export interface IconSet {
   folder: string;
   branch: string;
   git: string;
+  github: string;
+  gitlab: string;
+  bitbucket: string;
   tokens: string;
   context: string;
   cost: string;
@@ -56,6 +59,9 @@ export const NERD_ICONS: IconSet = {
   folder: "\uF115",     // nf-fa-folder_open
   branch: "\uF126",     // nf-fa-code_fork (git branch)
   git: "\uF1D3",        // nf-fa-git (git logo)
+  github: "\uF09B",     // nf-fa-github (octocat)
+  gitlab: "\uF296",     // nf-fa-gitlab (tanuki)
+  bitbucket: "\uF171",  // nf-fa-bitbucket
   tokens: "\uE26B",     // nf-seti-html (tokens symbol)
   context: "\uF1C0",    // nf-fa-database (stable Nerd Fonts v3 database)
   cost: "\uF155",       // nf-fa-dollar
@@ -77,6 +83,9 @@ export const ASCII_ICONS: IconSet = {
   folder: "dir",
   branch: "⎇",
   git: "⎇",
+  github: "⎇",
+  gitlab: "⎇",
+  bitbucket: "⎇",
   tokens: "⊛",
   context: "◫",
   cost: "$",

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -215,6 +215,7 @@ function normalizeSegmentOptions(raw: Record<string, unknown>): StatusLineSegmen
       ...(typeof raw.git.showUnstaged === "boolean" ? { showUnstaged: raw.git.showUnstaged } : {}),
       ...(typeof raw.git.showUntracked === "boolean" ? { showUntracked: raw.git.showUntracked } : {}),
       ...(raw.git.polling === "full" || raw.git.polling === "branch" || raw.git.polling === "off" ? { polling: raw.git.polling } : {}),
+      ...(typeof raw.git.hostIcon === "boolean" ? { hostIcon: raw.git.hostIcon } : {}),
     };
   }
 

--- a/segments.ts
+++ b/segments.ts
@@ -5,6 +5,9 @@ import type { BuiltinStatusLineSegmentId, RenderedSegment, SegmentContext, Seman
 import { normalizeCompactExtensionStatus, normalizeExtensionStatusValue } from "./powerline-config.ts";
 import { fg, rainbow, applyColor } from "./theme.ts";
 import { getIcons, SEP_DOT, getThinkingText } from "./icons.ts";
+import { getGitRemoteHost } from "./git-status.ts";
+import type { IconSet } from "./icons.ts";
+import type { GitHost } from "./git-status.ts";
 
 function color(ctx: SegmentContext, semantic: SemanticColor, text: string): string {
   return fg(ctx.theme, semantic, text, ctx.colors);
@@ -127,6 +130,23 @@ const pathSegment: StatusLineSegment = {
   },
 };
 
+/**
+ * Icon for the branch label: the origin remote's host logo when hostIcon is
+ * enabled and a remote is known, otherwise the plain branch icon. An
+ * unrecognized remote falls back to the generic git logo.
+ */
+function resolveBranchIcon(icons: IconSet, hostIcon: boolean): string {
+  if (!hostIcon) return icons.branch;
+  const host = getGitRemoteHost();
+  const byHost: Record<GitHost, string> = {
+    github: icons.github,
+    gitlab: icons.gitlab,
+    bitbucket: icons.bitbucket,
+    other: icons.git,
+  };
+  return host ? byHost[host] : icons.branch;
+}
+
 const gitSegment: StatusLineSegment = {
   id: "git",
   render(ctx) {
@@ -147,7 +167,8 @@ const gitSegment: StatusLineSegment = {
     let content = "";
     if (showBranch && branch) {
       // Color just the branch name (icon + branch text)
-      content = color(ctx, branchColor, withIcon(icons.branch, branch));
+      const branchIcon = resolveBranchIcon(icons, opts.hostIcon === true);
+      content = color(ctx, branchColor, withIcon(branchIcon, branch));
     }
 
     // Add status indicators (each with their own color, not wrapped)

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -147,7 +147,7 @@ test("parsePowerlineConfig extracts supported segment options", () => {
       preset: "default",
       model: { showThinkingLevel: true, display: "qualified" },
       path: { mode: "full", maxLength: 120 },
-      git: { showBranch: false, showStaged: false, showUnstaged: true, showUntracked: false, polling: "branch" },
+      git: { showBranch: false, showStaged: false, showUnstaged: true, showUntracked: false, polling: "branch", hostIcon: true },
       time: { format: "12h", showSeconds: true },
       cost: { subscriptionDisplay: "both" },
     },
@@ -157,7 +157,7 @@ test("parsePowerlineConfig extracts supported segment options", () => {
   assert.deepEqual(config.segmentOptions, {
     model: { showThinkingLevel: true, display: "qualified" },
     path: { mode: "full", maxLength: 120 },
-    git: { showBranch: false, showStaged: false, showUnstaged: true, showUntracked: false, polling: "branch" },
+    git: { showBranch: false, showStaged: false, showUnstaged: true, showUntracked: false, polling: "branch", hostIcon: true },
     time: { format: "12h", showSeconds: true },
     cost: { subscriptionDisplay: "both" },
   });

--- a/tests/git-status.test.ts
+++ b/tests/git-status.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { getCurrentBranch, getGitStatus, invalidateGitBranch, invalidateGitStatus } from "../git-status.ts";
+import { detectGitHost, getCurrentBranch, getGitStatus, invalidateGitBranch, invalidateGitStatus } from "../git-status.ts";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -42,4 +42,30 @@ test("invalidateGitBranch keeps serving the last known branch while refreshing",
 
   invalidateGitBranch();
   assert.equal(getCurrentBranch("provider-fallback"), realBranch);
+});
+
+test("detectGitHost recognizes known hosts over SSH and HTTPS", () => {
+  assert.equal(detectGitHost("git@github.com:owner/repo.git"), "github");
+  assert.equal(detectGitHost("https://github.com/owner/repo.git"), "github");
+  assert.equal(detectGitHost("ssh://git@gitlab.com/owner/repo.git"), "gitlab");
+  assert.equal(detectGitHost("https://gitlab.com/owner/repo"), "gitlab");
+  assert.equal(detectGitHost("git@bitbucket.org:owner/repo.git"), "bitbucket");
+  assert.equal(detectGitHost("https://user@bitbucket.org/owner/repo.git"), "bitbucket");
+});
+
+test("detectGitHost normalizes www and sub-domains", () => {
+  assert.equal(detectGitHost("https://www.github.com/owner/repo"), "github");
+  assert.equal(detectGitHost("git@ssh.github.com:owner/repo.git"), "github");
+});
+
+test("detectGitHost treats unknown or self-hosted remotes as a generic host", () => {
+  assert.equal(detectGitHost("git@git.example.com:owner/repo.git"), "other");
+  assert.equal(detectGitHost("https://gitea.mycorp.dev/owner/repo.git"), "other");
+  assert.equal(detectGitHost("/srv/git/local.git"), "other");
+});
+
+test("detectGitHost returns null when there is no remote", () => {
+  assert.equal(detectGitHost(null), null);
+  assert.equal(detectGitHost(""), null);
+  assert.equal(detectGitHost("   "), null);
 });

--- a/types.ts
+++ b/types.ts
@@ -91,6 +91,9 @@ export interface StatusLineSegmentOptions {
     showUnstaged?: boolean;
     showUntracked?: boolean;
     polling?: "full" | "branch" | "off";
+    /** Replace the branch icon with the origin remote's host logo
+     * (GitHub/GitLab/Bitbucket, or a generic git logo). Default false. */
+    hostIcon?: boolean;
   };
   time?: { format?: "12h" | "24h"; showSeconds?: boolean };
   cost?: { subscriptionDisplay?: "subscription" | "reported-cost" | "both" };


### PR DESCRIPTION
## What

Adds an opt-in `powerline.git.hostIcon` (default `false`). When enabled, the git segment replaces the branch icon with the origin remote's host logo:

| origin remote | icon |
|---------------|------|
| github.com |  (nf-fa-github) |
| gitlab.com |  (nf-fa-gitlab) |
| bitbucket.org |  (nf-fa-bitbucket) |
| any other remote (self-hosted, Gitea, Codeberg, …) |  (nf-fa-git, generic) |
| no origin remote |  branch icon (unchanged) |

```json
{ "powerline": { "git": { "hostIcon": true } } }
```

## Design

- **Detection** parses `git remote get-url origin` for both SSH (`git@host:owner/repo`, `ssh://git@host/…`) and HTTP(S) forms, normalizes `www.`/sub-domains, and treats any non-empty unrecognized remote as a generic git host. Extracted into `detectGitHost()` and unit-tested.
- **Caching:** the remote is read once with a long (60s) TTL following the existing branch/status cache pattern — the render path stays synchronous and adds no per-render `git` calls. The cache is dropped on branch invalidation (cwd/repo change) so switching repos re-detects.
- **Icons:** the generic `git` glyph already existed; this adds `github`/`gitlab`/`bitbucket` to the icon set. The ASCII (non–Nerd Font) set maps them all to the existing `⎇` fallback, so nothing breaks without Nerd Fonts.
- **Default unchanged:** `hostIcon` off (the default) renders exactly as before.

## Tests

`detectGitHost` cases (SSH/HTTPS, www/sub-domain normalization, self-hosted → generic, empty → none) in `tests/git-status.test.ts`, plus config parsing in `tests/custom-items.test.ts`. Full suite: 178 pass.
