### PR TITLE
Include subagent cost in footer total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added subagent child-run cost to the `cost` segment total so parallel/worker runs are reflected in session spend. Thanks to Ričardas Čubukinas (@xadips) for #128.
 - Fixed `/vibe generate` so multi-word theme names parse correctly when an optional count is provided. Thanks to Hacxy (@hacxy) for #127.
 - Removed the extension-owned fixed editor and chat scrolling; Pi now owns native input and feed scrolling.
 

--- a/index.ts
+++ b/index.ts
@@ -1991,7 +1991,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     // event's stats-relevant fields change, e.g. in-place streaming updates)
     const sessionEvents = ctx.sessionManager?.getBranch?.() ?? [];
     const tokenStats = tokenStatsCache.get(sessionEvents);
-    const { input, output, cacheRead, cacheWrite, cost } = tokenStats;
+    const { input, output, cacheRead, cacheWrite, cost, subagentCost } = tokenStats;
     const lastAssistant = tokenStats.lastAssistant;
     const thinkingLevelFromSession = tokenStats.thinkingLevelFromSession;
 
@@ -2023,7 +2023,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       thinkingLevel,
       sessionId: ctx.sessionManager?.getSessionId?.(),
       cwd: ctx.cwd,
-      usageStats: { input, output, cacheRead, cacheWrite, cost },
+      usageStats: { input, output, cacheRead, cacheWrite, cost, subagentCost },
       contextTokens,
       contextPercent,
       contextWindow,

--- a/segments.ts
+++ b/segments.ts
@@ -284,7 +284,7 @@ const tokenTotalSegment: StatusLineSegment = {
 const costSegment: StatusLineSegment = {
   id: "cost",
   render(ctx) {
-    const { cost } = ctx.usageStats;
+    const cost = ctx.usageStats.cost + (ctx.usageStats.subagentCost ?? 0);
     const usingSubscription = ctx.usingSubscription;
 
     if (!cost && !usingSubscription) {

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -32,7 +32,7 @@ function createSegmentContext(overrides: Partial<SegmentContext> = {}): SegmentC
     thinkingLevel: "off",
     sessionId: undefined,
     cwd: "/tmp/project",
-    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, subagentCost: 0 },
     contextTokens: 0,
     contextPercent: 0,
     contextWindow: 0,
@@ -74,16 +74,16 @@ test("model segment can show provider-qualified ids", () => {
 test("cost segment supports subscription display modes", () => {
   const subscription = renderSegment("cost", createSegmentContext({
     usingSubscription: true,
-    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.42 },
+    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.42, subagentCost: 0 },
   }));
   const reportedCost = renderSegment("cost", createSegmentContext({
     usingSubscription: true,
-    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.42 },
+    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.42, subagentCost: 0 },
     options: { cost: { subscriptionDisplay: "reported-cost" } },
   }));
   const both = renderSegment("cost", createSegmentContext({
     usingSubscription: true,
-    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.42 },
+    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.42, subagentCost: 0 },
     options: { cost: { subscriptionDisplay: "both" } },
   }));
   const zeroReported = renderSegment("cost", createSegmentContext({
@@ -94,12 +94,16 @@ test("cost segment supports subscription display modes", () => {
     usingSubscription: true,
     options: { cost: { subscriptionDisplay: "both" } },
   }));
+  const withSubagentCost = renderSegment("cost", createSegmentContext({
+    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.42, subagentCost: 0.58 },
+  }));
 
   assert.deepEqual(subscription, { content: "(sub)", visible: true });
   assert.deepEqual(reportedCost, { content: "$0.42", visible: true });
   assert.deepEqual(both, { content: "$0.42 (sub)", visible: true });
   assert.deepEqual(zeroReported, { content: "(sub)", visible: true });
   assert.deepEqual(zeroBoth, { content: "(sub)", visible: true });
+  assert.deepEqual(withSubagentCost, { content: "$1.00", visible: true });
 });
 
 test("context segment shows used tokens, maximum, and percentage", () => {

--- a/tests/thinking-segment.test.ts
+++ b/tests/thinking-segment.test.ts
@@ -17,7 +17,7 @@ function createSegmentContext(thinkingLevel: string, colors: ColorScheme): Segme
     model: undefined,
     thinkingLevel,
     sessionId: undefined,
-    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, subagentCost: 0 },
     contextTokens: 0,
     contextPercent: 0,
     contextWindow: 0,

--- a/tests/token-stats.test.ts
+++ b/tests/token-stats.test.ts
@@ -32,6 +32,25 @@ function userEvent() {
   };
 }
 
+function subagentToolResultEvent(costs: number[]) {
+  return {
+    type: "message",
+    message: {
+      role: "toolResult",
+      toolName: "subagent",
+      details: { results: costs.map((cost) => ({ usage: { cost } })) },
+    },
+  };
+}
+
+function subagentSlashResultEvent(costs: number[]) {
+  return {
+    type: "custom_message",
+    customType: "subagent-slash-result",
+    details: { result: { details: { results: costs.map((cost) => ({ usage: { cost } })) } } },
+  };
+}
+
 test("computeSessionTokenStats aggregates usage and tracks thinking level", () => {
   const events = [
     userEvent(),
@@ -51,6 +70,18 @@ test("computeSessionTokenStats aggregates usage and tracks thinking level", () =
   assert.ok(Math.abs(stats.cost - 0.074) < 1e-12);
   assert.equal(stats.lastAssistant, (events[5] as any).message);
   assert.equal(stats.thinkingLevelFromSession, "high");
+});
+
+test("computeSessionTokenStats sums subagent child run cost from tool results and slash results", () => {
+  const events = [
+    userEvent(),
+    assistantEvent(makeUsage(10, 5)),
+    subagentToolResultEvent([0.12, 0.34]),
+    subagentSlashResultEvent([0.5]),
+  ];
+
+  const stats = computeSessionTokenStats(events);
+  assert.ok(Math.abs(stats.subagentCost - 0.96) < 1e-12);
 });
 
 test("computeSessionTokenStats ignores assistant messages without tokens for lastAssistant", () => {
@@ -103,6 +134,21 @@ test("cache recomputes when the last event is updated in place (streaming)", () 
   assert.notEqual(second, first);
   assert.equal(second.output, 42);
   assert.equal(second.lastAssistant, tail.message);
+});
+
+test("cache recomputes when the last subagent result cost is updated in place", () => {
+  const cache = new SessionTokenStatsCache();
+  const tail = subagentToolResultEvent([0.1]);
+  const events = [assistantEvent(makeUsage(10, 5)), tail];
+
+  const first = cache.get(events);
+  assert.equal(first.subagentCost, 0.1);
+
+  tail.message.details.results = [{ usage: { cost: 0.3 } }];
+
+  const second = cache.get(events);
+  assert.notEqual(second, first);
+  assert.equal(second.subagentCost, 0.3);
 });
 
 test("cache recomputes when the last event turns into an error in place", () => {

--- a/tests/usage-display.test.ts
+++ b/tests/usage-display.test.ts
@@ -34,7 +34,7 @@ function createSegmentContext(options: StatusLineSegmentOptions = {}, overrides:
     model: undefined,
     thinkingLevel: "off",
     sessionId: undefined,
-    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, subagentCost: 0 },
     contextTokens: 0,
     contextPercent: 0,
     contextWindow: 0,
@@ -99,7 +99,7 @@ test("context_pct percent format keeps threshold colors and drops icons", () => 
 
 test("cache_read defaults to raw token count", () => {
   const ctx = createSegmentContext({}, {
-    usageStats: { input: 1000, output: 0, cacheRead: 12300, cacheWrite: 0, cost: 0 },
+    usageStats: { input: 1000, output: 0, cacheRead: 12300, cacheWrite: 0, cost: 0, subagentCost: 0 },
   });
 
   const rendered = renderSegment("cache_read", ctx);
@@ -108,7 +108,7 @@ test("cache_read defaults to raw token count", () => {
 
 test("cache_read percent format renders the cache hit rate", () => {
   const ctx = createSegmentContext({ cache_read: { format: "percent" } }, {
-    usageStats: { input: 2000, output: 0, cacheRead: 8000, cacheWrite: 0, cost: 0 },
+    usageStats: { input: 2000, output: 0, cacheRead: 8000, cacheWrite: 0, cost: 0, subagentCost: 0 },
   });
 
   const rendered = renderSegment("cache_read", ctx);
@@ -117,7 +117,7 @@ test("cache_read percent format renders the cache hit rate", () => {
 
 test("cache_read percent format handles zero total without NaN", () => {
   const ctx = createSegmentContext({ cache_read: { format: "percent" } }, {
-    usageStats: { input: 0, output: 0, cacheRead: 5, cacheWrite: 0, cost: 0 },
+    usageStats: { input: 0, output: 0, cacheRead: 5, cacheWrite: 0, cost: 0, subagentCost: 0 },
   });
   assert.equal(stripAnsi(renderSegment("cache_read", ctx).content), "cache 100%");
 

--- a/token-stats.ts
+++ b/token-stats.ts
@@ -8,6 +8,7 @@ export interface SessionTokenStats {
   cacheRead: number;
   cacheWrite: number;
   cost: number;
+  subagentCost: number;
   lastAssistant: AssistantMessage | undefined;
   thinkingLevelFromSession: string | null;
 }
@@ -45,6 +46,40 @@ function getUsageTokenTotal(usage: SessionAssistantUsage): number {
   return totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
 }
 
+// Matches pi-subagents' internal SLASH_RESULT_TYPE custom_message marker.
+const SUBAGENT_SLASH_RESULT_TYPE = "subagent-slash-result";
+
+function subagentDetailsFromSessionEntry(e: Record<string, unknown>): { results: unknown[] } | undefined {
+  if (e.type === "custom_message" && e.customType === SUBAGENT_SLASH_RESULT_TYPE) {
+    const details = isRecord(e.details) ? e.details : undefined;
+    const result = isRecord(details?.result) ? details.result : undefined;
+    const inner = isRecord(result?.details) ? result.details : undefined;
+    return Array.isArray(inner?.results) ? { results: inner.results } : undefined;
+  }
+  if (e.type === "message" && isRecord(e.message)) {
+    const message = e.message as { role?: unknown; toolName?: unknown; details?: unknown };
+    if (message.role === "toolResult" && message.toolName === "subagent" && isRecord(message.details) && Array.isArray(message.details.results)) {
+      return { results: message.details.results };
+    }
+  }
+  return undefined;
+}
+
+// Sums subagent child usage cost recorded on a single session entry (parallel/chain/single runs
+// launched via the subagent tool or /parallel, /worker etc. slash commands), so the footer can
+// show total spend rather than only the interactive parent session's cost.
+function extractSubagentResultCost(e: Record<string, unknown>): number {
+  const details = subagentDetailsFromSessionEntry(e);
+  if (!details) return 0;
+  let total = 0;
+  for (const result of details.results) {
+    if (!isRecord(result)) continue;
+    const usage = isRecord(result.usage) ? result.usage : undefined;
+    if (typeof usage?.cost === "number") total += usage.cost;
+  }
+  return total;
+}
+
 /**
  * Fingerprint of the fields on a session event that influence the aggregated
  * stats. Comparing only the event count is not enough: while streaming, pi
@@ -58,6 +93,11 @@ function eventStatsSignature(event: unknown): string {
 
   if (event.type === "thinking_level_change") {
     return `t:${typeof event.thinkingLevel === "string" ? event.thinkingLevel : ""}`;
+  }
+
+  const subagentDetails = subagentDetailsFromSessionEntry(event);
+  if (subagentDetails) {
+    return `s:${subagentDetails.results.length}:${extractSubagentResultCost(event)}`;
   }
 
   if (event.type === "message" && isRecord(event.message)) {
@@ -81,6 +121,7 @@ function emptySessionTokenStats(): SessionTokenStats {
     cacheRead: 0,
     cacheWrite: 0,
     cost: 0,
+    subagentCost: 0,
     lastAssistant: undefined,
     thinkingLevelFromSession: null,
   };
@@ -96,6 +137,8 @@ function accumulateSessionEvent(stats: SessionTokenStats, event: unknown): void 
   if (event.type === "thinking_level_change" && typeof event.thinkingLevel === "string") {
     stats.thinkingLevelFromSession = event.thinkingLevel;
   }
+
+  stats.subagentCost += extractSubagentResultCost(event);
 
   if (event.type !== "message" || !isSessionAssistantMessage(event.message)) return;
 
@@ -113,7 +156,7 @@ function accumulateSessionEvent(stats: SessionTokenStats, event: unknown): void 
 }
 
 export function computeSessionTokenStats(sessionEvents: readonly unknown[]): SessionTokenStats {
-  let input = 0, output = 0, cacheRead = 0, cacheWrite = 0, cost = 0;
+  let input = 0, output = 0, cacheRead = 0, cacheWrite = 0, cost = 0, subagentCost = 0;
   let lastAssistant: AssistantMessage | undefined;
   let thinkingLevelFromSession: string | null = null;
 
@@ -123,6 +166,8 @@ export function computeSessionTokenStats(sessionEvents: readonly unknown[]): Ses
     if (e.type === "thinking_level_change" && typeof e.thinkingLevel === "string") {
       thinkingLevelFromSession = e.thinkingLevel;
     }
+
+    subagentCost += extractSubagentResultCost(e);
 
     if (e.type !== "message" || !isSessionAssistantMessage(e.message)) continue;
 
@@ -139,7 +184,7 @@ export function computeSessionTokenStats(sessionEvents: readonly unknown[]): Ses
     }
   }
 
-  return { input, output, cacheRead, cacheWrite, cost, lastAssistant, thinkingLevelFromSession };
+  return { input, output, cacheRead, cacheWrite, cost, subagentCost, lastAssistant, thinkingLevelFromSession };
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -157,6 +157,8 @@ export interface UsageStats {
   cacheRead: number;
   cacheWrite: number;
   cost: number;
+  // Cumulative cost of subagent child runs (e.g. /parallel, /worker) launched from this session.
+  subagentCost: number;
 }
 
 // Context passed to segment render functions


### PR DESCRIPTION
## Summary

Includes subagent child-run cost in the existing cost segment total so parallel/worker runs are reflected in session spend.

This is a clean maintainer replacement for #128. Thanks to Ričardas Čubukinas (@xadips) for the original implementation and report.

## Validation

- node --experimental-strip-types --test tests/token-stats.test.ts tests/remaining-regressions.test.ts tests/usage-display.test.ts tests/thinking-segment.test.ts
- npm test
- git diff --check
- fresh read-only reviewer: no issues found
