### PR TITLE
Include subagent cost in the cost segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Subagent cost in footer** — The `cost` segment now includes the cumulative cost of subagent child runs (`/parallel`, `/worker`, etc.) launched from the session, instead of only the interactive parent session's cost.
+
 ## [0.8.1] - 2026-07-30
 
 ### Changed

--- a/index.ts
+++ b/index.ts
@@ -2202,7 +2202,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     // event's stats-relevant fields change, e.g. in-place streaming updates)
     const sessionEvents = ctx.sessionManager?.getBranch?.() ?? [];
     const tokenStats = tokenStatsCache.get(sessionEvents);
-    const { input, output, cacheRead, cacheWrite, cost } = tokenStats;
+    const { input, output, cacheRead, cacheWrite, cost, subagentCost } = tokenStats;
     const lastAssistant = tokenStats.lastAssistant;
     const thinkingLevelFromSession = tokenStats.thinkingLevelFromSession;
 
@@ -2234,7 +2234,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       thinkingLevel,
       sessionId: ctx.sessionManager?.getSessionId?.(),
       cwd: ctx.cwd,
-      usageStats: { input, output, cacheRead, cacheWrite, cost },
+      usageStats: { input, output, cacheRead, cacheWrite, cost, subagentCost },
       contextTokens,
       contextPercent,
       contextWindow,

--- a/segments.ts
+++ b/segments.ts
@@ -284,7 +284,7 @@ const tokenTotalSegment: StatusLineSegment = {
 const costSegment: StatusLineSegment = {
   id: "cost",
   render(ctx) {
-    const { cost } = ctx.usageStats;
+    const cost = ctx.usageStats.cost + ctx.usageStats.subagentCost;
     const usingSubscription = ctx.usingSubscription;
 
     if (!cost && !usingSubscription) {

--- a/tests/token-stats.test.ts
+++ b/tests/token-stats.test.ts
@@ -32,6 +32,25 @@ function userEvent() {
   };
 }
 
+function subagentToolResultEvent(costs: number[]) {
+  return {
+    type: "message",
+    message: {
+      role: "toolResult",
+      toolName: "subagent",
+      details: { results: costs.map((cost) => ({ usage: { cost } })) },
+    },
+  };
+}
+
+function subagentSlashResultEvent(costs: number[]) {
+  return {
+    type: "custom_message",
+    customType: "subagent-slash-result",
+    details: { result: { details: { results: costs.map((cost) => ({ usage: { cost } })) } } },
+  };
+}
+
 test("computeSessionTokenStats aggregates usage and tracks thinking level", () => {
   const events = [
     userEvent(),
@@ -51,6 +70,18 @@ test("computeSessionTokenStats aggregates usage and tracks thinking level", () =
   assert.ok(Math.abs(stats.cost - 0.074) < 1e-12);
   assert.equal(stats.lastAssistant, (events[5] as any).message);
   assert.equal(stats.thinkingLevelFromSession, "high");
+});
+
+test("computeSessionTokenStats sums subagent child run cost from tool results and slash results", () => {
+  const events = [
+    userEvent(),
+    assistantEvent(makeUsage(10, 5)),
+    subagentToolResultEvent([0.12, 0.34]),
+    subagentSlashResultEvent([0.5]),
+  ];
+
+  const stats = computeSessionTokenStats(events);
+  assert.ok(Math.abs(stats.subagentCost - 0.96) < 1e-12);
 });
 
 test("computeSessionTokenStats ignores assistant messages without tokens for lastAssistant", () => {

--- a/token-stats.ts
+++ b/token-stats.ts
@@ -8,6 +8,7 @@ export interface SessionTokenStats {
   cacheRead: number;
   cacheWrite: number;
   cost: number;
+  subagentCost: number;
   lastAssistant: AssistantMessage | undefined;
   thinkingLevelFromSession: string | null;
 }
@@ -43,6 +44,40 @@ function isSessionAssistantMessage(value: unknown): value is AssistantMessage {
 function getUsageTokenTotal(usage: SessionAssistantUsage): number {
   const totalTokens = "totalTokens" in usage && typeof usage.totalTokens === "number" ? usage.totalTokens : 0;
   return totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+}
+
+// Matches pi-subagents' internal SLASH_RESULT_TYPE custom_message marker.
+const SUBAGENT_SLASH_RESULT_TYPE = "subagent-slash-result";
+
+function subagentDetailsFromSessionEntry(e: Record<string, unknown>): { results: unknown[] } | undefined {
+  if (e.type === "custom_message" && e.customType === SUBAGENT_SLASH_RESULT_TYPE) {
+    const details = isRecord(e.details) ? e.details : undefined;
+    const result = isRecord(details?.result) ? details.result : undefined;
+    const inner = isRecord(result?.details) ? result.details : undefined;
+    return Array.isArray(inner?.results) ? { results: inner.results } : undefined;
+  }
+  if (e.type === "message" && isRecord(e.message)) {
+    const message = e.message as { role?: unknown; toolName?: unknown; details?: unknown };
+    if (message.role === "toolResult" && message.toolName === "subagent" && isRecord(message.details) && Array.isArray(message.details.results)) {
+      return { results: message.details.results };
+    }
+  }
+  return undefined;
+}
+
+// Sums subagent child usage cost recorded on a single session entry (parallel/chain/single runs
+// launched via the subagent tool or /parallel, /worker etc. slash commands), so the footer can
+// show total spend rather than only the interactive parent session's cost.
+function extractSubagentResultCost(e: Record<string, unknown>): number {
+  const details = subagentDetailsFromSessionEntry(e);
+  if (!details) return 0;
+  let total = 0;
+  for (const result of details.results) {
+    if (!isRecord(result)) continue;
+    const usage = isRecord(result.usage) ? result.usage : undefined;
+    if (typeof usage?.cost === "number") total += usage.cost;
+  }
+  return total;
 }
 
 /**
@@ -81,6 +116,7 @@ function emptySessionTokenStats(): SessionTokenStats {
     cacheRead: 0,
     cacheWrite: 0,
     cost: 0,
+    subagentCost: 0,
     lastAssistant: undefined,
     thinkingLevelFromSession: null,
   };
@@ -96,6 +132,8 @@ function accumulateSessionEvent(stats: SessionTokenStats, event: unknown): void 
   if (event.type === "thinking_level_change" && typeof event.thinkingLevel === "string") {
     stats.thinkingLevelFromSession = event.thinkingLevel;
   }
+
+  stats.subagentCost += extractSubagentResultCost(event);
 
   if (event.type !== "message" || !isSessionAssistantMessage(event.message)) return;
 
@@ -113,7 +151,7 @@ function accumulateSessionEvent(stats: SessionTokenStats, event: unknown): void 
 }
 
 export function computeSessionTokenStats(sessionEvents: readonly unknown[]): SessionTokenStats {
-  let input = 0, output = 0, cacheRead = 0, cacheWrite = 0, cost = 0;
+  let input = 0, output = 0, cacheRead = 0, cacheWrite = 0, cost = 0, subagentCost = 0;
   let lastAssistant: AssistantMessage | undefined;
   let thinkingLevelFromSession: string | null = null;
 
@@ -123,6 +161,8 @@ export function computeSessionTokenStats(sessionEvents: readonly unknown[]): Ses
     if (e.type === "thinking_level_change" && typeof e.thinkingLevel === "string") {
       thinkingLevelFromSession = e.thinkingLevel;
     }
+
+    subagentCost += extractSubagentResultCost(e);
 
     if (e.type !== "message" || !isSessionAssistantMessage(e.message)) continue;
 
@@ -139,7 +179,7 @@ export function computeSessionTokenStats(sessionEvents: readonly unknown[]): Ses
     }
   }
 
-  return { input, output, cacheRead, cacheWrite, cost, lastAssistant, thinkingLevelFromSession };
+  return { input, output, cacheRead, cacheWrite, cost, subagentCost, lastAssistant, thinkingLevelFromSession };
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -157,6 +157,8 @@ export interface UsageStats {
   cacheRead: number;
   cacheWrite: number;
   cost: number;
+  // Cumulative cost of subagent child runs (e.g. /parallel, /worker) launched from this session.
+  subagentCost: number;
 }
 
 // Context passed to segment render functions


### PR DESCRIPTION
I run a lot of work through subagents (parallel/worker runs), and the cost segment only ever showed the parent session's own spend, so the footer was way under-reporting what a session actually cost. This adds up the cost of subagent child runs (from the subagent tool results and the /parallel, /worker etc. slash command results) and folds it into the existing cost segment total.

Kept it inside the new token-stats cache module so it still benefits from the incremental recompute, no full rescans added. Added a test for both result shapes (tool result and slash result) and a changelog entry.