### PR TITLE
feat: add combined cache-read display format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Combined cache-read format** — Added opt-in `powerline.cache_read.format: "both"` to display raw cache-read tokens alongside the cache hit rate, for example `cache in: 12k (80%)`.
+
 ## [0.10.0] - 2026-08-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -195,13 +195,13 @@ Segment display formats (opt-in; defaults match the historical rendering):
 | Segment option | Values | Default | Effect |
 |---|---|---|---|
 | `"context": { "format" }` | `"full"` / `"percent"` | `"full"` | `"percent"` shows a bare rounded `83%` (threshold-colored, no icon) instead of `12k/200k (6.2%)` |
-| `"cache_read": { "format" }` | `"tokens"` / `"percent"` | `"tokens"` | `"percent"` shows the cache hit rate `cacheRead / (input + cacheRead)` instead of the raw token count |
+| `"cache_read": { "format" }` | `"tokens"` / `"percent"` / `"both"` | `"tokens"` | `"percent"` shows the cache hit rate `cacheRead / (input + cacheRead)` instead of the raw token count; `"both"` shows the raw token count followed by the hit rate, e.g. `cache in: 12k (80%)` |
 
 ```json
 {
   "powerline": {
     "context": { "format": "percent" },
-    "cache_read": { "format": "percent" }
+    "cache_read": { "format": "both" }
   }
 }
 ```

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -264,7 +264,9 @@ function normalizeSegmentOptions(raw: Record<string, unknown>): StatusLineSegmen
 
   if (isRecord(raw.cache_read)) {
     options.cache_read = {
-      ...(raw.cache_read.format === "tokens" || raw.cache_read.format === "percent" ? { format: raw.cache_read.format } : {}),
+      ...(raw.cache_read.format === "tokens" || raw.cache_read.format === "percent" || raw.cache_read.format === "both"
+        ? { format: raw.cache_read.format }
+        : {}),
     };
   }
 

--- a/segments.ts
+++ b/segments.ts
@@ -422,17 +422,20 @@ const cacheReadSegment: StatusLineSegment = {
     const { cacheRead, input } = ctx.usageStats;
     if (!cacheRead) return { content: "", visible: false };
 
+    const format = ctx.options.cache_read?.format ?? "tokens";
+    // Cache hit rate: cacheRead / (input + cacheRead)
+    const hitRate = input + cacheRead > 0
+      ? ((cacheRead / (input + cacheRead)) * 100).toFixed(0)
+      : "0";
+
     let content: string;
-    if (ctx.options.cache_read?.format === "percent") {
-      // Cache hit rate: cacheRead / (input + cacheRead)
-      const hitRate = input + cacheRead > 0
-        ? ((cacheRead / (input + cacheRead)) * 100).toFixed(0)
-        : "0";
+    if (format === "percent") {
       content = [icons.cache, `${hitRate}%`].filter(Boolean).join(" ");
     } else {
-      // "tokens" (default): raw cache-read token count
-      const parts = [icons.cache, icons.input, formatTokens(cacheRead)].filter(Boolean);
-      content = parts.join(" ");
+      // "tokens" (default): raw cache-read token count.
+      // "both": raw cache-read token count plus its cache hit rate.
+      const tokens = [icons.cache, icons.input, formatTokens(cacheRead)].filter(Boolean).join(" ");
+      content = format === "both" ? `${tokens} (${hitRate}%)` : tokens;
     }
     return { content: color(ctx, "tokens", content), visible: true };
   },

--- a/tests/usage-display.test.ts
+++ b/tests/usage-display.test.ts
@@ -115,14 +115,28 @@ test("cache_read percent format renders the cache hit rate", () => {
   assert.equal(stripAnsi(rendered.content), "cache 80%");
 });
 
-test("cache_read percent format handles zero total without NaN", () => {
-  const ctx = createSegmentContext({ cache_read: { format: "percent" } }, {
+test("cache_read both format renders raw token count and cache hit rate", () => {
+  const ctx = createSegmentContext({ cache_read: { format: "both" } }, {
+    usageStats: { input: 2000, output: 0, cacheRead: 8000, cacheWrite: 0, cost: 0, subagentCost: 0 },
+  });
+
+  const rendered = renderSegment("cache_read", ctx);
+  assert.equal(stripAnsi(rendered.content), "cache in: 8.0k (80%)");
+});
+
+test("cache_read percent and both formats handle zero input without NaN", () => {
+  const percentCtx = createSegmentContext({ cache_read: { format: "percent" } }, {
     usageStats: { input: 0, output: 0, cacheRead: 5, cacheWrite: 0, cost: 0, subagentCost: 0 },
   });
-  assert.equal(stripAnsi(renderSegment("cache_read", ctx).content), "cache 100%");
+  assert.equal(stripAnsi(renderSegment("cache_read", percentCtx).content), "cache 100%");
 
-  // cacheRead = 0 hides the segment entirely in both formats
-  const hidden = createSegmentContext({ cache_read: { format: "percent" } });
+  const bothCtx = createSegmentContext({ cache_read: { format: "both" } }, {
+    usageStats: { input: 0, output: 0, cacheRead: 5, cacheWrite: 0, cost: 0, subagentCost: 0 },
+  });
+  assert.equal(stripAnsi(renderSegment("cache_read", bothCtx).content), "cache in: 5 (100%)");
+
+  // cacheRead = 0 hides the segment entirely in every format
+  const hidden = createSegmentContext({ cache_read: { format: "both" } });
   assert.deepEqual(renderSegment("cache_read", hidden), { content: "", visible: false });
 });
 
@@ -131,11 +145,11 @@ test("cache_read percent format handles zero total without NaN", () => {
 test("parsePowerlineConfig accepts context and cache_read formats", () => {
   const config = parsePowerlineConfig({
     context: { format: "percent" },
-    cache_read: { format: "percent" },
+    cache_read: { format: "both" },
   }, PRESET_NAMES);
 
   assert.equal(config.segmentOptions.context?.format, "percent");
-  assert.equal(config.segmentOptions.cache_read?.format, "percent");
+  assert.equal(config.segmentOptions.cache_read?.format, "both");
 });
 
 test("parsePowerlineConfig ignores invalid format values", () => {
@@ -157,9 +171,9 @@ test("parsePowerlineConfig defaults to upstream rendering when options are absen
 test("mergeSegmentOptions merges context and cache_read per key", () => {
   const merged = mergeSegmentOptions(
     { context: { format: "percent" }, cache_read: { format: "percent" } },
-    { context: { format: "full" } },
+    { context: { format: "full" }, cache_read: { format: "both" } },
   );
 
   assert.equal(merged.context?.format, "full");
-  assert.equal(merged.cache_read?.format, "percent");
+  assert.equal(merged.cache_read?.format, "both");
 });

--- a/types.ts
+++ b/types.ts
@@ -99,7 +99,7 @@ export interface StatusLineSegmentOptions {
   time?: { format?: "12h" | "24h"; showSeconds?: boolean };
   cost?: { subscriptionDisplay?: "subscription" | "reported-cost" | "both"; currency?: CostCurrencyCode };
   context?: { format?: "full" | "percent" };
-  cache_read?: { format?: "tokens" | "percent" };
+  cache_read?: { format?: "tokens" | "percent" | "both" };
 }
 
 export type CustomItemPosition = "left" | "right" | "secondary";


### PR DESCRIPTION
## Summary

Adds an opt-in `powerline.cache_read.format: "both"` display mode, extending the formats introduced in #109.

`both` keeps the raw cache-read token count and appends the cache hit rate (`cacheRead / (input + cacheRead)`), for example:

```text
cache in: 12k (80%)
```

The default remains `tokens`, and the existing `percent` format remains unchanged.

## Changes

- Adds `"both"` to the `cache_read.format` type and configuration validation.
- Renders both cache-read tokens and the rounded hit rate when selected.
- Documents the new setting and adds a changelog entry.
- Adds tests for rendering, zero-input behavior, config parsing, and option merging.

## Validation

- `PI_CODING_AGENT_DIR=$(mktemp -d) npm test` — 149 passed
- `git diff --check`
