### PR TITLE
fix: load documented theme override path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Fixed-editor scrolling performance** — Uses terminal row shifts, cached transcript lines, an 8 ms repaint cadence, and transient shortcut-card hiding during active wheel movement to cut scroll latency and terminal output churn.
 
 ### Fixed
+- **Theme override path** — Loads `theme.json` from the documented agent-dir `extensions/powerline-footer` path before falling back to the loaded package directory, and clarifies setup docs for `showLastPrompt` and layout rows. Thanks to MeisterP for #117.
 - **Print-mode terminal cleanup** — Terminal reset and cursor restoration sequences run only during interactive TUI shutdowns, keeping `pi -p` output visible. Thanks to Sergey Konkin (@sergeykonkin) for #101.
 
 ## [0.7.0] - 2026-07-14

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can also set it in the agent settings file (`~/.pi/agent/settings.json` by d
 
 ```json
 {
+  "showLastPrompt": true,
   "powerline": {
     "preset": "default",
     "fixedEditor": false,
@@ -75,7 +76,7 @@ You can also set it in the agent settings file (`~/.pi/agent/settings.json` by d
 }
 ```
 
-Use `"fixedEditor": true` to enable it again. Set `"scrollAwayCard": false` to keep the fixed editor and navigation shortcuts while hiding the scroll-away hint card. `"placement"` accepts `"above"` (default) or `"below"` in both fixed and regular editor modes. It moves only the primary powerline row; notifications and Pi working status stay above, while responsive overflow, bash transcript, and the last-prompt reminder stay below. Set `"welcome": false` to skip the startup welcome overlay/header while leaving powerline itself enabled. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling. Set `"copyOnSelect": false` to prevent selected text from being automatically copied to the system clipboard; the selection stays highlighted with a character-count hint, and you copy explicitly with `ctrl+c` or right-click instead. In Herdr, tmux, and other terminal multiplexers, fixed-editor scrolling is Pi-owned while fixed-editor mode is on; keep mouse scrolling enabled for the fixed-editor viewport, or use `/powerline fixed-editor off` when you want the host multiplexer scrollback to own the experience. While fixed-editor mouse reporting is enabled, hold Shift during your terminal's normal modifier-click to bypass capture for OSC 8 links; otherwise use `/powerline mouse-scroll off` or `/powerline fixed-editor off` for native link handling.
+Use `"fixedEditor": true` to enable it again. Set `"scrollAwayCard": false` to keep the fixed editor and navigation shortcuts while hiding the scroll-away hint card. `"placement"` accepts `"above"` (default) or `"below"` in both fixed and regular editor modes. It moves only the primary powerline row; notifications and Pi working status stay above, while responsive overflow, bash transcript, and the last-prompt reminder stay below. Set `"showLastPrompt": false` at the top level of `settings.json` (not inside `powerline`) to hide that reminder. Set `"welcome": false` to skip the startup welcome overlay/header while leaving powerline itself enabled. Add `"mouseScroll": false` if you want native terminal selection instead of fixed-editor mouse handling. Set `"copyOnSelect": false` to prevent selected text from being automatically copied to the system clipboard; the selection stays highlighted with a character-count hint, and you copy explicitly with `ctrl+c` or right-click instead. In Herdr, tmux, and other terminal multiplexers, fixed-editor scrolling is Pi-owned while fixed-editor mode is on; keep mouse scrolling enabled for the fixed-editor viewport, or use `/powerline fixed-editor off` when you want the host multiplexer scrollback to own the experience. While fixed-editor mouse reporting is enabled, hold Shift during your terminal's normal modifier-click to bypass capture for OSC 8 links; otherwise use `/powerline mouse-scroll off` or `/powerline fixed-editor off` for native link handling.
 
 | Preset | Description |
 |--------|-------------|
@@ -171,7 +172,7 @@ Use `powerline.layout` to override segment order and grouping while keeping the 
 
 A present `left`, `right`, or `secondary` array replaces that preset group exactly; an empty array clears it. Omitted groups keep the preset entries and automatically append custom items by their configured `position`. Explicitly listing a segment moves it out of omitted preset groups, and explicitly placed custom items are not auto-appended elsewhere. `disabledSegments` is applied after layout. `separator` accepts any style listed below; omit it to keep the preset’s separator.
 
-Responsive behavior is unchanged: these groups control ordering and overflow priority, not permanently pinned terminal rows. On wide terminals secondary entries can fit in the top bar; on narrow terminals primary overflow moves into the secondary line. Unknown entries are ignored with a startup warning. The old fixed `custom` preset has been removed; combine any preset with `layout` instead.
+Responsive behavior is unchanged: these groups control ordering and overflow priority, not permanently pinned terminal rows. `right` means “later primary segments,” not right-edge alignment. On wide terminals secondary entries can fit in the top bar; on narrow terminals primary overflow moves into the secondary line. Some segments are hidden when they have no value, so `thinking` appears only when the active session/model reports a non-`off` thinking level. Unknown entries are ignored with a startup warning. The old fixed `custom` preset has been removed; combine any preset with `layout` instead.
 
 ### Demo settings
 
@@ -480,12 +481,11 @@ Colors are configurable via pi's theme system. Each preset defines its own color
 
 ### Custom Theme Override
 
-Create `extensions/powerline-footer/theme.json` in the agent dir:
+Create `extensions/powerline-footer/theme.json` in the agent dir (`~/.pi/agent` by default, or `PI_CODING_AGENT_DIR` when set):
 
 ```json
 {
   "colors": {
-    "pi": "#ff5500",
     "model": "accent",
     "shellMode": "accent",
     "path": "#00afaf",
@@ -507,5 +507,7 @@ Colors can be:
 - **Hex colors**: `#ff5500`, `#d787af`
 
 Icons can be any string, including `""` when you want to suppress a specific glyph entirely.
+
+For npm package installs, this documented agent-dir file is separate from the package files under `~/.pi/agent/npm/node_modules`. The extension reads the agent-dir override first, then falls back to a `theme.json` colocated with the loaded extension file. Use `/reload` or restart Pi after creating or editing `theme.json`.
 
 See `theme.example.json` for all available options.

--- a/tests/bash-mode.test.ts
+++ b/tests/bash-mode.test.ts
@@ -13,6 +13,7 @@ import {
   OneOffBashAutocompleteProvider,
 } from "../bash-mode/completion.ts";
 import { getIcons } from "../icons.ts";
+import { resolveColor } from "../theme.ts";
 import { ManagedShellSession } from "../bash-mode/shell-session.ts";
 
 function getMethod(target: object, name: string): Function {
@@ -112,6 +113,28 @@ test("theme.json can override icons without touching colors", () => {
     } else {
       process.env.POWERLINE_NERD_FONTS = originalNerdFonts;
     }
+  }
+});
+
+test("theme.json loads from the documented agent extension path", () => {
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const agentDir = mkdtempSync(join(tmpdir(), "powerline-theme-"));
+
+  try {
+    const themeDir = join(agentDir, "extensions", "powerline-footer");
+    mkdirSync(themeDir, { recursive: true });
+    writeFileSync(join(themeDir, "theme.json"), JSON.stringify({ colors: { model: "#ff5500", path: "#ff5500" } }));
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+
+    assert.equal(resolveColor("model"), "#ff5500");
+    assert.equal(resolveColor("path"), "#ff5500");
+  } finally {
+    if (originalAgentDir === undefined) {
+      delete process.env.PI_CODING_AGENT_DIR;
+    } else {
+      process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+    }
+    rmSync(agentDir, { recursive: true, force: true });
   }
 });
 

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -84,6 +84,38 @@ test("parsePowerlineConfig supports partial explicit layout rows", () => {
   assert.deepEqual(config.invalidLayoutSegments, ["left:unknown", "left:123", "right:model"]);
 });
 
+test("parsePowerlineConfig preserves reporter layout groups", () => {
+  const config = parsePowerlineConfig(
+    {
+      preset: "default",
+      layout: {
+        left: ["model"],
+        right: ["path"],
+        secondary: ["thinking"],
+      },
+    },
+    ["default", "compact"],
+  );
+
+  assert.deepEqual(config.layout, {
+    left: ["model"],
+    right: ["path"],
+    secondary: ["thinking"],
+  });
+  assert.deepEqual(config.invalidLayoutSegments, []);
+  assert.deepEqual(
+    mergeSegmentsWithCustomItems(PRESETS.default, config.customItems, {
+      layout: config.layout,
+      disabledSegments: config.disabledSegments,
+    }),
+    {
+      leftSegments: ["model"],
+      rightSegments: ["path"],
+      secondarySegments: ["thinking"],
+    },
+  );
+});
+
 test("parsePowerlineConfig supports separator overrides", () => {
   const config = parsePowerlineConfig(
     { preset: "default", separator: " chevron " },

--- a/theme.ts
+++ b/theme.ts
@@ -11,6 +11,7 @@ import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getAgentPath } from "./paths.ts";
 import type { ColorScheme, ColorValue, SemanticColor, ThemeLike } from "./types.ts";
 
 export interface PowerlineThemeConfig {
@@ -47,8 +48,10 @@ const RAINBOW_COLORS = [
 // Cache for user theme overrides
 let userThemeCache: ColorScheme | null = null;
 let userThemeCacheTime = 0;
+let userThemeCacheKey = "";
 let themeConfigCache: PowerlineThemeConfig | null = null;
 let themeConfigCacheTime = 0;
+let themeConfigCacheKey = "";
 const CACHE_TTL = 5000; // 5 seconds
 const warnedInvalidThemeColors = new Set<string>();
 
@@ -82,50 +85,60 @@ function sanitizeUserThemeOverrides(value: unknown): ColorScheme {
 }
 
 /**
- * Get the path to the theme.json file
+ * Get theme.json lookup paths.
  */
-function getThemePath(): string {
+function getThemePaths(): string[] {
   const extDir = dirname(fileURLToPath(import.meta.url));
-  return join(extDir, "theme.json");
+  return Array.from(new Set([
+    getAgentPath("extensions", "powerline-footer", "theme.json"),
+    join(extDir, "theme.json"),
+  ]));
 }
 
 /**
- * Load user theme config from theme.json
+ * Load user theme config from theme.json.
  */
 export function loadThemeConfig(): PowerlineThemeConfig {
   const now = Date.now();
-  if (themeConfigCache && now - themeConfigCacheTime < CACHE_TTL) {
+  const themePaths = getThemePaths();
+  const cacheKey = themePaths.join("\0");
+  if (themeConfigCache && themeConfigCacheKey === cacheKey && now - themeConfigCacheTime < CACHE_TTL) {
     return themeConfigCache;
   }
 
-  const themePath = getThemePath();
-  try {
-    if (existsSync(themePath)) {
-      const content = readFileSync(themePath, "utf-8");
-      const parsed = JSON.parse(content);
-      themeConfigCache = isRecord(parsed) ? parsed : {};
-      themeConfigCacheTime = now;
-      return themeConfigCache;
+  for (const themePath of themePaths) {
+    try {
+      if (existsSync(themePath)) {
+        const content = readFileSync(themePath, "utf-8");
+        const parsed = JSON.parse(content);
+        themeConfigCache = isRecord(parsed) ? parsed : {};
+        themeConfigCacheTime = now;
+        themeConfigCacheKey = cacheKey;
+        return themeConfigCache;
+      }
+    } catch (error) {
+      // Theme overrides are optional. If the file is unreadable or malformed,
+      // keep rendering with built-in defaults instead of breaking the footer.
+      console.debug(`[powerline-theme] Failed to load ${themePath}:`, error);
     }
-  } catch (error) {
-    // Theme overrides are optional. If the file is unreadable or malformed,
-    // keep rendering with built-in defaults instead of breaking the footer.
-    console.debug(`[powerline-theme] Failed to load ${themePath}:`, error);
   }
 
   themeConfigCache = {};
   themeConfigCacheTime = now;
+  themeConfigCacheKey = cacheKey;
   return themeConfigCache;
 }
 
 function loadUserTheme(): ColorScheme {
   const now = Date.now();
-  if (userThemeCache && now - userThemeCacheTime < CACHE_TTL) {
+  const cacheKey = getThemePaths().join("\0");
+  if (userThemeCache && userThemeCacheKey === cacheKey && now - userThemeCacheTime < CACHE_TTL) {
     return userThemeCache;
   }
 
   userThemeCache = sanitizeUserThemeOverrides(loadThemeConfig().colors);
   userThemeCacheTime = now;
+  userThemeCacheKey = cacheKey;
   return userThemeCache;
 }
 


### PR DESCRIPTION
## Summary

Fixes the setup mismatch from #117 by loading `theme.json` from the documented agent-dir path before falling back to the package-local file.

Also clarifies that `showLastPrompt` is top-level settings JSON, that layout rows control ordering/overflow rather than fixed right-edge alignment, and that `thinking` is hidden when no thinking level is active.

## Validation

- `git diff --check`
- `node --experimental-strip-types --test tests/bash-mode.test.ts tests/custom-items.test.ts`
- `npm test`
- `npm pack --dry-run --json`

Fixes #117
