### PR TITLE
feat: improve footer responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- **Long-session footer responsiveness** — Footer refreshes now reuse the active session branch and core context result while its leaf is unchanged, pull urgent paints ahead of queued streaming refreshes, and repaint as soon as background git data arrives. This removes repeated full-session walks from the interactive render path without slowing status updates.
 - **Minimum Pi version** — Working vibes now stream through the model registry's provider, which Pi exposes from 0.81.0 onward, so the supported Pi range is `>=0.81.0 <0.84.0`.
 
 ### Fixed

--- a/context-usage.ts
+++ b/context-usage.ts
@@ -1,4 +1,4 @@
-interface CoreContextUsage {
+export interface CoreContextUsage {
   contextTokens: number;
   contextWindow: number;
   contextPercent: number;
@@ -6,6 +6,46 @@ interface CoreContextUsage {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface ContextUsageSource {
+  sessionManager: {
+    getLeafId(): string | null;
+  };
+  getContextUsage(): unknown;
+}
+
+function isContextUsageSource(value: unknown): value is ContextUsageSource {
+  if (!isRecord(value) || typeof value.getContextUsage !== "function" || !isRecord(value.sessionManager)) {
+    return false;
+  }
+  return typeof value.sessionManager.getLeafId === "function";
+}
+
+export class CoreContextUsageCache {
+  private sessionManager: ContextUsageSource["sessionManager"] | null = null;
+  private leafId: string | null = null;
+  private usage: CoreContextUsage | null = null;
+
+  get(ctx: unknown): CoreContextUsage | null {
+    if (!isContextUsageSource(ctx)) return readCoreContextUsage(ctx);
+
+    const sessionManager = ctx.sessionManager;
+    const leafId = sessionManager.getLeafId();
+    // A reset cache holds sessionManager === null, which never matches a live one.
+    if (this.sessionManager !== sessionManager || this.leafId !== leafId) {
+      this.sessionManager = sessionManager;
+      this.leafId = leafId;
+      this.usage = readCoreContextUsage(ctx);
+    }
+    return this.usage;
+  }
+
+  reset(): void {
+    this.sessionManager = null;
+    this.leafId = null;
+    this.usage = null;
+  }
 }
 
 export function estimateInitialContextTokens(ctx: unknown): number | null {

--- a/git-status.ts
+++ b/git-status.ts
@@ -34,6 +34,16 @@ let pendingFetch: Promise<void> | null = null;
 let pendingBranchFetch: Promise<void> | null = null;
 let invalidationCounter = 0; // Track invalidations to prevent stale updates
 let branchInvalidationCounter = 0;
+const updateListeners = new Set<() => void>();
+
+function notifyGitUpdate(): void {
+  for (const listener of updateListeners) listener();
+}
+
+export function subscribeGitUpdates(listener: () => void): () => void {
+  updateListeners.add(listener);
+  return () => updateListeners.delete(listener);
+}
 
 /**
  * Parse git status --porcelain output
@@ -174,9 +184,11 @@ export function getGitRemoteHost(): GitHost | null {
     pendingRemoteFetch = fetchRemoteHost()
       .then((host) => {
         cachedRemoteHost = { host, timestamp: Date.now() };
+        notifyGitUpdate();
       })
       .catch(() => {
         cachedRemoteHost = { host: null, timestamp: Date.now() };
+        notifyGitUpdate();
       })
       .finally(() => {
         pendingRemoteFetch = null;
@@ -217,6 +229,7 @@ export function getCurrentBranch(providerBranch: string | null): string | null {
           branch: result,
           timestamp: Date.now(),
         };
+        notifyGitUpdate();
       }
       pendingBranchFetch = null;
     });
@@ -259,6 +272,7 @@ export function getGitStatus(providerBranch: string | null, pollingMode: GitPoll
         cachedStatus = result
           ? { staged: result.staged, unstaged: result.unstaged, untracked: result.untracked, timestamp: Date.now() }
           : { staged: 0, unstaged: 0, untracked: 0, timestamp: Date.now() };
+        notifyGitUpdate();
       }
       pendingFetch = null;
     });

--- a/index.ts
+++ b/index.ts
@@ -28,14 +28,14 @@ import { getAgentPath } from "./paths.ts";
 import { collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, mergeSegmentOptions, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, parsePowerlineConfig } from "./powerline-config.ts";
 import { getSeparator } from "./separators.ts";
 import { renderSegment } from "./segments.ts";
-import { getGitStatus, invalidateGitStatus, invalidateGitBranch } from "./git-status.ts";
-import { SessionTokenStatsCache } from "./token-stats.ts";
+import { getGitStatus, invalidateGitStatus, invalidateGitBranch, subscribeGitUpdates } from "./git-status.ts";
+import { SessionBranchCache, SessionTokenStatsCache } from "./token-stats.ts";
 import { ansi, getFgAnsiCode } from "./colors.ts";
 import { WelcomeComponent, WelcomeHeader, discoverLoadedCounts, getRecentSessions } from "./welcome.ts";
 import { createWelcomeDismissScheduler } from "./welcome-dismiss.ts";
 import { createRenderScheduler } from "./render-scheduler.ts";
 import { getEditorAutocompleteProvider, passAutocompleteProviderThroughPreviousEditor } from "./editor-composition.ts";
-import { estimateInitialContextTokens, readCoreContextUsage } from "./context-usage.ts";
+import { CoreContextUsageCache, estimateInitialContextTokens } from "./context-usage.ts";
 import { isStaleExtensionContextError, shouldShowStartupWelcome } from "./lifecycle.ts";
 import { getDefaultColors } from "./theme.ts";
 import { registerCdCommand } from "./cd-command.ts";
@@ -1005,7 +1005,9 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   // Cache for token counting: avoid re-scanning the full session event list
   // on every render (250ms-1s cadence). Revalidates the trailing event's
   // stats signature so in-place streaming updates are not served stale.
+  const sessionBranchCache = new SessionBranchCache();
   const tokenStatsCache = new SessionTokenStatsCache();
+  const coreContextUsageCache = new CoreContextUsageCache();
 
   const getShellPath = () => process.env.SHELL || "/bin/sh";
   const getShellCwd = () => shellSession?.state.cwd ?? currentCtx?.cwd ?? process.cwd();
@@ -1028,7 +1030,9 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   const resetLayoutCache = () => {
     lastLayoutResult = null;
     layoutDirty = true;
+    sessionBranchCache.reset();
     tokenStatsCache.reset();
+    coreContextUsageCache.reset();
   };
 
   const requestStatusRender = (delayMs?: number) => {
@@ -1305,16 +1309,16 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   pi.on("tool_result", async (event) => {
     if (event.toolName === "write" || event.toolName === "edit") {
       invalidateGitStatus();
+      requestStatusRender();
     }
     // Check for bash commands that might change git branch
     if (event.toolName === "bash" && event.input?.command) {
       const cmd = String(event.input.command);
       if (mightChangeGitBranch(cmd)) {
-        // Invalidate caches since working tree state changes with branch
+        // The command has completed, so start refreshing immediately.
         invalidateGitStatus();
         invalidateGitBranch();
-        // Small delay to let git update, then re-render
-        setTimeout(() => requestStatusRender(), 100);
+        requestStatusRender();
       }
     }
   });
@@ -1336,6 +1340,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   pi.on("model_select", async (_event, ctx) => {
     currentCtx = ctx;
+    coreContextUsageCache.reset();
     requestStatusRender();
   });
 
@@ -1384,6 +1389,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   pi.on("message_end", async (event, ctx) => {
     currentCtx = ctx;
+    coreContextUsageCache.reset();
     if (isSessionAssistantMessage(event.message)) {
       if (event.message.stopReason === "error" || event.message.stopReason === "aborted") {
         liveAssistantUsage = null;
@@ -1396,6 +1402,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   pi.on("turn_end", async (_event, ctx) => {
     currentCtx = ctx;
+    coreContextUsageCache.reset();
     requestImmediateStatusRender({ deferDuringTyping: false });
   });
 
@@ -1686,6 +1693,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   pi.on("agent_end", async (_event, ctx) => {
     isStreaming = false;
     liveAssistantUsage = null;
+    coreContextUsageCache.reset();
 
     let hasUI = false;
     try {
@@ -1989,7 +1997,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     // Build usage stats and get thinking level from session (cached; the full
     // event list is only re-scanned when events are appended or the trailing
     // event's stats-relevant fields change, e.g. in-place streaming updates)
-    const sessionEvents = ctx.sessionManager?.getBranch?.() ?? [];
+    const sessionEvents = sessionBranchCache.get(ctx.sessionManager);
     const tokenStats = tokenStatsCache.get(sessionEvents);
     const { input, output, cacheRead, cacheWrite, cost, subagentCost } = tokenStats;
     const lastAssistant = tokenStats.lastAssistant;
@@ -1997,7 +2005,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
     // Calculate context percentage.
     const latestUsage = isStreaming ? liveAssistantUsage ?? lastAssistant?.usage : lastAssistant?.usage;
-    const coreContextUsage = isStreaming && liveAssistantUsage ? null : readCoreContextUsage(ctx);
+    const coreContextUsage = isStreaming && liveAssistantUsage ? null : coreContextUsageCache.get(ctx);
     const contextTokens = coreContextUsage?.contextTokens ?? (latestUsage ? getUsageTokenTotal(latestUsage) : 0);
     const contextWindow = coreContextUsage?.contextWindow ?? ctx.model?.contextWindow ?? 0;
     const contextPercent = coreContextUsage?.contextPercent ?? (contextWindow > 0 ? (contextTokens / contextWindow) * 100 : 0);
@@ -2419,10 +2427,12 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       tuiRef = tui;
       installFooterStatusRepaintHook(footerData);
       const unsub = footerData.onBranchChange(() => requestStatusRender());
+      const unsubGitUpdates = subscribeGitUpdates(() => requestStatusRender());
 
       return {
         dispose() {
           unsub();
+          unsubGitUpdates();
           restoreFooterStatusRepaintHook?.();
           restoreFooterStatusRepaintHook = null;
         },

--- a/render-scheduler.ts
+++ b/render-scheduler.ts
@@ -4,21 +4,26 @@ export interface RenderScheduler {
 }
 
 export function createRenderScheduler(render: () => void, defaultDelayMs: number): RenderScheduler {
-  let timer: ReturnType<typeof setTimeout> | null = null;
+  let pending: { timer: ReturnType<typeof setTimeout>; deadline: number } | null = null;
 
   return {
     schedule(delayMs = defaultDelayMs) {
-      if (timer) return;
+      const deadline = Date.now() + delayMs;
+      if (pending) {
+        if (deadline >= pending.deadline) return;
+        clearTimeout(pending.timer);
+      }
 
-      timer = setTimeout(() => {
-        timer = null;
+      const timer = setTimeout(() => {
+        pending = null;
         render();
       }, delayMs);
+      pending = { timer, deadline };
     },
     cancel() {
-      if (!timer) return;
-      clearTimeout(timer);
-      timer = null;
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      pending = null;
     },
   };
 }

--- a/tests/context-usage.test.ts
+++ b/tests/context-usage.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { estimateInitialContextTokens, readCoreContextUsage } from "../context-usage.ts";
+import { CoreContextUsageCache, estimateInitialContextTokens, readCoreContextUsage } from "../context-usage.ts";
 
 test("readCoreContextUsage returns Pi context estimates for branch summaries", () => {
   const usage = readCoreContextUsage({
@@ -35,6 +35,32 @@ test("readCoreContextUsage ignores unknown or unusable estimates", () => {
   assert.equal(readCoreContextUsage({ getContextUsage: () => undefined }), null);
   assert.equal(readCoreContextUsage({ getContextUsage: () => ({ tokens: null, contextWindow: 5000, percent: null }) }), null);
   assert.equal(readCoreContextUsage({ getContextUsage: () => ({ tokens: 100, contextWindow: 0, percent: 0 }) }), null);
+});
+
+test("core context usage cache reuses a leaf and supports explicit invalidation", () => {
+  const cache = new CoreContextUsageCache();
+  let leafId = "leaf-1";
+  let tokens = 100;
+  let reads = 0;
+  const ctx = {
+    sessionManager: { getLeafId: () => leafId },
+    getContextUsage() {
+      reads += 1;
+      return { tokens, contextWindow: 1000, percent: tokens / 10 };
+    },
+  };
+
+  assert.equal(cache.get(ctx)?.contextTokens, 100);
+  tokens = 200;
+  assert.equal(cache.get(ctx)?.contextTokens, 100);
+  assert.equal(reads, 1);
+
+  cache.reset();
+  assert.equal(cache.get(ctx)?.contextTokens, 200);
+  leafId = "leaf-2";
+  tokens = 300;
+  assert.equal(cache.get(ctx)?.contextTokens, 300);
+  assert.equal(reads, 3);
 });
 
 test("estimateInitialContextTokens uses Pi's conservative character estimate", () => {

--- a/tests/editor-responsiveness.test.ts
+++ b/tests/editor-responsiveness.test.ts
@@ -35,6 +35,40 @@ test("render scheduler coalesces pending status renders", () => {
   }
 });
 
+test("render scheduler pulls pending work forward for an earlier deadline", () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const callbacks: Array<() => void> = [];
+  const delays: number[] = [];
+  const cleared = new Set<object>();
+  let renderCount = 0;
+
+  globalThis.setTimeout = ((callback: () => void, delay?: number) => {
+    const handle = { id: callbacks.length + 1 };
+    callbacks.push(callback);
+    delays.push(delay ?? 0);
+    return handle as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+  globalThis.clearTimeout = ((handle?: ReturnType<typeof setTimeout>) => {
+    if (handle && typeof handle === "object") cleared.add(handle);
+  }) as typeof clearTimeout;
+
+  try {
+    const scheduler = createRenderScheduler(() => { renderCount += 1; }, 33);
+
+    scheduler.schedule(250);
+    scheduler.schedule(33);
+
+    assert.deepEqual(delays, [250, 33]);
+    assert.equal(cleared.size, 1);
+    callbacks[1]?.();
+    assert.equal(renderCount, 1);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
 test("render scheduler allows callbacks to schedule follow-up renders", () => {
   const originalSetTimeout = globalThis.setTimeout;
   const callbacks: Array<() => void> = [];

--- a/tests/git-status.test.ts
+++ b/tests/git-status.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { detectGitHost, getCurrentBranch, getGitStatus, invalidateGitBranch, invalidateGitStatus } from "../git-status.ts";
+import { detectGitHost, getCurrentBranch, getGitStatus, invalidateGitBranch, invalidateGitStatus, subscribeGitUpdates } from "../git-status.ts";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -42,6 +42,20 @@ test("invalidateGitBranch keeps serving the last known branch while refreshing",
 
   invalidateGitBranch();
   assert.equal(getCurrentBranch("provider-fallback"), realBranch);
+});
+
+test("git cache completion notifies active footer subscribers", async () => {
+  let updates = 0;
+  const unsubscribe = subscribeGitUpdates(() => { updates += 1; });
+  try {
+    invalidateGitStatus();
+    invalidateGitBranch();
+    getGitStatus("provider-fallback");
+    await sleep(FETCH_SETTLE_MS);
+    assert.ok(updates > 0);
+  } finally {
+    unsubscribe();
+  }
 });
 
 test("detectGitHost recognizes known hosts over SSH and HTTPS", () => {

--- a/tests/token-stats.test.ts
+++ b/tests/token-stats.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { computeSessionTokenStats, SessionTokenStatsCache } from "../token-stats.ts";
+import { computeSessionTokenStats, SessionBranchCache, SessionTokenStatsCache } from "../token-stats.ts";
 
 function makeUsage(input: number, output: number, cacheRead = 0, cacheWrite = 0, costPerToken = 0.001) {
   return {
@@ -50,6 +50,37 @@ function subagentSlashResultEvent(costs: number[]) {
     details: { result: { details: { results: costs.map((cost) => ({ usage: { cost } })) } } },
   };
 }
+
+test("session branch cache reuses a leaf path and refreshes when the leaf changes", () => {
+  const cache = new SessionBranchCache();
+  let leafId = "leaf-1";
+  let branch: unknown[] = [{ id: leafId, value: 1 }];
+  let branchReads = 0;
+  const provider = {
+    getLeafId: () => leafId,
+    getBranch: () => {
+      branchReads += 1;
+      return branch;
+    },
+  };
+
+  assert.deepEqual(cache.get(null), []);
+
+  const first = cache.get(provider);
+  (branch[0] as { value: number }).value = 2;
+  assert.equal(cache.get(provider), first);
+  assert.equal((cache.get(provider)[0] as { value: number }).value, 2);
+  assert.equal(branchReads, 1);
+
+  leafId = "leaf-2";
+  branch = [...branch, { id: leafId }];
+  assert.equal(cache.get(provider), branch);
+  assert.equal(branchReads, 2);
+
+  cache.reset();
+  cache.get(provider);
+  assert.equal(branchReads, 3);
+});
 
 test("computeSessionTokenStats aggregates usage and tracks thinking level", () => {
   const events = [
@@ -211,7 +242,8 @@ test("reset forces recomputation", () => {
 
 test("index.ts wires the token stats cache into buildSegmentContext", () => {
   const source = readFileSync(new URL("../index.ts", import.meta.url), "utf-8");
-  assert.match(source, /import \{ SessionTokenStatsCache \} from "\.\/token-stats\.ts";/);
+  assert.match(source, /import \{ SessionBranchCache, SessionTokenStatsCache \} from "\.\/token-stats\.ts";/);
+  assert.match(source, /sessionBranchCache\.get\(ctx\.sessionManager\)/);
   assert.match(source, /tokenStatsCache\.get\(sessionEvents\)/);
   assert.match(source, /tokenStatsCache\.reset\(\)/);
 });

--- a/token-stats.ts
+++ b/token-stats.ts
@@ -155,6 +155,45 @@ function accumulateSessionEvent(stats: SessionTokenStats, event: unknown): void 
   }
 }
 
+export interface SessionBranchProvider {
+  getLeafId(): string | null;
+  getBranch(): readonly unknown[];
+}
+
+function isSessionBranchProvider(value: unknown): value is SessionBranchProvider {
+  return isRecord(value) && typeof value.getLeafId === "function" && typeof value.getBranch === "function";
+}
+
+/**
+ * Session branches are immutable for a given leaf. Keep the already-built path
+ * while streaming updates mutate only its trailing message in place.
+ */
+export class SessionBranchCache {
+  private provider: SessionBranchProvider | null = null;
+  private leafId: string | null = null;
+  private branch: readonly unknown[] = [];
+
+  get(source: unknown): readonly unknown[] {
+    if (!isSessionBranchProvider(source)) return [];
+
+    const provider = source;
+    const leafId = provider.getLeafId();
+    // A reset cache holds provider === null, which never matches a live provider.
+    if (this.provider !== provider || this.leafId !== leafId) {
+      this.provider = provider;
+      this.leafId = leafId;
+      this.branch = provider.getBranch();
+    }
+    return this.branch;
+  }
+
+  reset(): void {
+    this.provider = null;
+    this.leafId = null;
+    this.branch = [];
+  }
+}
+
 export function computeSessionTokenStats(sessionEvents: readonly unknown[]): SessionTokenStats {
   let input = 0, output = 0, cacheRead = 0, cacheWrite = 0, cost = 0, subagentCost = 0;
   let lastAssistant: AssistantMessage | undefined;


### PR DESCRIPTION
## Summary

- cache the active session branch and core context usage by session leaf
- let urgent paints supersede queued streaming refreshes
- repaint as soon as asynchronous git data arrives and refresh immediately after mutating tools
- simplify cache and scheduler state so invalid internal combinations are not representable

## Performance

On a synthetic 20,000-entry session, rebuilding the active branch took about 18.6 ms per footer refresh. Same-leaf refreshes now reuse the existing branch, removing that repeated full-session walk from the interactive render path.

## Validation

- `npm test` — 148/148 passed
- focused cache, scheduler, context, and git tests passed
- extension entrypoint import passed on Pi 0.83.0 dependencies
- `git diff --check` passed
- fresh adversarial review found no concrete issues
