### PR TITLE
feat: allow separator override independent of preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Separator override** — Added `powerline.separator` so separator style can be chosen independently of the active preset. Thanks to Andy8647 and mj-meyer for #106/#116.
 - **Git host icon** — Added opt-in `powerline.git.hostIcon` to replace the git branch icon with a detected GitHub, GitLab, Bitbucket, or generic git host icon when an origin remote is available. Thanks to Andy8647 for #113.
 - **Segment display formats** — Added opt-in `powerline.context.format` and `powerline.cache_read.format` settings for compact percentage-style context and cache-read segments. Thanks to Andy8647 for #109.
 - **copyOnSelect toggle** — Added `powerline.copyOnSelect` (default `true`) to control whether mouse text selection auto-copies to clipboard on release. Set to `false` to disable auto-copy; the selection then stays highlighted with a `N characters selected, ctrl+c to copy` hint, and copies explicitly via `ctrl+c` or right-click. Thanks to Andy8647 for #105.

--- a/README.md
+++ b/README.md
@@ -150,12 +150,13 @@ Built-in names are listed under Segments below. Custom items use `custom:<id>`. 
 
 ### Custom layout
 
-Use `powerline.layout` to override segment order and grouping while keeping the selected preset’s separator, colors, and segment options:
+Use `powerline.layout` to override segment order and grouping while keeping the selected preset’s colors and segment options. Set `powerline.separator` when you want a separator style independent of the preset:
 
 ```json
 {
   "powerline": {
     "preset": "default",
+    "separator": "chevron",
     "layout": {
       "left": ["model", "thinking", "path", "git"],
       "right": ["context_pct", "cost"],
@@ -168,7 +169,7 @@ Use `powerline.layout` to override segment order and grouping while keeping the 
 }
 ```
 
-A present `left`, `right`, or `secondary` array replaces that preset group exactly; an empty array clears it. Omitted groups keep the preset entries and automatically append custom items by their configured `position`. Explicitly listing a segment moves it out of omitted preset groups, and explicitly placed custom items are not auto-appended elsewhere. `disabledSegments` is applied after layout.
+A present `left`, `right`, or `secondary` array replaces that preset group exactly; an empty array clears it. Omitted groups keep the preset entries and automatically append custom items by their configured `position`. Explicitly listing a segment moves it out of omitted preset groups, and explicitly placed custom items are not auto-appended elsewhere. `disabledSegments` is applied after layout. `separator` accepts any style listed below; omit it to keep the preset’s separator.
 
 Responsive behavior is unchanged: these groups control ordering and overflow priority, not permanently pinned terminal rows. On wide terminals secondary entries can fit in the top bar; on narrow terminals primary overflow moves into the secondary line. Unknown entries are ignored with a startup warning. The old fixed `custom` preset has been removed; combine any preset with `layout` instead.
 

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@ import { isKeyRelease, type AutocompleteProvider, type SelectItem, SelectList, t
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 
-import type { ColorScheme, SegmentContext, StatusLinePreset, StatusLineSegmentId } from "./types.ts";
+import type { ColorScheme, SegmentContext, StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "./types.ts";
 import type { PowerlineConfig } from "./powerline-config.ts";
 import { BashTranscriptStore } from "./bash-mode/transcript.ts";
 import {
@@ -957,10 +957,10 @@ function renderSegmentWithWidth(
 /** Build content string from pre-rendered parts */
 function buildContentFromParts(
   parts: string[],
-  presetDef: ReturnType<typeof getPreset>
+  separatorStyle: StatusLineSeparatorStyle,
 ): string {
   if (parts.length === 0) return "";
-  const separatorDef = getSeparator(presetDef.separator);
+  const separatorDef = getSeparator(separatorStyle);
   const sepAnsi = getFgAnsiCode("sep");
   const sep = separatorDef.left;
   return " " + parts.join(` ${sepAnsi}${sep}${ansi.reset} `) + ansi.reset + " ";
@@ -976,7 +976,8 @@ function computeResponsiveLayout(
   presetDef: ReturnType<typeof getPreset>,
   availableWidth: number
 ): { topContent: string; secondaryContent: string } {
-  const separatorDef = getSeparator(presetDef.separator);
+  const separatorStyle = config.separator ?? presetDef.separator;
+  const separatorDef = getSeparator(separatorStyle);
   const sepWidth = visibleWidth(separatorDef.left) + 2; // separator + spaces around it
   
   // Get all segments: primary first, then secondary
@@ -1037,8 +1038,8 @@ function computeResponsiveLayout(
   }
   
   return {
-    topContent: buildContentFromParts(topSegments, presetDef),
-    secondaryContent: buildContentFromParts(secondarySegments, presetDef),
+    topContent: buildContentFromParts(topSegments, separatorStyle),
+    secondaryContent: buildContentFromParts(secondarySegments, separatorStyle),
   };
 }
 

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,6 +1,6 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { BUILTIN_STATUS_LINE_SEGMENT_IDS } from "./types.ts";
-import type { ColorValue, CustomItemPosition, CustomStatusItem, PowerlinePlacement, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions } from "./types.ts";
+import type { ColorValue, CustomItemPosition, CustomStatusItem, PowerlinePlacement, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions, StatusLineSeparatorStyle } from "./types.ts";
 
 export interface PowerlineConfig {
   preset: StatusLinePreset;
@@ -9,6 +9,7 @@ export interface PowerlineConfig {
   invalidDisabledSegments: string[];
   layout: StatusLineLayout | null;
   invalidLayoutSegments: string[];
+  separator: StatusLineSeparatorStyle | null;
   segmentOptions: StatusLineSegmentOptions;
   mouseScroll: boolean;
   fixedEditor: boolean;
@@ -43,6 +44,27 @@ function normalizePlacement(value: unknown): { placement: PowerlinePlacement; in
     placement: "above",
     invalidPlacement: typeof value === "string" ? value.trim() : String(value),
   };
+}
+
+const SEPARATOR_STYLES = [
+  "powerline",
+  "powerline-thin",
+  "slash",
+  "pipe",
+  "block",
+  "none",
+  "ascii",
+  "dot",
+  "chevron",
+  "star",
+] as const satisfies readonly StatusLineSeparatorStyle[];
+
+function normalizeSeparator(value: unknown): StatusLineSeparatorStyle | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return (SEPARATOR_STYLES as readonly string[]).includes(normalized)
+    ? (normalized as StatusLineSeparatorStyle)
+    : null;
 }
 
 function normalizeCustomItemId(value: unknown): string | null {
@@ -276,6 +298,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     invalidDisabledSegments: [],
     layout: null,
     invalidLayoutSegments: [],
+    separator: null,
     segmentOptions: {},
     mouseScroll: true,
     fixedEditor: true,
@@ -304,6 +327,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     invalidDisabledSegments,
     layout,
     invalidLayoutSegments,
+    separator: normalizeSeparator(value.separator),
     segmentOptions: normalizeSegmentOptions(value),
     mouseScroll: value.mouseScroll !== false,
     fixedEditor: value.fixedEditor !== false,

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, normalizeExtensionStatusValue, parsePowerlineConfig, mergeSegmentOptions, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, normalizeCompactExtensionStatus } from "../powerline-config.ts";
+import { getSeparator } from "../separators.ts";
 import { PRESETS } from "../presets.ts";
 
 test("fixed custom preset is removed in favor of powerline.layout", () => {
@@ -32,6 +33,7 @@ test("parsePowerlineConfig supports object config with custom items", () => {
   assert.equal(config.mouseScroll, true);
   assert.equal(config.fixedEditor, true);
   assert.equal(config.scrollAwayCard, true);
+  assert.equal(config.separator, null);
   assert.equal(config.placement, "above");
   assert.equal(config.invalidPlacement, null);
   assert.equal(config.welcome, true);
@@ -80,6 +82,28 @@ test("parsePowerlineConfig supports partial explicit layout rows", () => {
     secondary: [],
   });
   assert.deepEqual(config.invalidLayoutSegments, ["left:unknown", "left:123", "right:model"]);
+});
+
+test("parsePowerlineConfig supports separator overrides", () => {
+  const config = parsePowerlineConfig(
+    { preset: "default", separator: " chevron " },
+    ["default", "compact"],
+  );
+  const invalid = parsePowerlineConfig(
+    { preset: "default", separator: "sparkle" },
+    ["default", "compact"],
+  );
+
+  assert.equal(config.separator, "chevron");
+  assert.equal(invalid.separator, null);
+});
+
+test("configured separators resolve independently of presets", () => {
+  const presetSeparator = getSeparator(PRESETS.default.separator).left;
+  const configuredSeparator = getSeparator("chevron").left;
+
+  assert.notEqual(configuredSeparator, presetSeparator);
+  assert.equal(configuredSeparator, "›");
 });
 
 test("parsePowerlineConfig validates primary powerline placement", () => {


### PR DESCRIPTION
Adds a narrow `powerline.separator` override so users can pick any documented separator style without changing presets or segment layout. This extracts the separator slice from #106 and leaves the broader pill-segment work split for later.\n\nFixes #116.\n\nThanks to Andy8647 for the original separator idea in #106 and mj-meyer for the report in #116.\n\nValidation:\n- `node --experimental-strip-types --test tests/custom-items.test.ts`\n- `npm test` (211/211)\n- fresh read-only review: no issues found