### PR TITLE
Add cost currency display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added optional non-USD display for the `cost` segment via `powerline.cost.currency`, with background FX-rate caching. Thanks to @tanuki-cat for #130.
 - Added subagent child-run cost to the `cost` segment total so parallel/worker runs are reflected in session spend. Thanks to Ričardas Čubukinas (@xadips) for #128.
 - Fixed `/vibe generate` so multi-word theme names parse correctly when an optional count is provided. Thanks to Hacxy (@hacxy) for #127.
 - Removed the extension-owned fixed editor and chat scrolling; Pi now owns native input and feed scrolling.

--- a/README.md
+++ b/README.md
@@ -173,12 +173,14 @@ For a compact current footer setup:
     "preset": "default",
     "path": { "mode": "basename" },
     "model": { "display": "name" },
-    "cost": { "subscriptionDisplay": "subscription" }
+    "cost": { "subscriptionDisplay": "subscription", "currency": "USD" }
   }
 }
 ```
 
 Use `"model": { "display": "qualified" }` when two providers expose models with the same display name.
+
+`cost.currency` accepts `USD`, `CNY`, `EUR`, `GBP`, `JPY`, `CAD`, `AUD`, `CHF`, `INR`, or `KRW`. Pi reports costs in USD; non-USD display uses a keyless USD FX rate fetched in the background and cached for 24 hours under the Pi agent directory. If no cached rate is available yet, the cost segment renders `-- CODE` until a later footer refresh can use the fetched rate.
 
 Subscription cost display accepts:
 

--- a/currency-rates.ts
+++ b/currency-rates.ts
@@ -1,0 +1,142 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { getAgentPath } from "./paths.ts";
+
+export const SUPPORTED_COST_CURRENCIES = ["USD", "CNY", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF", "INR", "KRW"] as const;
+export type CostCurrencyCode = typeof SUPPORTED_COST_CURRENCIES[number];
+
+const CURRENCY_SYMBOLS: Record<CostCurrencyCode, string> = {
+  USD: "$",
+  CNY: "¥",
+  EUR: "€",
+  GBP: "£",
+  JPY: "¥",
+  CAD: "CA$",
+  AUD: "A$",
+  CHF: "CHF ",
+  INR: "₹",
+  KRW: "₩",
+};
+
+const RATE_TTL_MS = 24 * 60 * 60 * 1000;
+const RATE_URL = "https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/usd.min.json";
+const RATE_CACHE_PATH = getAgentPath("powerline-footer", "currency-rates.json");
+
+type RateTable = Partial<Record<CostCurrencyCode, number>>;
+
+interface CachedRates {
+  timestamp: number;
+  rates: RateTable;
+}
+
+let cachedRates: CachedRates | null = null;
+let pendingFetch: Promise<void> | null = null;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function normalizeCostCurrency(value: unknown): CostCurrencyCode | undefined {
+  if (typeof value !== "string") return undefined;
+  const code = value.trim().toUpperCase();
+  return (SUPPORTED_COST_CURRENCIES as readonly string[]).includes(code) ? code as CostCurrencyCode : undefined;
+}
+
+function parseCachedRates(value: unknown): CachedRates | null {
+  if (!isRecord(value) || typeof value.timestamp !== "number" || !isRecord(value.rates)) return null;
+
+  const rates: RateTable = { USD: 1 };
+  for (const currency of SUPPORTED_COST_CURRENCIES) {
+    const rate = value.rates[currency.toLowerCase()] ?? value.rates[currency];
+    if (typeof rate === "number" && Number.isFinite(rate) && rate > 0) {
+      rates[currency] = rate;
+    }
+  }
+
+  return { timestamp: value.timestamp, rates };
+}
+
+async function readCachedRatesFromDisk(): Promise<CachedRates | null> {
+  try {
+    return parseCachedRates(JSON.parse(await readFile(RATE_CACHE_PATH, "utf8")));
+  } catch {
+    return null;
+  }
+}
+
+async function writeCachedRatesToDisk(rates: CachedRates): Promise<void> {
+  try {
+    await mkdir(dirname(RATE_CACHE_PATH), { recursive: true });
+    await writeFile(RATE_CACHE_PATH, JSON.stringify(rates));
+  } catch {
+    // The footer can still use in-memory rates when the cache file is unavailable.
+  }
+}
+
+async function fetchLatestRates(): Promise<CachedRates> {
+  const response = await fetch(RATE_URL);
+  if (!response.ok) throw new Error(`currency rate fetch failed with HTTP ${response.status}`);
+
+  const body = await response.json();
+  if (!isRecord(body) || !isRecord(body.usd)) throw new Error("currency rate response did not include USD rates");
+
+  const rates: RateTable = { USD: 1 };
+  for (const currency of SUPPORTED_COST_CURRENCIES) {
+    if (currency === "USD") continue;
+    const rate = body.usd[currency.toLowerCase()];
+    if (typeof rate === "number" && Number.isFinite(rate) && rate > 0) {
+      rates[currency] = rate;
+    }
+  }
+
+  return { timestamp: Date.now(), rates };
+}
+
+function ensureRatesRefreshing(now: number): void {
+  if (pendingFetch) return;
+  if (cachedRates && now - cachedRates.timestamp < RATE_TTL_MS) return;
+
+  pendingFetch = (async () => {
+    if (!cachedRates) cachedRates = await readCachedRatesFromDisk();
+    if (cachedRates && Date.now() - cachedRates.timestamp < RATE_TTL_MS) return;
+    if (typeof fetch !== "function") return;
+
+    try {
+      const rates = await fetchLatestRates();
+      cachedRates = rates;
+      void writeCachedRatesToDisk(rates);
+    } catch {
+      if (!cachedRates) cachedRates = await readCachedRatesFromDisk();
+    }
+  })().finally(() => {
+    pendingFetch = null;
+  });
+}
+
+function getRate(currency: CostCurrencyCode): number | null {
+  if (currency === "USD") return 1;
+
+  const rate = cachedRates?.rates[currency];
+  ensureRatesRefreshing(Date.now());
+
+  return typeof rate === "number" && Number.isFinite(rate) && rate > 0 ? rate : null;
+}
+
+export function formatUsdCost(amountUsd: number, currency: CostCurrencyCode = "USD"): string | null {
+  const rate = getRate(currency);
+  if (!rate) return `-- ${currency}`;
+
+  const amount = amountUsd * rate;
+  const decimals = currency === "JPY" || currency === "KRW" ? 0 : 2;
+  return `${CURRENCY_SYMBOLS[currency]}${amount.toFixed(decimals)}`;
+}
+
+export function __setCurrencyRatesForTest(rates: RateTable, timestamp = Date.now()): void {
+  cachedRates = { timestamp, rates: { USD: 1, ...rates } };
+  pendingFetch = null;
+}
+
+export function __resetCurrencyRatesForTest(): void {
+  cachedRates = null;
+  pendingFetch = null;
+}

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -1,4 +1,5 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
+import { normalizeCostCurrency } from "./currency-rates.ts";
 import { BUILTIN_STATUS_LINE_SEGMENT_IDS } from "./types.ts";
 import type { ColorValue, CustomItemPosition, CustomStatusItem, PowerlinePlacement, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions, StatusLineSeparatorStyle } from "./types.ts";
 
@@ -244,12 +245,14 @@ function normalizeSegmentOptions(raw: Record<string, unknown>): StatusLineSegmen
   }
 
   if (isRecord(raw.cost)) {
+    const currency = normalizeCostCurrency(raw.cost.currency);
     options.cost = {
       ...(raw.cost.subscriptionDisplay === "subscription"
         || raw.cost.subscriptionDisplay === "reported-cost"
         || raw.cost.subscriptionDisplay === "both"
         ? { subscriptionDisplay: raw.cost.subscriptionDisplay }
         : {}),
+      ...(currency ? { currency } : {}),
     };
   }
 

--- a/segments.ts
+++ b/segments.ts
@@ -5,6 +5,7 @@ import type { BuiltinStatusLineSegmentId, RenderedSegment, SegmentContext, Seman
 import { normalizeCompactExtensionStatus, normalizeExtensionStatusValue } from "./powerline-config.ts";
 import { fg, rainbow, applyColor } from "./theme.ts";
 import { getIcons, SEP_DOT, getThinkingText } from "./icons.ts";
+import { formatUsdCost } from "./currency-rates.ts";
 import { getGitRemoteHost } from "./git-status.ts";
 import type { IconSet } from "./icons.ts";
 import type { GitHost } from "./git-status.ts";
@@ -291,7 +292,7 @@ const costSegment: StatusLineSegment = {
       return { content: "", visible: false };
     }
 
-    const reportedCost = cost > 0 ? `$${cost.toFixed(2)}` : null;
+    const reportedCost = cost > 0 ? formatUsdCost(cost, ctx.options.cost?.currency) : null;
     if (!usingSubscription) {
       return reportedCost
         ? { content: color(ctx, "cost", reportedCost), visible: true }

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -175,8 +175,12 @@ test("parsePowerlineConfig extracts supported segment options", () => {
       path: { mode: "full", maxLength: 120 },
       git: { showBranch: false, showStaged: false, showUnstaged: true, showUntracked: false, polling: "branch", hostIcon: true },
       time: { format: "12h", showSeconds: true },
-      cost: { subscriptionDisplay: "both" },
+      cost: { subscriptionDisplay: "both", currency: "cny" },
     },
+    ["default", "compact"],
+  );
+  const invalidCurrency = parsePowerlineConfig(
+    { cost: { currency: "BTC" } },
     ["default", "compact"],
   );
 
@@ -185,8 +189,9 @@ test("parsePowerlineConfig extracts supported segment options", () => {
     path: { mode: "full", maxLength: 120 },
     git: { showBranch: false, showStaged: false, showUnstaged: true, showUntracked: false, polling: "branch", hostIcon: true },
     time: { format: "12h", showSeconds: true },
-    cost: { subscriptionDisplay: "both" },
+    cost: { subscriptionDisplay: "both", currency: "CNY" },
   });
+  assert.deepEqual(invalidCurrency.segmentOptions, { cost: {} });
 });
 
 test("mergeSegmentOptions lets user config override preset segment defaults", () => {

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { NERD_ICONS } from "../icons.ts";
 import { isStaleExtensionContextError, shouldShowStartupWelcome } from "../lifecycle.ts";
+import { __resetCurrencyRatesForTest, __setCurrencyRatesForTest } from "../currency-rates.ts";
 import { renderSegment } from "../segments.ts";
 import type { SegmentContext } from "../types.ts";
 
@@ -71,7 +72,9 @@ test("model segment can show provider-qualified ids", () => {
   assert.equal(stripAnsi(alreadyQualified.content), "openai/gpt-4.1");
 });
 
-test("cost segment supports subscription display modes", () => {
+test("cost segment supports subscription display modes and converted currencies", () => {
+  __setCurrencyRatesForTest({ CNY: 7.2 });
+
   const subscription = renderSegment("cost", createSegmentContext({
     usingSubscription: true,
     usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.42, subagentCost: 0 },
@@ -97,6 +100,12 @@ test("cost segment supports subscription display modes", () => {
   const withSubagentCost = renderSegment("cost", createSegmentContext({
     usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0.42, subagentCost: 0.58 },
   }));
+  const convertedCurrency = renderSegment("cost", createSegmentContext({
+    usageStats: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 1, subagentCost: 0.25 },
+    options: { cost: { currency: "CNY" } },
+  }));
+
+  __resetCurrencyRatesForTest();
 
   assert.deepEqual(subscription, { content: "(sub)", visible: true });
   assert.deepEqual(reportedCost, { content: "$0.42", visible: true });
@@ -104,6 +113,7 @@ test("cost segment supports subscription display modes", () => {
   assert.deepEqual(zeroReported, { content: "(sub)", visible: true });
   assert.deepEqual(zeroBoth, { content: "(sub)", visible: true });
   assert.deepEqual(withSubagentCost, { content: "$1.00", visible: true });
+  assert.deepEqual(convertedCurrency, { content: "¥9.00", visible: true });
 });
 
 test("context segment shows used tokens, maximum, and percentage", () => {

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,5 @@
 import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
+import type { CostCurrencyCode } from "./currency-rates.ts";
 
 // Theme color - either a pi theme color name or a custom hex color
 export type ColorValue = ThemeColor | `#${string}`;
@@ -96,7 +97,7 @@ export interface StatusLineSegmentOptions {
     hostIcon?: boolean;
   };
   time?: { format?: "12h" | "24h"; showSeconds?: boolean };
-  cost?: { subscriptionDisplay?: "subscription" | "reported-cost" | "both" };
+  cost?: { subscriptionDisplay?: "subscription" | "reported-cost" | "both"; currency?: CostCurrencyCode };
   context?: { format?: "full" | "percent" };
   cache_read?: { format?: "tokens" | "percent" };
 }


### PR DESCRIPTION
## Summary

Adds optional non-USD display for the cost segment via `powerline.cost.currency`.

Pi still reports cost internally in USD. For configured non-USD display, the footer fetches a keyless USD FX table in the background, caches it under the Pi agent directory for 24 hours, and keeps render synchronous/nonblocking. If no cached rate is available yet, the segment renders `-- CODE` until a later refresh can use the fetched rate.

Closes #130.

Thanks to @tanuki-cat for the feature request and implementation direction in #130.

## Validation

- node --experimental-strip-types --test tests/custom-items.test.ts tests/remaining-regressions.test.ts
- npm test
- git diff --check
- npm pack --dry-run --json
- fresh read-only review: found hot-path sync I/O issue; fixed
- targeted follow-up review: no issues found
