### PR TITLE
perf: cache history reads, bound cluster normalization, reuse token prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Interactive hot-path performance** — Shell history ghost suggestions now cache project and global history behind file-fingerprint validation instead of re-reading and re-parsing history files on every keystroke; fixed-editor cluster rendering only width-normalizes rows that can reach the terminal instead of every candidate line; and streaming token-stat updates reuse the append-only session prefix instead of rescanning the full event list. Measured on stress workloads with byte-identical output: 100k-line zsh history reads ~5,500x faster, large fixed-editor redraws ~390x faster, and 20k-event streaming token updates ~300x faster.
+
 ## [0.8.0] - 2026-07-29
 
 ### Added

--- a/bash-mode/history.ts
+++ b/bash-mode/history.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { getAgentPath, getHomeDir } from "../paths.ts";
 
@@ -7,6 +7,29 @@ interface PersistedHistoryEntry {
   cwd: string;
   timestamp: number;
 }
+
+// mode and ctimeMs are part of the fingerprint so permission/ACL transitions
+// (e.g. chmod 000) invalidate the cache even when content is unchanged.
+interface FileFingerprint {
+  ctimeMs: number;
+  mtimeMs: number;
+  mode: number;
+  size: number;
+}
+
+interface CachedHistory<T> extends FileFingerprint {
+  entries: T;
+}
+
+function matchesFingerprint(cached: FileFingerprint, stat: FileFingerprint): boolean {
+  return cached.ctimeMs === stat.ctimeMs
+    && cached.mtimeMs === stat.mtimeMs
+    && cached.mode === stat.mode
+    && cached.size === stat.size;
+}
+
+const projectHistoryCache = new Map<string, CachedHistory<PersistedHistoryEntry[]>>();
+const globalHistoryCache = new Map<string, CachedHistory<string[]>>();
 
 function getHistoryDir(): string {
   return getAgentPath("powerline-footer", "bash-history");
@@ -39,13 +62,30 @@ function normalizePersistedEntries(value: unknown): PersistedHistoryEntry[] {
 
 export function readProjectHistory(cwd: string): PersistedHistoryEntry[] {
   const filePath = projectHistoryPath(cwd);
-  if (!existsSync(filePath)) return [];
+  if (!existsSync(filePath)) {
+    projectHistoryCache.delete(filePath);
+    return [];
+  }
 
   try {
+    const stat = statSync(filePath);
+    const cached = projectHistoryCache.get(filePath);
+    if (cached && matchesFingerprint(cached, stat)) {
+      return cached.entries;
+    }
+
     const parsed = JSON.parse(readFileSync(filePath, "utf8"));
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return [];
-    return normalizePersistedEntries((parsed as { entries?: unknown }).entries)
+    const entries = normalizePersistedEntries((parsed as { entries?: unknown }).entries)
       .sort((a, b) => b.timestamp - a.timestamp);
+    projectHistoryCache.set(filePath, {
+      ctimeMs: stat.ctimeMs,
+      mtimeMs: stat.mtimeMs,
+      mode: stat.mode,
+      size: stat.size,
+      entries,
+    });
+    return entries;
   } catch (error) {
     // Project history is a best-effort cache. If it is unreadable or malformed,
     // bash mode should keep working instead of failing command entry entirely.
@@ -62,12 +102,23 @@ export function appendProjectHistory(cwd: string, command: string, entryCwd: str
   const next: PersistedHistoryEntry[] = [
     { command: normalizedCommand, cwd: entryCwd, timestamp: Date.now() },
     ...existing.filter((entry) => entry.command !== normalizedCommand),
-  ].slice(0, 500);
+  ]
+    .slice(0, 500)
+    .sort((a, b) => b.timestamp - a.timestamp);
 
   const filePath = projectHistoryPath(cwd);
+  projectHistoryCache.delete(filePath);
   try {
     mkdirSync(dirname(filePath), { recursive: true });
     writeFileSync(filePath, JSON.stringify({ version: 1, entries: next }, null, 2) + "\n");
+    const stat = statSync(filePath);
+    projectHistoryCache.set(filePath, {
+      ctimeMs: stat.ctimeMs,
+      mtimeMs: stat.mtimeMs,
+      mode: stat.mode,
+      size: stat.size,
+      entries: next,
+    });
   } catch (error) {
     // History persistence should never block a successful shell command from completing.
     console.debug(`[powerline-footer] Failed to persist bash project history to ${filePath}:`, error);
@@ -100,27 +151,37 @@ function parseFishHistory(raw: string): string[] {
 export function readGlobalShellHistory(shellPath: string): string[] {
   const shellName = shellPath.split("/").pop()?.toLowerCase() ?? "";
   const home = getHomeDir();
+  const filePath = shellName.includes("fish")
+    ? join(home, ".local", "share", "fish", "fish_history")
+    : process.env.HISTFILE || join(home, shellName.includes("zsh") ? ".zsh_history" : ".bash_history");
+  const cacheKey = `${shellName}\0${filePath}`;
+
+  if (!existsSync(filePath)) {
+    globalHistoryCache.delete(cacheKey);
+    return [];
+  }
 
   try {
-    if (shellName.includes("zsh")) {
-      const filePath = process.env.HISTFILE || join(home, ".zsh_history");
-      if (!existsSync(filePath)) return [];
-      return readFileSync(filePath, "utf8")
-        .split("\n")
-        .map(parseZshHistoryLine)
-        .filter((entry): entry is string => Boolean(entry))
-        .reverse();
+    const stat = statSync(filePath);
+    const cached = globalHistoryCache.get(cacheKey);
+    if (cached && matchesFingerprint(cached, stat)) {
+      return cached.entries;
     }
 
-    if (shellName.includes("fish")) {
-      const filePath = join(home, ".local", "share", "fish", "fish_history");
-      if (!existsSync(filePath)) return [];
-      return parseFishHistory(readFileSync(filePath, "utf8")).reverse();
-    }
-
-    const filePath = process.env.HISTFILE || join(home, ".bash_history");
-    if (!existsSync(filePath)) return [];
-    return parseBashHistory(readFileSync(filePath, "utf8").split("\n")).reverse();
+    const raw = readFileSync(filePath, "utf8");
+    const entries = shellName.includes("zsh")
+      ? raw.split("\n").map(parseZshHistoryLine).filter((entry): entry is string => Boolean(entry)).reverse()
+      : shellName.includes("fish")
+        ? parseFishHistory(raw).reverse()
+        : parseBashHistory(raw.split("\n")).reverse();
+    globalHistoryCache.set(cacheKey, {
+      ctimeMs: stat.ctimeMs,
+      mtimeMs: stat.mtimeMs,
+      mode: stat.mode,
+      size: stat.size,
+      entries,
+    });
+    return entries;
   } catch (error) {
     // Global shell history is optional recall data. If it is unavailable, shell predictions
     // should degrade to other sources instead of failing the editor.

--- a/fixed-editor/cluster.ts
+++ b/fixed-editor/cluster.ts
@@ -25,30 +25,47 @@ export interface FixedEditorClusterRender {
   cursor: FixedEditorCursor | null;
 }
 
+function normalizeLine(line: string, width: number): string {
+  return visibleWidth(line) > width ? truncateToWidth(line, width, "", true) : line;
+}
+
 function normalizeLines(lines: string[] | undefined, width: number): string[] {
   if (!lines || width <= 0) return [];
 
   return lines
     .filter((line) => line !== undefined && line !== null)
-    .map((line) => visibleWidth(line) > width ? truncateToWidth(line, width, "", true) : line);
+    .map((line) => normalizeLine(line, width));
 }
 
-function takeTail(lines: string[], count: number): string[] {
-  if (count <= 0) return [];
-  return lines.length <= count ? lines : lines.slice(lines.length - count);
+function normalizeTailLines(lines: string[] | undefined, count: number, width: number): string[] {
+  if (!lines || count <= 0 || width <= 0) return [];
+
+  const normalized: string[] = [];
+  for (let index = lines.length - 1; index >= 0 && normalized.length < count; index -= 1) {
+    const line = lines[index];
+    if (line === undefined || line === null) continue;
+    normalized.push(normalizeLine(line, width));
+  }
+  normalized.reverse();
+  return normalized;
 }
 
-function capEditorLines(lines: string[], count: number): string[] {
+function capEditorLines(lines: string[], count: number, width: number): string[] {
   if (count <= 0) return [];
   if (lines.length <= count) return lines;
 
-  const cursorRow = lines.findIndex((line) => line.includes(CURSOR_MARKER));
+  // Width-aware checks preserve pre-optimization semantics: truncation can
+  // drop a marker/arrow that sits beyond the visible width, and such rows must
+  // not win row selection. The raw includes() is a cheap short-circuit.
+  const cursorRow = lines.findIndex((line) => line.includes(CURSOR_MARKER)
+    && normalizeLine(line, width).includes(CURSOR_MARKER));
   if (cursorRow !== -1) {
     const start = Math.max(0, Math.min(cursorRow - count + 1, lines.length - count));
     return lines.slice(start, start + count);
   }
 
-  const selectedRow = lines.findIndex((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trimStart().startsWith("→ "));
+  const selectedRow = lines.findIndex((line) => line.includes("→")
+    && normalizeLine(line, width).replace(/\x1b\[[0-9;]*m/g, "").trimStart().startsWith("→ "));
   if (selectedRow === -1) {
     return lines.slice(0, count);
   }
@@ -80,29 +97,23 @@ export function renderFixedEditorCluster(input: FixedEditorClusterInput): FixedE
   const width = Math.max(1, input.width);
   const maxRows = Math.max(1, input.terminalRows - 1);
 
-  const statusLines = normalizeLines(input.statusLines, width);
-  const primaryLines = normalizeLines(input.primaryLines, width);
-  const editorSource = normalizeLines(input.editorLines, width);
-  const secondaryLines = normalizeLines(input.secondaryLines, width);
-  const transcriptLines = normalizeLines(input.transcriptLines, width);
-  const lastPromptLines = normalizeLines(input.lastPromptLines, width);
-
-  const editorLines = capEditorLines(editorSource, maxRows);
+  const editorSource = (input.editorLines ?? []).filter((line) => line !== undefined && line !== null);
+  const editorLines = normalizeLines(capEditorLines(editorSource, maxRows, width), width);
   let remaining = maxRows - editorLines.length;
 
-  const primary = takeTail(primaryLines, remaining);
+  const primary = normalizeTailLines(input.primaryLines, remaining, width);
   remaining -= primary.length;
 
-  const secondary = takeTail(secondaryLines, remaining);
+  const secondary = normalizeTailLines(input.secondaryLines, remaining, width);
   remaining -= secondary.length;
 
-  const lastPrompt = takeTail(lastPromptLines, remaining);
+  const lastPrompt = normalizeTailLines(input.lastPromptLines, remaining, width);
   remaining -= lastPrompt.length;
 
-  const status = takeTail(statusLines, remaining);
+  const status = normalizeTailLines(input.statusLines, remaining, width);
   remaining -= status.length;
 
-  const transcript = takeTail(transcriptLines, remaining);
+  const transcript = normalizeTailLines(input.transcriptLines, remaining, width);
 
   return extractCursor(input.placement === "above"
     ? [

--- a/token-stats.ts
+++ b/token-stats.ts
@@ -74,29 +74,61 @@ function eventStatsSignature(event: unknown): string {
   return `e:${typeof event.type === "string" ? event.type : "?"}`;
 }
 
+function emptySessionTokenStats(): SessionTokenStats {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    cost: 0,
+    lastAssistant: undefined,
+    thinkingLevelFromSession: null,
+  };
+}
+
+function copySessionTokenStats(stats: SessionTokenStats): SessionTokenStats {
+  return { ...stats };
+}
+
+function accumulateSessionEvent(stats: SessionTokenStats, event: unknown): void {
+  if (!isRecord(event)) return;
+
+  if (event.type === "thinking_level_change" && typeof event.thinkingLevel === "string") {
+    stats.thinkingLevelFromSession = event.thinkingLevel;
+  }
+
+  if (event.type !== "message" || !isSessionAssistantMessage(event.message)) return;
+
+  const message = event.message;
+  if (message.stopReason === "error" || message.stopReason === "aborted") return;
+
+  stats.input += message.usage.input;
+  stats.output += message.usage.output;
+  stats.cacheRead += message.usage.cacheRead;
+  stats.cacheWrite += message.usage.cacheWrite;
+  stats.cost += message.usage.cost.total;
+  if (getUsageTokenTotal(message.usage) > 0) {
+    stats.lastAssistant = message;
+  }
+}
+
 export function computeSessionTokenStats(sessionEvents: readonly unknown[]): SessionTokenStats {
   let input = 0, output = 0, cacheRead = 0, cacheWrite = 0, cost = 0;
   let lastAssistant: AssistantMessage | undefined;
   let thinkingLevelFromSession: string | null = null;
 
   for (const e of sessionEvents) {
-    if (!isRecord(e)) {
-      continue;
-    }
+    if (!isRecord(e)) continue;
 
-    // Check for thinking level change entries
     if (e.type === "thinking_level_change" && typeof e.thinkingLevel === "string") {
       thinkingLevelFromSession = e.thinkingLevel;
     }
 
-    if (e.type !== "message" || !isSessionAssistantMessage(e.message)) {
-      continue;
-    }
+    if (e.type !== "message" || !isSessionAssistantMessage(e.message)) continue;
 
     const m = e.message;
-    if (m.stopReason === "error" || m.stopReason === "aborted") {
-      continue;
-    }
+    if (m.stopReason === "error" || m.stopReason === "aborted") continue;
+
     input += m.usage.input;
     output += m.usage.output;
     cacheRead += m.usage.cacheRead;
@@ -112,38 +144,68 @@ export function computeSessionTokenStats(sessionEvents: readonly unknown[]): Ses
 
 /**
  * Cache for token counting: avoid re-scanning the full session event list on
- * every render (250ms-1s cadence while streaming). Reuses the aggregated
- * totals while the session hasn't changed.
- *
- * An event-count-only check would go stale when streaming updates the last
- * event in place, so validity requires all of:
- *   1. same event count,
- *   2. same last-event reference,
- *   3. same last-event stats signature (usage/stopReason/thinking level).
+ * every render (250ms-1s cadence while streaming). Historical session entries
+ * are append-only, so appended entries are accumulated and an in-place update
+ * to the trailing streaming entry only recomputes that entry.
  */
 export class SessionTokenStatsCache {
   private eventCount = -1;
   private lastEvent: unknown;
   private lastSignature = "";
+  private prefixStats: SessionTokenStats | null = null;
   private stats: SessionTokenStats | null = null;
 
   get(sessionEvents: readonly unknown[]): SessionTokenStats {
     const eventCount = sessionEvents.length;
     const lastEvent = eventCount > 0 ? sessionEvents[eventCount - 1] : undefined;
+    const lastSignature = eventStatsSignature(lastEvent);
 
     if (
       this.stats !== null
       && this.eventCount === eventCount
       && this.lastEvent === lastEvent
-      && this.lastSignature === eventStatsSignature(lastEvent)
+      && this.lastSignature === lastSignature
     ) {
       return this.stats;
     }
 
-    const stats = computeSessionTokenStats(sessionEvents);
+    // getBranch() walks unique parent links, so an identical trailing event at
+    // the previous count proves the whole previous array is an unchanged prefix.
+    const previousStats = this.stats;
+    const canExtendPreviousStats = previousStats !== null
+      && eventCount > this.eventCount
+      && (this.eventCount === 0 || (
+        sessionEvents[this.eventCount - 1] === this.lastEvent
+        && eventStatsSignature(sessionEvents[this.eventCount - 1]) === this.lastSignature
+      ));
+
+    let prefixStats: SessionTokenStats;
+    if (canExtendPreviousStats && previousStats !== null) {
+      prefixStats = copySessionTokenStats(previousStats);
+      for (let index = this.eventCount; index < eventCount - 1; index += 1) {
+        accumulateSessionEvent(prefixStats, sessionEvents[index]);
+      }
+    } else if (
+      this.prefixStats !== null
+      && this.eventCount === eventCount
+      && this.lastEvent === lastEvent
+    ) {
+      // Same array with an in-place tail mutation: reuse the cached prefix.
+      prefixStats = this.prefixStats;
+    } else {
+      prefixStats = emptySessionTokenStats();
+      for (let index = 0; index < eventCount - 1; index += 1) {
+        accumulateSessionEvent(prefixStats, sessionEvents[index]);
+      }
+    }
+
+    const stats = copySessionTokenStats(prefixStats);
+    if (eventCount > 0) accumulateSessionEvent(stats, lastEvent);
+
     this.eventCount = eventCount;
     this.lastEvent = lastEvent;
-    this.lastSignature = eventStatsSignature(lastEvent);
+    this.lastSignature = lastSignature;
+    this.prefixStats = prefixStats;
     this.stats = stats;
     return stats;
   }
@@ -152,6 +214,7 @@ export class SessionTokenStatsCache {
     this.eventCount = -1;
     this.lastEvent = undefined;
     this.lastSignature = "";
+    this.prefixStats = null;
     this.stats = null;
   }
 }


### PR DESCRIPTION
Three interactive hot paths were doing work proportional to total data size instead of visible/changed size. This keeps output byte-identical (verified with a randomized differential harness) while cutting the cost dramatically.

**What changed**

- `bash-mode/history.ts` — project and global shell history reads back ghost suggestions on every keystroke and previously re-read and re-parsed the whole history file each time. Both readers now cache behind a file fingerprint (ctime/mtime/mode/size), so external edits, deletions, and permission transitions invalidate immediately, and `appendProjectHistory` re-primes the cache with the sorted entries it just wrote.
- `fixed-editor/cluster.ts` — cluster rendering normalized (ANSI width scan + truncation) every candidate line before row priority discarded most of them. It now selects rows first and normalizes only what can reach the terminal. Cursor/selected-row detection stays width-aware so truncation-hidden markers behave exactly as before.
- `token-stats.ts` — streaming token updates rescanned the entire session branch on every tail change. Since `getBranch()` walks unique parent links, an identical trailing event proves the prefix is unchanged, so the cache now accumulates appended events and recomputes only the mutable tail.

**Measured (same stress workloads, identical output checksums)**

| Path | Before | After |
|---|---|---|
| 100k-line zsh history read | 16.45 ms | 0.003 ms (~5,500x) |
| Fixed-editor redraw, 29k off-screen lines | 249.0 ms | ~0.6 ms (~390x) |
| Streaming token update, 20k events | 0.116 ms | 0.0004 ms (~300x) |
| Project history read, 500 entries | 0.122 ms | 0.005 ms (~24x) |

**Validation**

- Full suite: 227/227
- Differential harness: 10,000 randomized cluster layouts and 1,000 token-update sequences byte-identical to the previous implementation; history invalidation on external writes and unreadable/readable permission transitions verified
- Two independent fresh-context reviews (one adversarial, Opus xhigh); all findings applied — permission-transition cache invalidation, exact selected-row parity, sorted append cache
- `npm pack --dry-run` and `git diff --check` pass