### PR TITLE
fix: respect outputPad in fixed editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Fixed-editor scrolling performance** — Uses terminal row shifts, cached transcript lines, an 8 ms repaint cadence, and transient shortcut-card hiding during active wheel movement to cut scroll latency and terminal output churn.
 
 ### Fixed
+- **Fixed-editor output padding** — Applies top-level `outputPad` as the fixed-editor outer inset so fixed-editor mode matches Pi’s regular output spacing. Thanks to Gabriel Dehan for #104.
 - **Fixed-editor keyboard negotiation** — Retries extended keyboard mode setup briefly after entering the alternate screen so late Kitty/modifyOtherKeys negotiation is enabled on the active screen. Thanks to Raymond Ko for #102.
 - **Theme override path** — Loads `theme.json` from the documented agent-dir `extensions/powerline-footer` path before falling back to the loaded package directory, and clarifies setup docs for `showLastPrompt` and layout rows. Thanks to MeisterP for #117.
 - **Print-mode terminal cleanup** — Terminal reset and cursor restoration sequences run only during interactive TUI shutdowns, keeping `pi -p` output visible. Thanks to Sergey Konkin (@sergeykonkin) for #101.

--- a/fixed-editor/terminal-split.ts
+++ b/fixed-editor/terminal-split.ts
@@ -39,6 +39,7 @@ interface TerminalSplitCompositorOptions {
   /** When false, mouse release does not auto-copy; explicit copy (right-click, ctrl+c) still works. Default true. */
   autoCopyOnSelect?: boolean;
   scrollRepaintThrottleMs?: number;
+  outputPad?: number;
 }
 
 interface PatchedRenderable {
@@ -568,6 +569,7 @@ export class TerminalSplitCompositor {
   private readonly onCopySelection: ((text: string, source: "auto" | "explicit") => void) | null;
   private readonly autoCopyOnSelect: boolean;
   private readonly scrollRepaintThrottleMs: number;
+  private readonly outputPad: number;
   private extendedKeyboardMode: ExtendedKeyboardMode | null = null;
   private readonly rowsDescriptor: PropertyDescriptor | undefined;
   private readonly originalWrite: (data: string) => void;
@@ -621,6 +623,7 @@ export class TerminalSplitCompositor {
     this.onCopySelection = options.onCopySelection ?? null;
     this.autoCopyOnSelect = options.autoCopyOnSelect !== false;
     this.scrollRepaintThrottleMs = Math.max(0, options.scrollRepaintThrottleMs ?? 0);
+    this.outputPad = Number.isFinite(options.outputPad) ? Math.max(0, Math.floor(options.outputPad ?? 0)) : 0;
     this.rowsDescriptor = descriptorForRows(options.terminal);
     this.originalWrite = options.terminal.write.bind(options.terminal);
     this.originalDoRender = typeof options.tui.doRender === "function" ? options.tui.doRender.bind(options.tui) : null;
@@ -907,14 +910,41 @@ export class TerminalSplitCompositor {
     }
   }
 
+  private outerPadding(width: number): number {
+    return Math.min(this.outputPad, Math.max(0, Math.floor((width - 1) / 2)));
+  }
+
+  private innerWidth(width: number): number {
+    return Math.max(1, width - this.outerPadding(width) * 2);
+  }
+
+  private insetLine(line: string, width: number): string {
+    const padding = this.outerPadding(width);
+    if (padding === 0) return sanitizeLine(line, width);
+
+    return `${" ".repeat(padding)}${sanitizeLine(line, this.innerWidth(width))}${" ".repeat(padding)}`;
+  }
+
+  private contentCol(packet: SgrMousePacket, width: number): number | null {
+    const padding = this.outerPadding(width);
+    const col = packet.col - 1 - padding;
+    return col >= 0 && col < this.innerWidth(width) ? col : null;
+  }
+
+  private clampedContentCol(packet: SgrMousePacket, width: number): number {
+    const padding = this.outerPadding(width);
+    return Math.max(0, Math.min(packet.col - 1 - padding, this.innerWidth(width)));
+  }
+
   private refreshRootWindow(width: number): number {
     if (!this.originalRender) return this.updateVisibleRootWindow();
 
     const rawRows = this.getRawRows();
     const renderWidth = Math.max(1, Number.isFinite(width) ? width : this.terminal.columns || 80);
+    const contentWidth = this.innerWidth(renderWidth);
     const cluster = this.getCluster(renderWidth, rawRows);
     const scrollableRows = Math.max(1, rawRows - cluster.lines.length);
-    const lines = this.originalRender(renderWidth);
+    const lines = this.originalRender(contentWidth);
     this.rootLines = lines;
     if (this.scrollOffset > 0 && this.lastRootLineCount > 0 && lines.length > this.lastRootLineCount) {
       this.scrollOffset += lines.length - this.lastRootLineCount;
@@ -1051,20 +1081,21 @@ export class TerminalSplitCompositor {
 
   private renderVisibleRootLines(start: number, width: number, scrollableRows: number): string[] {
     this.visibleRootWidth = width;
+    const contentWidth = this.innerWidth(width);
     const renderedLines = this.visibleRootLines.map((line, index) => {
       return this.renderSelectionHighlight(line, start + index, "root");
     });
-    const card = this.computeScrollAwayNavigationCard(width, scrollableRows);
-    if (!card) return renderedLines;
+    const card = this.computeScrollAwayNavigationCard(contentWidth, scrollableRows);
+    if (!card) return renderedLines.map((line) => this.insetLine(line, width));
 
     const firstCardRow = scrollableRows - card.lines.length;
     for (let index = 0; index < card.lines.length; index++) {
       const row = firstCardRow + index;
       if (row < 0 || row >= renderedLines.length) continue;
-      renderedLines[row] = this.composeScrollAwayCardLine(renderedLines[row] ?? "", card.lines[index] ?? "", card.startCol, card.width, width);
+      renderedLines[row] = this.composeScrollAwayCardLine(renderedLines[row] ?? "", card.lines[index] ?? "", card.startCol, card.width, contentWidth);
     }
 
-    return renderedLines;
+    return renderedLines.map((line) => this.insetLine(line, width));
   }
 
   private composeScrollAwayCardLine(baseLine: string, overlayLine: string, startCol: number, overlayWidth: number, totalWidth: number): string {
@@ -1088,10 +1119,12 @@ export class TerminalSplitCompositor {
   }
 
   private isScrollAwayCardClick(packet: SgrMousePacket, width: number): boolean {
-    const card = this.computeScrollAwayNavigationCard(width, this.visibleScrollableRows);
+    const card = this.computeScrollAwayNavigationCard(this.innerWidth(width), this.visibleScrollableRows);
     if (!card) return false;
 
-    const col = Math.max(0, packet.col - 1);
+    const col = this.contentCol(packet, width);
+    if (col === null) return false;
+
     return card.bounds.some((bound) => {
       return packet.row === bound.row && col >= bound.startCol && col < bound.endCol;
     });
@@ -1186,7 +1219,9 @@ export class TerminalSplitCompositor {
   private selectionLocationForPacket(packet: SgrMousePacket): SelectionLocation | null {
     if (packet.row < 1) return null;
 
-    const col = Math.max(0, packet.col - 1);
+    const col = this.contentCol(packet, Math.max(1, this.terminal.columns || 80));
+    if (col === null) return null;
+
     if (packet.row <= this.visibleScrollableRows) {
       return {
         area: "root",
@@ -1220,24 +1255,25 @@ export class TerminalSplitCompositor {
     const edgeLine = delta > 0 ? start : start + Math.max(0, this.visibleScrollableRows - 1);
     this.selectionFocus = {
       line: edgeLine,
-      col: Math.max(0, packet.col - 1),
+      col: this.clampedContentCol(packet, Math.max(1, this.terminal.columns || 80)),
     };
     this.requestRender();
     return true;
   }
 
   private clampedSelectionPointForPacket(packet: SgrMousePacket, area: SelectionArea | null): SelectionPoint {
+    const col = this.clampedContentCol(packet, Math.max(1, this.terminal.columns || 80));
     if (area === "cluster") {
       return {
         line: Math.max(0, Math.min(packet.row - this.visibleScrollableRows - 1, this.visibleClusterLines.length - 1)),
-        col: Math.max(0, packet.col - 1),
+        col,
       };
     }
 
     const row = Math.max(1, Math.min(packet.row, this.visibleScrollableRows));
     return {
       line: this.visibleRootStart + row - 1,
-      col: Math.max(0, packet.col - 1),
+      col,
     };
   }
 
@@ -1432,8 +1468,9 @@ export class TerminalSplitCompositor {
     const previousScrollableRows = this.visibleScrollableRows;
     const previousRootStart = this.visibleRootStart;
     const previousVisibleRootLines = this.visibleRootLines;
+    const contentWidth = this.innerWidth(width);
     const previousCard = previousCardVisible
-      ? this.computeScrollAwayNavigationCard(width, previousScrollableRows, previousScrollOffset, true)
+      ? this.computeScrollAwayNavigationCard(contentWidth, previousScrollableRows, previousScrollOffset, true)
       : null;
     const start = this.updateVisibleRootWindow(scrollableRows);
     const visibleLines = this.renderVisibleRootLines(start, width, scrollableRows);
@@ -1454,7 +1491,7 @@ export class TerminalSplitCompositor {
           const row = bound.row - 1;
           buffer += moveCursor(bound.row, 1);
           buffer += clearLine();
-          buffer += sanitizeLine(previousVisibleRootLines[row] ?? "", width);
+          buffer += this.insetLine(previousVisibleRootLines[row] ?? "", width);
         }
       }
 
@@ -1466,10 +1503,10 @@ export class TerminalSplitCompositor {
       for (let row = firstExposedRow; row < lastExposedRow; row++) {
         buffer += moveCursor(row + 1, 1);
         buffer += clearLine();
-        buffer += sanitizeLine(this.visibleRootLines[row] ?? "", width);
+        buffer += sanitizeLine(visibleLines[row] ?? "", width);
       }
 
-      const card = this.computeScrollAwayNavigationCard(width, scrollableRows);
+      const card = this.computeScrollAwayNavigationCard(contentWidth, scrollableRows);
       if (card) {
         for (const bound of card.bounds) {
           const row = bound.row - 1;
@@ -1670,7 +1707,7 @@ export class TerminalSplitCompositor {
       return this.renderPassCluster.cluster;
     }
 
-    const cluster = this.withClusterRender(() => this.renderCluster(width, terminalRows));
+    const cluster = this.withClusterRender(() => this.renderCluster(this.innerWidth(width), terminalRows));
     this.visibleClusterLines = cluster.lines;
     if (this.renderPassActive) {
       this.renderPassCluster = { width, terminalRows, cluster };
@@ -1679,13 +1716,17 @@ export class TerminalSplitCompositor {
   }
 
   private decorateCluster(cluster: FixedEditorClusterRender, width: number): FixedEditorClusterRender {
+    const contentWidth = this.innerWidth(width);
     const lines = this.selectionArea === "cluster"
       ? cluster.lines.map((line, index) => this.renderSelectionHighlight(line, index, "cluster"))
       : cluster.lines;
+    const paddedLines = this.overlaySelectionHint(lines, contentWidth).map((line) => this.insetLine(line, width));
+    const padding = this.outerPadding(width);
 
     return {
       ...cluster,
-      lines: this.overlaySelectionHint(lines, width),
+      cursor: cluster.cursor ? { ...cluster.cursor, col: cluster.cursor.col + padding } : null,
+      lines: paddedLines,
     };
   }
 

--- a/index.ts
+++ b/index.ts
@@ -607,6 +607,10 @@ function readSettings(cwd: string = process.cwd()): Record<string, unknown> {
   return mergeSettings(readSettingsFile(getSettingsPath()), readSettingsFile(getProjectSettingsPath(cwd)));
 }
 
+function readOutputPadSetting(cwd: string = process.cwd()): number {
+  return readSettings(cwd).outputPad === 0 ? 0 : 1;
+}
+
 function writePowerlineSetting(cwd: string, update: (existingPowerlineSetting: unknown) => unknown): boolean {
   const globalSettingsPath = getSettingsPath();
   const projectSettingsPath = getProjectSettingsPath(cwd);
@@ -2449,6 +2453,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         down: resolvedShortcuts.scrollChatDown,
       },
       scrollRepaintThrottleMs: DEFAULT_SCROLL_REPAINT_THROTTLE_MS,
+      outputPad: readOutputPadSetting(ctx.cwd),
       scrollAwayNavigationCard: config.scrollAwayCard ? {
         shortcuts: [
           scrollAwayShortcutEntry("bottom", resolvedShortcuts.jumpChatBottom),

--- a/tests/fixed-editor.test.ts
+++ b/tests/fixed-editor.test.ts
@@ -197,6 +197,44 @@ test("terminal split can render a hidden status container in the fixed cluster",
   assert.deepEqual(status.render(), ["", "⠙ Shaolin Switchblade Sync..."]);
 });
 
+test("terminal split applies outputPad as an outer fixed-editor inset", () => {
+  const terminal = new FakeTerminal();
+  terminal.columns = 12;
+  const rootRenderWidths: number[] = [];
+  const clusterRenderWidths: number[] = [];
+  const tui = {
+    terminal,
+    render(width: number) {
+      rootRenderWidths.push(width);
+      return [`root:${width}`];
+    },
+  };
+
+  const compositor = new TerminalSplitCompositor({
+    tui,
+    terminal,
+    outputPad: 1,
+    getShowHardwareCursor: () => true,
+    renderCluster: (width) => {
+      clusterRenderWidths.push(width);
+      return { lines: [`cluster:${width}`], cursor: { row: 0, col: 2 } };
+    },
+  });
+
+  compositor.install();
+
+  assert.deepEqual(tui.render(12), [" root:10 ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  ", "  "]);
+  assert.deepEqual(rootRenderWidths, [10]);
+  assert.deepEqual(clusterRenderWidths.at(-1), 10);
+
+  compositor.requestRepaint();
+  const repaint = terminal.writes.at(-1) ?? "";
+  assert.ok(repaint.includes("\x1b[12;1H\x1b[2K cluster:10 "));
+  assert.ok(repaint.includes("\x1b[12;4H\x1b[?25h"));
+
+  compositor.dispose();
+});
+
 test("terminal split escape helpers generate DEC scroll region controls", () => {
   assert.equal(beginSynchronizedOutput(), "\x1b[?2026h");
   assert.equal(endSynchronizedOutput(), "\x1b[?2026l");
@@ -990,6 +1028,52 @@ test("terminal split ignores card clicks created only by a queued wheel flush", 
   compositor.dispose();
 });
 
+test("terminal split does not route outputPad gutter clicks to the scroll-away card", () => {
+  const terminal = new FakeTerminal();
+  terminal.columns = 10;
+  terminal.setRows(6);
+  let inputListener: ((data: string) => { consume?: boolean; data?: string } | undefined) | null = null;
+  let bottomClicks = 0;
+  const tui = {
+    terminal,
+    addInputListener(listener: (data: string) => { consume?: boolean; data?: string } | undefined) {
+      inputListener = listener;
+      return () => {
+        inputListener = null;
+      };
+    },
+    requestRender() {},
+    render() {
+      return Array.from({ length: 8 }, (_, index) => `line-${index}`);
+    },
+  };
+
+  const compositor = new TerminalSplitCompositor({
+    tui,
+    terminal,
+    outputPad: 1,
+    scrollAwayNavigationCard: navigationCardOptions(() => {
+      bottomClicks++;
+      return true;
+    }),
+    renderCluster: () => ({ lines: ["cluster"], cursor: null }),
+  });
+
+  compositor.install();
+  tui.render(10);
+  inputListener?.("\x1b[5~");
+  const rendered = tui.render(10);
+  const cardRow = rendered.findIndex((line) => line.includes("Bottom")) + 1;
+  assert.ok(cardRow > 0, "compact card should render");
+
+  assert.deepEqual(inputListener?.(`\x1b[<0;1;${cardRow}M`), { consume: true });
+  assert.equal(bottomClicks, 0);
+  assert.deepEqual(inputListener?.(`\x1b[<0;2;${cardRow}M`), { consume: true });
+  assert.equal(bottomClicks, 1);
+
+  compositor.dispose();
+});
+
 test("terminal split renders a scroll-away navigation card in render and repaint paths", () => {
   const terminal = new FakeTerminal();
   terminal.columns = 80;
@@ -1556,6 +1640,44 @@ test("terminal split selects visible chat text and copies it on drag release", (
   assert.deepEqual(copied, ["ravo two\ncharlie three\ndelta"]);
   assert.ok(!terminal.writes.at(-1)?.includes("\x1b[?1006l\x1b[?1002l\x1b[?1000l"));
   assert.deepEqual(renderRequests, [undefined, undefined, undefined]);
+
+  compositor.dispose();
+});
+
+test("terminal split clamps outputPad gutter selection to content edges", () => {
+  const terminal = new FakeTerminal();
+  terminal.columns = 10;
+  let inputListener: ((data: string) => { consume?: boolean; data?: string } | undefined) | null = null;
+  const copied: string[] = [];
+  const tui = {
+    terminal,
+    addInputListener(listener: (data: string) => { consume?: boolean; data?: string } | undefined) {
+      inputListener = listener;
+      return () => {
+        inputListener = null;
+      };
+    },
+    requestRender() {},
+    render() {
+      return ["abcdefgh"];
+    },
+  };
+
+  const compositor = new TerminalSplitCompositor({
+    tui,
+    terminal,
+    outputPad: 1,
+    onCopySelection: (text) => copied.push(text),
+    renderCluster: () => ({ lines: ["cluster"], cursor: null }),
+  });
+
+  compositor.install();
+  assert.equal(tui.render(10)[0], " abcdefgh ");
+
+  assert.deepEqual(inputListener?.("\x1b[<0;2;1M"), { consume: true });
+  assert.deepEqual(inputListener?.("\x1b[<0;10;1m"), { consume: true });
+
+  assert.deepEqual(copied, ["abcdefgh"]);
 
   compositor.dispose();
 });

--- a/tests/jump-shortcuts.test.ts
+++ b/tests/jump-shortcuts.test.ts
@@ -164,6 +164,11 @@ test("extension status changes invalidate powerline status rendering", () => {
   assert.match(source, /restoreFooterStatusRepaintHook\?\.\(\);\n\s+restoreFooterStatusRepaintHook = null;/);
 });
 
+test("fixed editor passes top-level outputPad to the compositor", () => {
+  assert.match(source, /function readOutputPadSetting\(cwd: string = process\.cwd\(\)\): number \{\n\s+return readSettings\(cwd\)\.outputPad === 0 \? 0 : 1;\n\}/);
+  assert.match(source, /outputPad: readOutputPadSetting\(ctx\.cwd\)/);
+});
+
 test("fixed editor captures Pi status messages with the editor cluster", () => {
   assert.match(source, /let fixedStatusContainer: any = null/);
   assert.match(source, /const statusContainerCandidate = tuiChildren\[editorContainerMatch\.index - 2\] \?\? null/);


### PR DESCRIPTION
## Summary

Fixes #104 by applying top-level `outputPad` as an outer inset around the fixed-editor viewport and fixed chrome. Root chat rendering and fixed cluster rendering now use the inset content width, then paint inside the padded outer area so fixed-editor mode matches regular Pi output spacing.

The compositor also maps mouse hit testing back into content coordinates so scroll-away cards and text selection do not treat the outer padding as clickable/selectable content.

## Validation

- `git diff --check`
- `node --experimental-strip-types --test tests/fixed-editor.test.ts tests/jump-shortcuts.test.ts`
- `npm test`
- `npm pack --dry-run --json`
- Fresh read-only review found and verified fixes for gutter hit testing; final deterministic regressions cover card clicks and right-gutter selection clamping.

Fixes #104
