### PR TITLE
fix: retry fixed-editor keyboard negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Fixed-editor scrolling performance** — Uses terminal row shifts, cached transcript lines, an 8 ms repaint cadence, and transient shortcut-card hiding during active wheel movement to cut scroll latency and terminal output churn.
 
 ### Fixed
+- **Fixed-editor keyboard negotiation** — Retries extended keyboard mode setup briefly after entering the alternate screen so late Kitty/modifyOtherKeys negotiation is enabled on the active screen. Thanks to Raymond Ko for #102.
 - **Theme override path** — Loads `theme.json` from the documented agent-dir `extensions/powerline-footer` path before falling back to the loaded package directory, and clarifies setup docs for `showLastPrompt` and layout rows. Thanks to MeisterP for #117.
 - **Print-mode terminal cleanup** — Terminal reset and cursor restoration sequences run only during interactive TUI shutdowns, keeping `pi -p` output visible. Thanks to Sergey Konkin (@sergeykonkin) for #101.
 

--- a/fixed-editor/terminal-split.ts
+++ b/fixed-editor/terminal-split.ts
@@ -128,6 +128,8 @@ const CONTEXT_MENU_SELECTION_RESTORE_WINDOW_MS = 5000;
 const CONTEXT_MENU_CLIPBOARD_RESTORE_INTERVAL_MS = 100;
 export const DEFAULT_SCROLL_REPAINT_THROTTLE_MS = 8;
 const SCROLL_SETTLED_RENDER_MS = 80;
+const EXTENDED_KEYBOARD_RETRY_MS = 10;
+const EXTENDED_KEYBOARD_RETRY_ATTEMPTS = 50;
 const DOUBLE_CLICK_MS = 500;
 const DEFAULT_KEYBOARD_SCROLL_SHORTCUTS: KeyboardScrollShortcuts = {
   up: "super+up",
@@ -576,6 +578,7 @@ export class TerminalSplitCompositor {
   private removeInputListener: (() => void) | null = null;
   private emergencyCleanup: (() => void) | null = null;
   private mouseReportingResumeTimer: ReturnType<typeof setTimeout> | null = null;
+  private alternateScreenKeyboardRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private clipboardRestoreTimer: ReturnType<typeof setTimeout> | null = null;
   private scrollRepaintTimer: ReturnType<typeof setTimeout> | null = null;
   private scrollSettledRenderTimer: ReturnType<typeof setTimeout> | null = null;
@@ -638,6 +641,10 @@ export class TerminalSplitCompositor {
       + this.mouseReportingStateGuard()
       + endSynchronizedOutput(),
     );
+    if (this.extendedKeyboardMode === null) {
+      this.scheduleAlternateScreenKeyboardRetry(EXTENDED_KEYBOARD_RETRY_ATTEMPTS);
+    }
+
     this.emergencyCleanup = () => {
       if (!this.disposed) {
         this.restoreTerminalStateForExit();
@@ -827,6 +834,10 @@ export class TerminalSplitCompositor {
     if (this.mouseReportingResumeTimer) {
       clearTimeout(this.mouseReportingResumeTimer);
       this.mouseReportingResumeTimer = null;
+    }
+    if (this.alternateScreenKeyboardRetryTimer) {
+      clearTimeout(this.alternateScreenKeyboardRetryTimer);
+      this.alternateScreenKeyboardRetryTimer = null;
     }
     if (this.clipboardRestoreTimer) {
       clearTimeout(this.clipboardRestoreTimer);
@@ -1548,6 +1559,28 @@ export class TerminalSplitCompositor {
   private enableAlternateScreenKeyboardMode(): string {
     this.extendedKeyboardMode = this.activeExtendedKeyboardMode();
     return this.extendedKeyboardMode ? enableExtendedKeyboardMode(this.extendedKeyboardMode) : "";
+  }
+
+  private scheduleAlternateScreenKeyboardRetry(remainingAttempts: number): void {
+    if (remainingAttempts <= 0 || this.disposed || this.extendedKeyboardMode !== null) return;
+
+    this.alternateScreenKeyboardRetryTimer = setTimeout(() => {
+      this.alternateScreenKeyboardRetryTimer = null;
+      if (this.disposed || this.extendedKeyboardMode !== null) return;
+
+      const activeMode = this.activeExtendedKeyboardMode();
+      if (activeMode) {
+        this.extendedKeyboardMode = activeMode;
+        this.originalWrite(enableExtendedKeyboardMode(activeMode));
+        return;
+      }
+
+      this.scheduleAlternateScreenKeyboardRetry(remainingAttempts - 1);
+    }, EXTENDED_KEYBOARD_RETRY_MS);
+
+    if (typeof this.alternateScreenKeyboardRetryTimer === "object" && "unref" in this.alternateScreenKeyboardRetryTimer) {
+      this.alternateScreenKeyboardRetryTimer.unref();
+    }
   }
 
   private restoreTerminalState(options: DisposeOptions = {}): void {

--- a/tests/fixed-editor.test.ts
+++ b/tests/fixed-editor.test.ts
@@ -329,6 +329,77 @@ test("terminal split re-enables modifyOtherKeys in alternate screen", () => {
   assert.ok(!cleanup.includes("\x1b[<999u"));
 });
 
+test("terminal split retries Kitty keyboard protocol when negotiation completes after install", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const terminal = new FakeTerminal();
+  const compositor = new TerminalSplitCompositor({
+    tui: { terminal },
+    terminal,
+    renderCluster: () => ({ lines: ["cluster"], cursor: null }),
+  });
+
+  compositor.install();
+
+  const setup = terminal.writes[0] ?? "";
+  assert.ok(setup.includes("\x1b[?1049h"));
+  assert.ok(!setup.includes("\x1b[>7u"));
+
+  terminal.kittyProtocolActive = true;
+  t.mock.timers.tick(10);
+
+  assert.equal(terminal.writes.at(-1), "\x1b[>7u");
+
+  compositor.dispose();
+
+  const cleanup = terminal.writes.at(-1) ?? "";
+  assert.ok(cleanup.includes("\x1b[<u"));
+  assert.ok(cleanup.indexOf("\x1b[<u") < cleanup.indexOf("\x1b[?1049l"));
+});
+
+test("terminal split retries modifyOtherKeys when negotiation completes after install", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const terminal = new FakeTerminal();
+  const compositor = new TerminalSplitCompositor({
+    tui: { terminal },
+    terminal,
+    renderCluster: () => ({ lines: ["cluster"], cursor: null }),
+  });
+
+  compositor.install();
+  Reflect.set(terminal, "_modifyOtherKeysActive", true);
+  t.mock.timers.tick(10);
+
+  assert.equal(terminal.writes.at(-1), "\x1b[>4;2m");
+
+  compositor.dispose();
+
+  const cleanup = terminal.writes.at(-1) ?? "";
+  assert.ok(cleanup.includes("\x1b[>4;0m"));
+  assert.ok(cleanup.indexOf("\x1b[>4;0m") < cleanup.indexOf("\x1b[?1049l"));
+});
+
+test("terminal split cancels pending keyboard retries on dispose", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const terminal = new FakeTerminal();
+  const compositor = new TerminalSplitCompositor({
+    tui: { terminal },
+    terminal,
+    renderCluster: () => ({ lines: ["cluster"], cursor: null }),
+  });
+
+  compositor.install();
+  compositor.dispose();
+  const writeCount = terminal.writes.length;
+
+  terminal.kittyProtocolActive = true;
+  t.mock.timers.tick(100);
+
+  assert.equal(terminal.writes.length, writeCount);
+});
+
 test("terminal split restores main screen mode when Kitty activates after install", () => {
   const terminal = new FakeTerminal();
   const compositor = new TerminalSplitCompositor({


### PR DESCRIPTION
## Summary

Fixes #102 by retrying extended keyboard mode detection briefly after fixed-editor enters the alternate screen. If Pi's async Kitty or modifyOtherKeys negotiation completes just after install, the compositor now enables that mode on the active alternate screen instead of leaving the terminal to emit legacy key encodings there.

The retry is bounded and canceled on compositor disposal, and existing cleanup still disables the active mode before leaving the alternate screen.

## Validation

- `git diff --check`
- `node --experimental-strip-types --test tests/fixed-editor.test.ts`
- `npm test`
- `npm pack --dry-run --json`
- Fresh read-only reviewer: no issues found

Fixes #102
