### PR TITLE
Fix multi-word vibe generation themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed `/vibe generate` so multi-word theme names parse correctly when an optional count is provided. Thanks to Hacxy (@hacxy) for #127.
 - Removed the extension-owned fixed editor and chat scrolling; Pi now owns native input and feed scrolling.
 
 ## [0.8.1] - 2026-07-30

--- a/index.ts
+++ b/index.ts
@@ -61,6 +61,7 @@ import {
   hasVibeFile,
   getVibeFileCount,
   generateVibesBatch,
+  parseVibeGenerateArgs,
 } from "./working-vibes.ts";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1936,17 +1937,13 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
       // /vibe generate <theme> [count] - generate vibes and save to file
       if (subcommand === "generate") {
-        const theme = parts[1];
-        const parsedCount = Number.parseInt(parts[2] ?? "", 10);
-        const count = Number.isFinite(parsedCount)
-          ? Math.min(Math.max(Math.floor(parsedCount), 1), 500)
-          : 100;
-
-        if (!theme) {
+        const parsed = parseVibeGenerateArgs(parts.slice(1));
+        if (!parsed) {
           ctx.ui.notify("Usage: /vibe generate <theme> [count]", "error");
           return;
         }
 
+        const { theme, count } = parsed;
         ctx.ui.notify(`Generating ${count} vibes for "${theme}"...`, "info");
 
         const result = await generateVibesBatch(theme, count);

--- a/tests/working-vibes.test.ts
+++ b/tests/working-vibes.test.ts
@@ -4,6 +4,8 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync }
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { parseVibeGenerateArgs } from "../working-vibes.ts";
+
 const FAUX_PROVIDER_PATH = new URL("../node_modules/@earendil-works/pi-ai/dist/providers/faux.js", import.meta.url).href;
 
 async function importFauxProviderTools() {
@@ -50,6 +52,15 @@ function ensurePiModuleLinks(): { cleanup: () => void } {
     },
   };
 }
+
+test("parseVibeGenerateArgs supports multi-word themes", () => {
+  assert.deepEqual(parseVibeGenerateArgs(["pirate", "200"]), { theme: "pirate", count: 200 });
+  assert.deepEqual(parseVibeGenerateArgs(["star", "trek", "200"]), { theme: "star trek", count: 200 });
+  assert.deepEqual(parseVibeGenerateArgs(["star", "trek"]), { theme: "star trek", count: 100 });
+  assert.deepEqual(parseVibeGenerateArgs(["star", "trek", "abc"]), { theme: "star trek abc", count: 100 });
+  assert.deepEqual(parseVibeGenerateArgs(["lord", "of", "rings", "999"]), { theme: "lord of rings", count: 500 });
+  assert.equal(parseVibeGenerateArgs([]), null);
+});
 
 test("generateVibesBatch includes a system prompt so faux providers can return text", async () => {
   const links = ensurePiModuleLinks();

--- a/working-vibes.ts
+++ b/working-vibes.ts
@@ -625,6 +625,21 @@ export type GenerateVibesResult =
   | { success: true; count: number; filePath: string }
   | { success: false; count: 0; filePath: string; error: string };
 
+export function parseVibeGenerateArgs(args: readonly string[]): { theme: string; count: number } | null {
+  if (args.length === 0) return null;
+
+  const last = args.at(-1);
+  const parsedCount = last && /^\d+$/.test(last) ? Number.parseInt(last, 10) : Number.NaN;
+  const hasCount = Number.isFinite(parsedCount) && args.length > 1;
+  const theme = hasCount ? args.slice(0, -1).join(" ") : args.join(" ");
+  if (!theme) return null;
+
+  return {
+    theme,
+    count: hasCount ? Math.min(Math.max(Math.floor(parsedCount), 1), 500) : 100,
+  };
+}
+
 export async function generateVibesBatch(
   theme: string,
   count: number = 100,


### PR DESCRIPTION
## Summary

Fixes /vibe generate so multi-word theme names parse correctly when the optional count is provided.

This is a clean maintainer replacement for #127. Thanks to Hacxy (@hacxy) for the report and original implementation.

## Validation

- node --experimental-strip-types --test tests/working-vibes.test.ts
- npm test
- git diff --check
