### PR TITLE
feat: add session cwd command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Session directory switching** — Added `/cd <path>` to continue the current conversation from another working directory while keeping Pi tools and the footer path segment in sync. Thanks to chengxiang (@chengxiang1997) for #114.
 - **Separator override** — Added `powerline.separator` so separator style can be chosen independently of the active preset. Thanks to Andy8647 and mj-meyer for #106/#116.
 - **Git host icon** — Added opt-in `powerline.git.hostIcon` to replace the git branch icon with a detected GitHub, GitLab, Bitbucket, or generic git host icon when an origin remote is available. Thanks to Andy8647 for #113.
 - **Segment display formats** — Added opt-in `powerline.context.format` and `powerline.cache_read.format` settings for compact percentage-style context and cache-read segments. Thanks to Andy8647 for #109.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Restart pi to activate.
 
 Activates automatically. Toggle with `/powerline`, switch presets with `/powerline <name>`, fixed-editor mode with `/powerline fixed-editor on|off|toggle`, the scroll-away card with `/powerline scroll-away-card on|off|toggle`, primary-row placement with `/powerline placement above|below|toggle`, and wheel mode with `/powerline mouse-scroll on|off|toggle`.
 
+Use `/cd <path>` to continue the current conversation from another working directory. It supports relative paths, absolute paths, `~`, `~/...`, and directory completions. With no argument, `/cd` prints the current Pi session directory. The command switches into a cwd-updated session file so Pi tools and the footer path segment agree after the change.
+
 Fixed editor is on by default.
 
 - `/powerline fixed-editor off` — return to Pi’s regular scrolling layout

--- a/cd-command.ts
+++ b/cd-command.ts
@@ -1,0 +1,190 @@
+import { existsSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { SessionManager, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { AutocompleteItem } from "@earendil-works/pi-tui";
+
+function stripMatchingQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
+function unescapePathArg(value: string): string {
+  return stripMatchingQuotes(value).replace(/\\(.)/g, "$1");
+}
+
+function expandHomePath(value: string, homeDir = homedir()): string {
+  if (value === "~") return homeDir;
+  if (value.startsWith("~/")) return join(homeDir, value.slice(2));
+  return value;
+}
+
+function escapeCompletionPath(value: string): string {
+  return value.replace(/([\\\s"'`$&|;<>()[\]{}?!*])/g, "\\$1");
+}
+
+function displayPath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+export function resolveCdTarget(args: string, cwd: string, homeDir = homedir()): { path: string } | { error: string } | null {
+  const input = unescapePathArg(args);
+  if (!input) return null;
+
+  const expanded = expandHomePath(input, homeDir);
+  const target = isAbsolute(expanded) ? resolve(expanded) : resolve(cwd, expanded);
+
+  if (!existsSync(target)) {
+    return { error: `Directory does not exist: ${target}` };
+  }
+
+  try {
+    if (!statSync(target).isDirectory()) {
+      return { error: `Not a directory: ${target}` };
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { error: `Cannot access directory: ${message}` };
+  }
+
+  return { path: target };
+}
+
+function pathBase(token: string, cwd: string, homeDir: string): { dir: string; prefix: string; displayPrefix: string } {
+  const unescaped = unescapePathArg(token);
+  const expanded = expandHomePath(unescaped, homeDir);
+  const hasSlash = expanded.includes("/");
+
+  if (!hasSlash) {
+    return { dir: cwd, prefix: expanded, displayPrefix: "" };
+  }
+
+  const baseDir = expanded.endsWith("/") ? expanded.slice(0, -1) : dirname(expanded);
+  const dir = isAbsolute(baseDir) ? baseDir : resolve(cwd, baseDir);
+  const prefix = expanded.endsWith("/") ? "" : basename(expanded);
+  const displayPrefix = unescaped.endsWith("/") ? unescaped : unescaped.slice(0, Math.max(0, unescaped.length - prefix.length));
+  return { dir, prefix, displayPrefix };
+}
+
+function isDirectoryEntry(dir: string, name: string): boolean {
+  try {
+    return statSync(join(dir, name)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export function getCdArgumentCompletions(argumentPrefix: string, cwd: string, homeDir = homedir()): AutocompleteItem[] {
+  const prefix = argumentPrefix.trimStart();
+  const suggestions: AutocompleteItem[] = [];
+
+  for (const quickPick of ["../", "~/"]) {
+    if (!prefix || quickPick.startsWith(prefix)) {
+      suggestions.push({ value: quickPick, label: quickPick, description: quickPick === "../" ? "Parent directory" : "Home directory" });
+    }
+  }
+
+  const { dir, prefix: entryPrefix, displayPrefix } = pathBase(prefix, cwd, homeDir);
+
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.name.startsWith(entryPrefix) && (entry.isDirectory() || entry.isSymbolicLink() && isDirectoryEntry(dir, entry.name)))
+      .slice(0, 50)
+      .map((entry) => {
+        const path = displayPath(`${displayPrefix}${entry.name}/`);
+        return {
+          value: escapeCompletionPath(path),
+          label: path,
+        } satisfies AutocompleteItem;
+      });
+
+    suggestions.push(...entries);
+  } catch {
+    return suggestions;
+  }
+
+  const seen = new Set<string>();
+  return suggestions.filter((item) => {
+    if (seen.has(item.value)) return false;
+    seen.add(item.value);
+    return true;
+  });
+}
+
+function removeSessionFile(filePath: string | undefined): void {
+  if (!filePath) return;
+  try {
+    unlinkSync(filePath);
+  } catch {
+    // Best-effort cleanup only; the command still reports the cancellation/error.
+  }
+}
+
+export async function runCdCommand(args: string, ctx: ExtensionCommandContext): Promise<void> {
+  const resolved = resolveCdTarget(args, ctx.cwd);
+  if (resolved === null) {
+    ctx.ui.notify(ctx.cwd, "info");
+    return;
+  }
+  if ("error" in resolved) {
+    ctx.ui.notify(resolved.error, "error");
+    return;
+  }
+  if (resolved.path === ctx.cwd) {
+    ctx.ui.notify(`Already in ${ctx.cwd}`, "info");
+    return;
+  }
+
+  const sessionFile = ctx.sessionManager.getSessionFile();
+  if (!sessionFile) {
+    ctx.ui.notify("/cd requires a persisted Pi session", "error");
+    return;
+  }
+
+  await ctx.waitForIdle();
+  const nextSession = SessionManager.forkFrom(sessionFile, resolved.path);
+  const nextSessionFile = nextSession.getSessionFile();
+
+  try {
+    const result = await ctx.switchSession(nextSessionFile!, {
+      withSession: async (nextCtx) => {
+        try {
+          process.chdir(nextCtx.cwd);
+          nextCtx.ui.notify(`Changed directory to ${nextCtx.cwd}`, "info");
+          nextCtx.ui.setTitle(`pi - ${basename(nextCtx.cwd) || nextCtx.cwd}`);
+        } catch (error) {
+          console.debug("[powerline-footer] Failed to update process cwd after /cd:", error);
+        }
+      },
+    });
+    if (result.cancelled) {
+      removeSessionFile(nextSessionFile);
+      ctx.ui.notify("Directory change cancelled", "warning");
+      return;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    try {
+      ctx.ui.notify(`Failed to change directory: ${message}`, "error");
+    } catch {
+      console.debug("[powerline-footer] Failed to report /cd error:", error);
+    }
+  }
+}
+
+export function registerCdCommand(pi: ExtensionAPI, getCwd: () => string): void {
+  pi.registerCommand("cd", {
+    description: "Switch the Pi session working directory",
+    getArgumentCompletions(argumentPrefix) {
+      return getCdArgumentCompletions(argumentPrefix, getCwd());
+    },
+    handler: runCdCommand,
+  });
+}

--- a/index.ts
+++ b/index.ts
@@ -41,6 +41,7 @@ import { renderFixedEditorCluster } from "./fixed-editor/cluster.ts";
 import { DEFAULT_SCROLL_REPAINT_THROTTLE_MS, emergencyTerminalModeReset, TerminalSplitCompositor } from "./fixed-editor/terminal-split.ts";
 import { inlineEditorQuitCursorRestore } from "./terminal-cursor.ts";
 import { getDefaultColors } from "./theme.ts";
+import { registerCdCommand } from "./cd-command.ts";
 import {
   isSupportedSuperShortcut,
   matchesConfiguredShortcut,
@@ -1864,6 +1865,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
     requestStatusRender();
   });
+
+  registerCdCommand(pi, () => currentCtx?.cwd ?? process.cwd());
 
   // Command to toggle/configure
   pi.registerCommand("powerline", {

--- a/tests/cd-command.test.ts
+++ b/tests/cd-command.test.ts
@@ -1,0 +1,142 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, writeFileSync, mkdtempSync, readFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { getCdArgumentCompletions, resolveCdTarget, runCdCommand } from "../cd-command.ts";
+
+const cdCommandSource = readFileSync(new URL("../cd-command.ts", import.meta.url), "utf-8");
+const indexSource = readFileSync(new URL("../index.ts", import.meta.url), "utf-8");
+
+test("resolveCdTarget supports current, relative, home, and invalid directories", () => {
+  const root = mkdtempSync(join(tmpdir(), "powerline-cd-root-"));
+  const home = mkdtempSync(join(tmpdir(), "powerline-cd-home-"));
+  const child = join(root, "child");
+  const homeProject = join(home, "project");
+  mkdirSync(child);
+  mkdirSync(homeProject);
+  writeFileSync(join(root, "file.txt"), "not a directory");
+
+  assert.equal(resolveCdTarget("", root, home), null);
+  assert.deepEqual(resolveCdTarget("child", root, home), { path: child });
+  assert.deepEqual(resolveCdTarget("~/project", root, home), { path: homeProject });
+  assert.deepEqual(resolveCdTarget("My\\ Folder", root, home), { error: `Directory does not exist: ${join(root, "My Folder")}` });
+  assert.match(resolveCdTarget("missing", root, home)?.error ?? "", /Directory does not exist:/);
+  assert.match(resolveCdTarget("file.txt", root, home)?.error ?? "", /Not a directory:/);
+});
+
+test("cd argument completions suggest directories and quick picks", () => {
+  const root = mkdtempSync(join(tmpdir(), "powerline-cd-complete-root-"));
+  const home = mkdtempSync(join(tmpdir(), "powerline-cd-complete-home-"));
+  mkdirSync(join(root, "child"));
+  mkdirSync(join(root, "My Folder"));
+  writeFileSync(join(root, "file.txt"), "not a directory");
+  mkdirSync(join(home, "project"));
+
+  const rootCompletions = getCdArgumentCompletions("", root, home);
+  assert.ok(rootCompletions.some((item) => item.value === "../" && item.label === "../"));
+  assert.ok(rootCompletions.some((item) => item.value === "~/" && item.label === "~/"));
+  assert.ok(rootCompletions.some((item) => item.value === "child/" && item.label === "child/"));
+  assert.ok(rootCompletions.some((item) => item.value === "My\\ Folder/" && item.label === "My Folder/"));
+  assert.ok(!rootCompletions.some((item) => item.label === "file.txt"));
+
+  assert.deepEqual(
+    getCdArgumentCompletions("~/p", root, home).map((item) => item.value),
+    ["~/project/"],
+  );
+});
+
+test("cd command cleans up the forked session when switching is cancelled", async () => {
+  const originalCwd = process.cwd();
+  const root = mkdtempSync(join(tmpdir(), "powerline-cd-command-root-"));
+  const target = join(root, "target");
+  const sessionDir = join(root, "sessions");
+  mkdirSync(target);
+
+  const session = SessionManager.create(root, sessionDir);
+  session.appendMessage({ role: "user", content: "hello", timestamp: Date.now() });
+  session.appendMessage({ role: "assistant", content: "hi", timestamp: Date.now(), usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } } });
+
+  let switchedPath: string | undefined;
+  const notifications: Array<{ message: string; type?: string }> = [];
+  const ctx = {
+    cwd: root,
+    sessionManager: {
+      getSessionFile: () => session.getSessionFile(),
+    },
+    ui: {
+      notify(message: string, type?: string) {
+        notifications.push({ message, type });
+      },
+    },
+    waitForIdle: async () => {},
+    switchSession: async (path: string) => {
+      switchedPath = path;
+      return { cancelled: true };
+    },
+  } as any;
+
+  try {
+    await runCdCommand("target", ctx);
+  } finally {
+    process.chdir(originalCwd);
+  }
+
+  assert.equal(process.cwd(), originalCwd);
+  assert.ok(switchedPath, "switchSession should receive the forked session path");
+  assert.equal(existsSync(switchedPath!), false);
+  assert.deepEqual(notifications.at(-1), { message: "Directory change cancelled", type: "warning" });
+});
+
+test("cd command preserves the target session after a post-apply switch error", async () => {
+  const originalCwd = process.cwd();
+  const root = mkdtempSync(join(tmpdir(), "powerline-cd-post-apply-root-"));
+  const target = join(root, "target");
+  const sessionDir = join(root, "sessions");
+  mkdirSync(target);
+
+  const session = SessionManager.create(root, sessionDir);
+  session.appendMessage({ role: "user", content: "hello", timestamp: Date.now() });
+  session.appendMessage({ role: "assistant", content: "hi", timestamp: Date.now(), usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } } });
+
+  let switchedPath: string | undefined;
+  const ctx = {
+    cwd: root,
+    sessionManager: {
+      getSessionFile: () => session.getSessionFile(),
+    },
+    ui: {
+      notify() {},
+    },
+    waitForIdle: async () => {},
+    switchSession: async (path: string, options: { withSession?: (ctx: any) => Promise<void> }) => {
+      switchedPath = path;
+      await options.withSession?.({
+        cwd: target,
+        ui: {
+          notify() {},
+          setTitle() {},
+        },
+      });
+      throw new Error("post-apply failure");
+    },
+  } as any;
+
+  try {
+    await runCdCommand("target", ctx);
+    assert.equal(realpathSync(process.cwd()), realpathSync(target));
+    assert.ok(switchedPath, "switchSession should receive the forked session path");
+    assert.equal(existsSync(switchedPath!), true);
+  } finally {
+    process.chdir(originalCwd);
+  }
+});
+
+test("cd command uses session replacement instead of private cwd mutation", () => {
+  assert.match(indexSource, /registerCdCommand\(pi, \(\) => currentCtx\?\.cwd \?\? process\.cwd\(\)\)/);
+  assert.match(cdCommandSource, /SessionManager\.forkFrom\(sessionFile, resolved\.path\)/);
+  assert.match(cdCommandSource, /ctx\.switchSession\(nextSessionFile!/);
+  assert.match(cdCommandSource, /process\.chdir\(nextCtx\.cwd\)/);
+  assert.doesNotMatch(cdCommandSource, /ctx\.cwd\s*=/);
+});


### PR DESCRIPTION
## Summary

Fixes #114 by adding `/cd <path>` as a session-aware directory switch command.

The command resolves relative paths, absolute paths, `~`, and `~/...`, provides directory completions, and uses Pi’s supported session replacement APIs instead of mutating private cwd state. It forks the current session into a new session file with the target cwd, switches to that session, and updates `process.cwd()` from the replacement-session callback so Pi tools and the footer path segment agree.

## Validation

- `git diff --check`
- `node --experimental-strip-types --test tests/cd-command.test.ts tests/jump-shortcuts.test.ts`
- `npm test`
- `npm pack --dry-run --json`
- Fresh read-only lifecycle review found cancellation/post-apply session safety issues; both were fixed with production-handler regressions.

Fixes #114
