### PR TITLE
Add Powerline Queue and Inbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Powerline Queue + Inbox** — Added a file-backed queue and idea inbox for capturing thoughts without interrupting the current agent. Messages submitted during compaction are held by Powerline and delivered after successful compaction, while failed or cancelled compactions leave them blocked and visible. New `/idea`, `/ideas`, and `/queue` commands manage captured ideas, queued prompts, project aliases, retries, clears, and current-session delivery; the `queue` segment and preview row surface active queue, idea, and blocked counts.
+
 ## [0.10.0] - 2026-08-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Customizes the default [pi](https://github.com/badlogic/pi-mono) editor with a p
 
 **Editor stash** — Press `Alt+S` to save your editor content and clear the editor, type a quick prompt, and your stashed text auto-restores when the agent finishes. Toggles between stash, pop, and update-existing-stash. A `stash` indicator appears in the powerline bar while text is stashed.
 
+**Powerline Queue + Inbox** — Capture thoughts without interrupting the current agent. Messages typed during compaction are held by Powerline and delivered after successful compaction instead of disappearing into Pi's native queue. `/idea`, `/ideas`, and `/queue` provide a file-backed inbox for current-session prompts, project ideas, aliases, retries, clears, and manual delivery. Active queue, idea, and blocked counts appear in the `queue` segment only when there is something to show.
+
 **Working Vibes** — AI-generated themed loading messages. Set `/vibe star trek` and your "Working..." becomes "Running diagnostics..." or "Engaging warp drive...". Supports any theme: pirate, zen, noir, cowboy, etc.
 
 **Welcome overlay** — Branded splash screen shown as centered overlay on startup. Shows gradient logo, model info, keyboard tips, loaded AGENTS.md/extensions/skills/templates counts, an approximate initial system-prompt token count, and recent sessions. Auto-dismisses after 30 seconds or on any key press. Set `powerline.welcome` to `false` to disable it while keeping the footer enabled.
@@ -48,6 +50,22 @@ Restart pi to activate.
 Activates automatically. Toggle with `/powerline`, switch presets with `/powerline <name>`, and move the primary row with `/powerline placement above|below|toggle`.
 
 Use `/cd <path>` to continue the current conversation from another working directory. It supports relative paths, absolute paths, `~`, `~/...`, and directory completions. With no argument, `/cd` prints the current Pi session directory. The command switches into a cwd-updated session file so Pi tools and the footer path segment agree after the change.
+
+Powerline Queue + Inbox commands:
+
+- `/idea <text>` — capture an idea for the current project without sending it to the agent
+- `/idea @global <text>` — capture a global idea
+- `/idea @current <text>` — capture an idea targeted to the current session
+- `/queue alias <name> [path]` — save a project alias, defaulting to the current cwd when `path` is omitted
+- `/idea @name <text>` — capture an idea for a saved project alias
+- `/ideas` — open the captured-ideas picker
+- `/ideas send <id>` — send an idea to the current session
+- `/queue` — open the queued-prompt picker
+- `/queue send [id]` / `/queue retry [id]` — deliver a queued item now
+- `/queue clear <id|all>` — clear queued prompt items
+- `/queue target <id> @name|global|current` — retarget a queued item
+
+Captured data is stored under the Pi agent directory in `powerline-footer/inbox.jsonl` and `powerline-footer/projects.json`.
 
 - `/powerline placement below` — move the primary powerline row below the editor
 - `/powerline placement above` — restore the default placement
@@ -275,6 +293,8 @@ Selecting an entry inserts it into the editor. If the editor already has text, y
 
 - `ctrl+alt+c` — copy full editor content
 - `ctrl+alt+x` — cut full editor content (copy, then clear)
+- `ctrl+alt+i` — capture the current editor text as a project idea and clear the editor
+- `ctrl+alt+q` — open the queued-prompt picker
 - `cmd+shift+up` — move the editor cursor to the start of the first line
 - `cmd+shift+down` — move the editor cursor to the end of the last line
 
@@ -290,6 +310,8 @@ You can override shortcut keys in the agent settings file:
     "stashHistory": "ctrl+alt+h",
     "copyEditor": "ctrl+alt+c",
     "cutEditor": "ctrl+alt+x",
+    "ideaCapture": "ctrl+alt+i",
+    "queueOpen": "ctrl+alt+q",
     "editorStart": "cmd+shift+up",
     "editorEnd": "cmd+shift+down"
   }

--- a/index.ts
+++ b/index.ts
@@ -63,6 +63,8 @@ import {
   generateVibesBatch,
   parseVibeGenerateArgs,
 } from "./working-vibes.ts";
+import { PowerlineQueueStore, currentQueueContext, parseTargetPrefix, targetForIdea } from "./queue/store.ts";
+import type { PowerlineQueueItem, QueueIntent, QueueTarget } from "./queue/types.ts";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Configuration
@@ -92,6 +94,8 @@ export interface PowerlineShortcuts {
   stashHistory: ShortcutBinding;
   copyEditor: ShortcutBinding;
   cutEditor: ShortcutBinding;
+  ideaCapture: ShortcutBinding;
+  queueOpen: ShortcutBinding;
   editorStart: ShortcutBinding;
   editorEnd: ShortcutBinding;
 }
@@ -101,6 +105,8 @@ type PowerlineShortcutAction =
   | { kind: "stashHistory" }
   | { kind: "copyEditor" }
   | { kind: "cutEditor" }
+  | { kind: "ideaCapture" }
+  | { kind: "queueOpen" }
   | { kind: "bashMode" };
 const STASH_HISTORY_LIMIT = 12;
 const PROJECT_PROMPT_HISTORY_LIMIT = 50;
@@ -109,6 +115,8 @@ const DEFAULT_SHORTCUTS: Record<PowerlineShortcutKey, string> = {
   stashHistory: "ctrl+alt+h",
   copyEditor: "ctrl+alt+c",
   cutEditor: "ctrl+alt+x",
+  ideaCapture: "ctrl+alt+i",
+  queueOpen: "ctrl+alt+q",
   editorStart: "super+shift+up",
   editorEnd: "super+shift+down",
 };
@@ -117,7 +125,7 @@ const DEFAULT_BASH_MODE_SETTINGS: BashModeSettings = {
   transcriptMaxLines: 2000,
   transcriptMaxBytes: 512 * 1024,
 };
-const SHORTCUT_KEYS: PowerlineShortcutKey[] = ["stashHistory", "copyEditor", "cutEditor", "editorStart", "editorEnd"];
+const SHORTCUT_KEYS: PowerlineShortcutKey[] = ["stashHistory", "copyEditor", "cutEditor", "ideaCapture", "queueOpen", "editorStart", "editorEnd"];
 const APP_RESERVED_SHORTCUTS = [
   "escape",
   "ctrl+c",
@@ -993,6 +1001,9 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   let bashTranscript = new BashTranscriptStore(bashModeSettings);
   let bashCompletionEngine = new BashCompletionEngine();
   let shellSession: ManagedShellSession | null = null;
+  const queueStore = new PowerlineQueueStore();
+  let powerlineCompacting = false;
+  let queueDeliveryTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Cache for the top and secondary powerline widgets.
   let lastLayoutWidth = 0;
@@ -1220,6 +1231,196 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     );
   }
 
+  function getQueueSessionId(ctx: any): string | undefined {
+    const sessionId = ctx.sessionManager?.getSessionId?.();
+    return typeof sessionId === "string" && sessionId.trim() ? sessionId : undefined;
+  }
+
+  function getQueueContext(ctx: any) {
+    return currentQueueContext(ctx.cwd ?? process.cwd(), getQueueSessionId(ctx));
+  }
+
+  function requestQueueRender(): void {
+    requestImmediateStatusRender({ deferDuringTyping: false });
+  }
+
+  function queueItemLabel(item: PowerlineQueueItem): string {
+    const status = item.status === "queued" ? item.intent : `${item.intent}/${item.status}`;
+    return `${item.id} ${status} ${buildStashPreview(item.text, 56)}`;
+  }
+
+  function queueItemDescription(item: PowerlineQueueItem): string {
+    if (item.target.kind === "global") return "global";
+    if (item.target.kind === "current-session") return "current session";
+    return item.target.alias ? `@${item.target.alias}` : item.target.cwd;
+  }
+
+  function captureQueueItem(ctx: any, text: string, intent: QueueIntent, target: QueueTarget): PowerlineQueueItem {
+    const item = queueStore.add({
+      text,
+      intent,
+      target,
+      source: getQueueContext(ctx),
+    });
+    requestQueueRender();
+    return item;
+  }
+
+  function captureCurrentProjectIdea(ctx: any, text: string): PowerlineQueueItem | null {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      ctx.ui.notify("Nothing to capture", "info");
+      return null;
+    }
+
+    const item = captureQueueItem(ctx, trimmed, "idea", { kind: "project", cwd: ctx.cwd ?? process.cwd() });
+    ctx.ui.notify(`Captured idea ${item.id}`, "info");
+    return item;
+  }
+
+  function capturePostCompactPrompt(ctx: any, text: string): PowerlineQueueItem | null {
+    const trimmed = text.trim();
+    if (!trimmed) return null;
+
+    const item = captureQueueItem(ctx, trimmed, "post-compact", { kind: "current-session" });
+    ctx.ui.notify(`Queued for after compaction (${item.id})`, "info");
+    return item;
+  }
+
+  function deliveryModeForItem(ctx: any, item: PowerlineQueueItem): "steer" | "followUp" | undefined {
+    const idle = typeof ctx.isIdle === "function" ? ctx.isIdle() : true;
+    if (idle) return undefined;
+    return item.intent === "steer" ? "steer" : "followUp";
+  }
+
+  function deliverQueueItem(ctx: any, item: PowerlineQueueItem): boolean {
+    if (powerlineCompacting) {
+      queueStore.update(item.id, { status: "queued" });
+      requestQueueRender();
+      return false;
+    }
+
+    queueStore.update(item.id, { status: "delivering", error: undefined });
+    requestQueueRender();
+
+    try {
+      const deliverAs = deliveryModeForItem(ctx, item);
+      if (deliverAs) {
+        pi.sendUserMessage(item.text, { deliverAs });
+      } else {
+        pi.sendUserMessage(item.text);
+      }
+      queueStore.update(item.id, { status: "sent", error: undefined });
+      ctx.ui.notify(`Sent queued item ${item.id}`, "info");
+      requestQueueRender();
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      queueStore.update(item.id, { status: "failed", error: message });
+      ctx.ui.notify(`Failed to send ${item.id}: ${message}`, "error");
+      requestQueueRender();
+      return false;
+    }
+  }
+
+  function schedulePostCompactionDelivery(ctx: any): void {
+    if (queueDeliveryTimer) clearTimeout(queueDeliveryTimer);
+    queueDeliveryTimer = setTimeout(() => {
+      queueDeliveryTimer = null;
+      const item = queueStore.queuedDeliveryItems(getQueueContext(ctx), "post-compact")[0];
+      if (item) deliverQueueItem(ctx, item);
+    }, 50);
+  }
+
+  function blockPostCompactionQueue(ctx: any, errorMessage: string): void {
+    const items = queueStore.queuedDeliveryItems(getQueueContext(ctx), "post-compact");
+    for (const item of items) {
+      queueStore.update(item.id, { status: "blocked", error: errorMessage });
+    }
+    if (items.length > 0) {
+      ctx.ui.notify(`Kept ${items.length} post-compaction item${items.length === 1 ? "" : "s"} blocked`, "warning");
+      requestQueueRender();
+    }
+  }
+
+  async function chooseQueueAction(ctx: any, item: PowerlineQueueItem): Promise<void> {
+    const actions: SelectItem[] = [
+      { value: "send", label: "Send to current session", description: "Deliver as prompt/follow-up" },
+      { value: "edit", label: "Edit in prompt", description: "Move text into the editor" },
+      { value: "retry", label: "Retry", description: "Mark queued and deliver" },
+      { value: "clear", label: "Clear", description: "Mark item done" },
+      { value: "cancel", label: "Cancel" },
+    ];
+    const selected = await showSelectOverlay(ctx, `Queue item ${item.id}`, buildStashPreview(item.text, 72), actions, actions.length);
+    if (!selected || selected.value === "cancel") return;
+
+    if (selected.value === "send") {
+      deliverQueueItem(ctx, item);
+      return;
+    }
+
+    if (selected.value === "retry") {
+      const updated = queueStore.update(item.id, { status: "queued", error: undefined });
+      if (updated) deliverQueueItem(ctx, updated);
+      return;
+    }
+
+    if (selected.value === "edit") {
+      ctx.ui.setEditorText(item.text);
+      queueStore.clear(item.id);
+      requestQueueRender();
+      return;
+    }
+
+    if (selected.value === "clear") {
+      queueStore.clear(item.id);
+      ctx.ui.notify(`Cleared ${item.id}`, "info");
+      requestQueueRender();
+    }
+  }
+
+  async function openQueuePicker(ctx: any, mode: "ideas" | "queue"): Promise<void> {
+    const active = queueStore.activeItems(getQueueContext(ctx)).filter((item) => (
+      mode === "ideas" ? item.intent === "idea" : item.intent !== "idea"
+    ));
+    if (active.length === 0) {
+      ctx.ui.notify(mode === "ideas" ? "No ideas captured" : "No queued items", "info");
+      return;
+    }
+
+    const items: SelectItem[] = active.map((item) => ({
+      value: item.id,
+      label: queueItemLabel(item),
+      description: queueItemDescription(item),
+    }));
+    const selected = await showSelectOverlay(
+      ctx,
+      mode === "ideas" ? "Powerline ideas" : "Powerline queue",
+      "↑↓ navigate • enter manage • esc cancel",
+      items,
+      Math.min(active.length, 12),
+    );
+    if (!selected) return;
+
+    const item = active.find((candidate) => candidate.id === selected.value);
+    if (item) await chooseQueueAction(ctx, item);
+  }
+
+  function resolveCommandTarget(ctx: any, spec: string): QueueTarget {
+    const normalized = spec.trim().replace(/^@/, "");
+    return targetForIdea(normalized || null, queueStore, ctx.cwd ?? process.cwd());
+  }
+
+  function sendOrRetryQueueItem(ctx: any, idPrefix: string): void {
+    const item = queueStore.get(idPrefix);
+    if (!item) {
+      ctx.ui.notify(`No unique queue item matches ${idPrefix}`, "warning");
+      return;
+    }
+    const updated = queueStore.update(item.id, { status: "queued", error: undefined });
+    if (updated) deliverQueueItem(ctx, updated);
+  }
+
   // Track session start
   pi.on("session_start", async (event, ctx) => {
     shellSession?.dispose();
@@ -1231,6 +1432,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     lastUserPrompt = "";
     isStreaming = false;
     liveAssistantUsage = null;
+    powerlineCompacting = false;
     stashedEditorText = null;
 
     const settings = readSettings(ctx.cwd);
@@ -1285,6 +1487,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     stashShortcutInputUnsubscribe = null;
     shellSession?.dispose();
     shellSession = null;
+    if (queueDeliveryTimer) {
+      clearTimeout(queueDeliveryTimer);
+      queueDeliveryTimer = null;
+    }
+    powerlineCompacting = false;
     bashModeActive = false;
     currentCtx = null;
     footerDataRef = null;
@@ -1404,6 +1611,24 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     currentCtx = ctx;
     coreContextUsageCache.reset();
     requestImmediateStatusRender({ deferDuringTyping: false });
+  });
+
+  pi.on("compaction_start", async (_event, ctx) => {
+    powerlineCompacting = true;
+    currentCtx = ctx;
+    requestQueueRender();
+  });
+
+  pi.on("compaction_end", async (event, ctx) => {
+    powerlineCompacting = false;
+    currentCtx = ctx;
+    const errorMessage = event.errorMessage || (event.aborted ? "Compaction cancelled" : "Compaction did not complete");
+    if (event.aborted || !event.result) {
+      blockPostCompactionQueue(ctx, errorMessage);
+    } else {
+      schedulePostCompactionDelivery(ctx);
+    }
+    requestQueueRender();
   });
 
   // Also dismiss on tool calls (agent is working) + refresh vibe if rate limit allows
@@ -1607,6 +1832,12 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     if (matchesConfiguredShortcut(data, resolvedShortcuts.cutEditor)) {
       return { kind: "cutEditor" };
     }
+    if (matchesConfiguredShortcut(data, resolvedShortcuts.ideaCapture)) {
+      return { kind: "ideaCapture" };
+    }
+    if (matchesConfiguredShortcut(data, resolvedShortcuts.queueOpen)) {
+      return { kind: "queueOpen" };
+    }
     if (matchesConfiguredShortcut(data, bashModeSettings.toggleShortcut)) {
       return { kind: "bashMode" };
     }
@@ -1629,6 +1860,22 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         ctx.ui.setEditorText("");
         ctx.ui.notify("Cut editor text", "info");
       }
+      return;
+    }
+
+    if (action.kind === "ideaCapture") {
+      const text = getEditorTextForClipboard(ctx);
+      if (!text) return;
+
+      const item = captureCurrentProjectIdea(ctx, text);
+      if (item) {
+        ctx.ui.setEditorText("");
+      }
+      return;
+    }
+
+    if (action.kind === "queueOpen") {
+      void openQueuePicker(ctx, "queue");
       return;
     }
 
@@ -1726,9 +1973,182 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
 
     requestStatusRender();
+    if (!powerlineCompacting) {
+      schedulePostCompactionDelivery(ctx);
+    }
   });
 
   registerCdCommand(pi, () => currentCtx?.cwd ?? process.cwd());
+
+  pi.registerCommand("idea", {
+    description: "Capture an idea without interrupting the current agent. Usage: /idea [@alias|@global|@current] <text>",
+    handler: async (args, ctx) => {
+      currentCtx = ctx;
+      const raw = args.trim() || getCurrentEditorText(ctx, currentEditor).trim();
+      if (!raw) {
+        ctx.ui.notify("Usage: /idea [@alias|@global|@current] <text>", "info");
+        return;
+      }
+
+      try {
+        const parsed = parseTargetPrefix(raw);
+        if (!parsed.text) {
+          ctx.ui.notify("Idea text is empty", "warning");
+          return;
+        }
+        const target = targetForIdea(parsed.target, queueStore, ctx.cwd ?? process.cwd());
+        const item = captureQueueItem(ctx, parsed.text, "idea", target);
+        if (!args.trim()) {
+          ctx.ui.setEditorText("");
+        }
+        ctx.ui.notify(`Captured idea ${item.id}`, "info");
+      } catch (error) {
+        ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+      }
+    },
+  });
+
+  pi.registerCommand("ideas", {
+    description: "Review or send captured ideas. Usage: /ideas [send|retry|clear|edit] <id>",
+    handler: async (args, ctx) => {
+      currentCtx = ctx;
+      const parts = args.trim().split(/\s+/).filter(Boolean);
+      const action = parts[0];
+      const id = parts[1];
+
+      if (!action) {
+        await openQueuePicker(ctx, "ideas");
+        return;
+      }
+
+      if (!id) {
+        ctx.ui.notify("Usage: /ideas [send|retry|clear|edit] <id>", "info");
+        return;
+      }
+
+      const item = queueStore.get(id);
+      if (!item || item.intent !== "idea") {
+        ctx.ui.notify(`No unique idea matches ${id}`, "warning");
+        return;
+      }
+
+      if (action === "send" || action === "retry") {
+        const updated = queueStore.update(item.id, { status: "queued", target: { kind: "current-session" }, error: undefined });
+        if (updated) deliverQueueItem(ctx, updated);
+        return;
+      }
+
+      if (action === "edit") {
+        ctx.ui.setEditorText(item.text);
+        queueStore.clear(item.id);
+        requestQueueRender();
+        return;
+      }
+
+      if (action === "clear") {
+        queueStore.clear(item.id);
+        ctx.ui.notify(`Cleared idea ${item.id}`, "info");
+        requestQueueRender();
+        return;
+      }
+
+      ctx.ui.notify("Usage: /ideas [send|retry|clear|edit] <id>", "info");
+    },
+  });
+
+  pi.registerCommand("queue", {
+    description: "Manage Powerline queued prompts and project aliases",
+    handler: async (args, ctx) => {
+      currentCtx = ctx;
+      const parts = args.trim().split(/\s+/).filter(Boolean);
+      const action = parts[0];
+
+      if (!action) {
+        await openQueuePicker(ctx, "queue");
+        return;
+      }
+
+      if (action === "alias") {
+        const alias = parts[1];
+        const aliasPath = parts.slice(2).join(" ") || ctx.cwd || process.cwd();
+        if (!alias) {
+          ctx.ui.notify("Usage: /queue alias <name> [path]", "info");
+          return;
+        }
+        try {
+          queueStore.setAlias(alias, aliasPath);
+          ctx.ui.notify(`Alias @${alias} → ${aliasPath}`, "info");
+        } catch (error) {
+          ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+        }
+        return;
+      }
+
+      if (action === "send" || action === "retry") {
+        const id = parts[1];
+        if (!id) {
+          const item = queueStore.queuedDeliveryItems(getQueueContext(ctx))[0];
+          if (!item) {
+            ctx.ui.notify("No queued item to send", "info");
+            return;
+          }
+          sendOrRetryQueueItem(ctx, item.id);
+          return;
+        }
+        sendOrRetryQueueItem(ctx, id);
+        return;
+      }
+
+      if (action === "clear") {
+        const id = parts[1];
+        if (id === "all") {
+          const active = queueStore.activeItems(getQueueContext(ctx)).filter((item) => item.intent !== "idea");
+          for (const item of active) queueStore.clear(item.id);
+          ctx.ui.notify(`Cleared ${active.length} queued item${active.length === 1 ? "" : "s"}`, "info");
+          requestQueueRender();
+          return;
+        }
+        if (!id) {
+          ctx.ui.notify("Usage: /queue clear <id|all>", "info");
+          return;
+        }
+        const item = queueStore.get(id);
+        if (!item || item.intent === "idea") {
+          ctx.ui.notify(`No unique queued item matches ${id}`, "warning");
+          return;
+        }
+        queueStore.clear(item.id);
+        ctx.ui.notify(`Cleared ${item.id}`, "info");
+        requestQueueRender();
+        return;
+      }
+
+      if (action === "target") {
+        const id = parts[1];
+        const spec = parts[2];
+        if (!id || !spec) {
+          ctx.ui.notify("Usage: /queue target <id> @alias|global|current", "info");
+          return;
+        }
+        const item = queueStore.get(id);
+        if (!item) {
+          ctx.ui.notify(`No unique queue item matches ${id}`, "warning");
+          return;
+        }
+        try {
+          const target = resolveCommandTarget(ctx, spec);
+          queueStore.update(item.id, { target });
+          ctx.ui.notify(`Retargeted ${item.id}`, "info");
+          requestQueueRender();
+        } catch (error) {
+          ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+        }
+        return;
+      }
+
+      ctx.ui.notify("Usage: /queue [send|retry|clear|target|alias]", "info");
+    },
+  });
 
   // Command to toggle/configure
   pi.registerCommand("powerline", {
@@ -1768,6 +2188,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           ctx.ui.setWidget("powerline-secondary", undefined);
           ctx.ui.setWidget("powerline-bash-transcript", undefined);
           ctx.ui.setWidget("powerline-status", undefined);
+          ctx.ui.setWidget("powerline-queue-preview", undefined);
           ctx.ui.setWidget("powerline-last-prompt", undefined);
           footerDataRef = null;
           tuiRef = null;
@@ -2025,6 +2446,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       : false;
 
     const thinkingLevel = currentThinkingLevel ?? thinkingLevelFromSession ?? getThinkingLevelFn?.() ?? "off";
+    const queueSummary = queueStore.summarize(getQueueContext(ctx), powerlineCompacting);
 
     return {
       model: ctx.model,
@@ -2038,6 +2460,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       autoCompactEnabled: ctx.settingsManager?.getCompactionSettings?.()?.enabled ?? true,
       customCompactionEnabled: customCompactionEnabled || extensionStatuses.has(CUSTOM_COMPACTION_STATUS_KEY),
       usingSubscription,
+      queueSummary,
       sessionStartTime,
       shellModeActive: bashModeActive,
       shellRunning: shellSession?.state.running ?? false,
@@ -2130,6 +2553,17 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     return layout.secondaryContent ? [layout.secondaryContent] : [];
   }
 
+  function renderPowerlineQueuePreviewLines(width: number, theme: Theme): string[] {
+    if (!currentCtx) return [];
+    const summary = queueStore.summarize(getQueueContext(currentCtx), powerlineCompacting);
+    if (!summary.leadingText) return [];
+
+    const prefix = summary.blockedCount > 0 ? "blocked: " : "queued: ";
+    const text = `${prefix}${summary.leadingText.replace(/\s+/g, " ").trim()}`;
+    const color = summary.blockedCount > 0 ? "warning" : "dim";
+    return [` ${theme.fg(color, truncateToWidth(text, Math.max(1, width - 1), "…"))}`];
+  }
+
   function renderBashTranscriptLines(width: number, theme: Theme): string[] {
     if (!bashModeActive) return [];
 
@@ -2217,6 +2651,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       },
     }), { placement: "belowEditor" });
 
+    ctx.ui.setWidget("powerline-queue-preview", (_tui: any, theme: Theme) => ({
+      dispose() {},
+      invalidate() {},
+      render(width: number): string[] {
+        return renderPowerlineQueuePreviewLines(width, theme);
+      },
+    }), { placement: "belowEditor" });
+
     ctx.ui.setWidget("powerline-last-prompt", () => ({
       dispose() {},
       invalidate() {},
@@ -2261,6 +2703,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     ctx.ui.setWidget("powerline-secondary", undefined);
     ctx.ui.setWidget("powerline-bash-transcript", undefined);
     ctx.ui.setWidget("powerline-status", undefined);
+    ctx.ui.setWidget("powerline-queue-preview", undefined);
     ctx.ui.setWidget("powerline-last-prompt", undefined);
 
     let autocompleteFixed = false;
@@ -2344,6 +2787,22 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       const originalHandleInput = editor.handleInput.bind(editor);
       editor.handleInput = (data: string) => {
         lastEditorInputAt = Date.now();
+
+        const isSubmit = keybindings.matches(data, "tui.input.submit") && !keybindings.matches(data, "tui.input.newLine");
+        const isFollowUpSubmit = keybindings.matches(data, "app.message.followUp");
+        if (powerlineCompacting && !bashModeActive && (isSubmit || isFollowUpSubmit)) {
+          const text = editor.getExpandedText().trim();
+          if (!text) return;
+          if (text.startsWith("/")) {
+            originalHandleInput(data);
+            return;
+          }
+          editor.addToHistory?.(text);
+          editor.setText("");
+          capturePostCompactPrompt(ctx, text);
+          scheduleDismissWelcome(ctx);
+          return;
+        }
 
         if (isStashShortcutInput(data)) {
           stashOrRestoreEditorText(ctx);

--- a/index.ts
+++ b/index.ts
@@ -1625,7 +1625,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const errorMessage = event.errorMessage || (event.aborted ? "Compaction cancelled" : "Compaction did not complete");
     if (event.aborted || !event.result) {
       blockPostCompactionQueue(ctx, errorMessage);
-    } else {
+    } else if (!event.willRetry) {
       schedulePostCompactionDelivery(ctx);
     }
     requestQueueRender();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "*.md",
     "*.json",
     "!progress.md",
-    "bash-mode/**/*.ts"
+    "bash-mode/**/*.ts",
+    "queue/**/*.ts"
   ],
   "keywords": [
     "pi-package",

--- a/presets.ts
+++ b/presets.ts
@@ -23,7 +23,7 @@ const NERD_COLORS: ColorScheme = {
 
 export const PRESETS: Record<StatusLinePreset, PresetDef> = {
   default: {
-    leftSegments: ["model", "thinking", "shell_mode", "path", "git", "context_pct", "cache_read", "cost"],
+    leftSegments: ["model", "thinking", "shell_mode", "path", "git", "queue", "context_pct", "cache_read", "cost"],
     rightSegments: [],
     secondarySegments: ["extension_statuses"],
     separator: "powerline-thin",
@@ -48,7 +48,7 @@ export const PRESETS: Record<StatusLinePreset, PresetDef> = {
 
   compact: {
     leftSegments: ["model", "shell_mode", "git"],
-    rightSegments: ["cost", "context_pct"],
+    rightSegments: ["queue", "cost", "context_pct"],
     separator: "powerline-thin",
     colors: DEFAULT_COLORS,
     segmentOptions: {
@@ -58,7 +58,7 @@ export const PRESETS: Record<StatusLinePreset, PresetDef> = {
   },
 
   full: {
-    leftSegments: ["hostname", "model", "thinking", "shell_mode", "path", "git", "subagents"],
+    leftSegments: ["hostname", "model", "thinking", "shell_mode", "path", "git", "queue", "subagents"],
     rightSegments: ["token_in", "token_out", "cache_read", "cost", "context_pct", "time_spent", "time", "extension_statuses"],
     separator: "powerline",
     colors: DEFAULT_COLORS,
@@ -71,7 +71,7 @@ export const PRESETS: Record<StatusLinePreset, PresetDef> = {
   },
 
   nerd: {
-    leftSegments: ["hostname", "model", "thinking", "shell_mode", "path", "git", "session", "subagents"],
+    leftSegments: ["hostname", "model", "thinking", "shell_mode", "path", "git", "queue", "session", "subagents"],
     rightSegments: ["token_in", "token_out", "cache_read", "cache_write", "cost", "context_pct", "context_total", "time_spent", "time", "extension_statuses"],
     separator: "powerline",
     colors: NERD_COLORS,
@@ -85,7 +85,7 @@ export const PRESETS: Record<StatusLinePreset, PresetDef> = {
 
   ascii: {
     leftSegments: ["model", "shell_mode", "path", "git"],
-    rightSegments: ["token_total", "cost", "context_pct"],
+    rightSegments: ["queue", "token_total", "cost", "context_pct"],
     separator: "ascii",
     colors: MINIMAL_COLORS,
     segmentOptions: {

--- a/queue/store.ts
+++ b/queue/store.ts
@@ -1,0 +1,322 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import { getAgentPath } from "../paths.ts";
+import type {
+  CreateQueueItemInput,
+  PowerlineQueueItem,
+  QueueAliasMap,
+  QueueContext,
+  QueueIntent,
+  QueueStatus,
+  QueueSummary,
+  QueueTarget,
+} from "./types.ts";
+import { ACTIVE_QUEUE_STATUSES } from "./types.ts";
+
+const STORE_DIR = "powerline-footer";
+const INBOX_FILE = "inbox.jsonl";
+const ALIASES_FILE = "projects.json";
+const LOCK_RETRY_MS = 25;
+const LOCK_TIMEOUT_MS = 2000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeCwd(cwd: string): string {
+  return resolve(cwd);
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeTarget(value: unknown): QueueTarget | null {
+  if (!isRecord(value)) return null;
+  if (value.kind === "current-session") return { kind: "current-session" };
+  if (value.kind === "global") return { kind: "global" };
+  if (value.kind === "project" && typeof value.cwd === "string" && value.cwd.trim()) {
+    const alias = normalizeOptionalString(value.alias);
+    return alias
+      ? { kind: "project", cwd: normalizeCwd(value.cwd), alias }
+      : { kind: "project", cwd: normalizeCwd(value.cwd) };
+  }
+  return null;
+}
+
+function normalizeIntent(value: unknown): QueueIntent | null {
+  return value === "steer" || value === "follow-up" || value === "post-compact" || value === "idea"
+    ? value
+    : null;
+}
+
+function normalizeStatus(value: unknown): QueueStatus | null {
+  return value === "queued" || value === "blocked" || value === "delivering" || value === "sent" || value === "failed"
+    ? value
+    : null;
+}
+
+function normalizeItem(value: unknown): PowerlineQueueItem | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.id !== "string" || !value.id.trim()) return null;
+  if (typeof value.text !== "string" || !value.text.trim()) return null;
+  if (typeof value.createdAt !== "number" || !Number.isFinite(value.createdAt)) return null;
+  if (typeof value.updatedAt !== "number" || !Number.isFinite(value.updatedAt)) return null;
+  if (!isRecord(value.source) || typeof value.source.cwd !== "string" || !value.source.cwd.trim()) return null;
+
+  const target = normalizeTarget(value.target);
+  const intent = normalizeIntent(value.intent);
+  const status = normalizeStatus(value.status);
+  if (!target || !intent || !status) return null;
+
+  const sessionId = normalizeOptionalString(value.source.sessionId);
+  const error = normalizeOptionalString(value.error);
+
+  return {
+    id: value.id.trim(),
+    text: value.text,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+    source: sessionId
+      ? { cwd: normalizeCwd(value.source.cwd), sessionId }
+      : { cwd: normalizeCwd(value.source.cwd) },
+    target,
+    intent,
+    status,
+    ...(error ? { error } : {}),
+  };
+}
+
+function readJsonObject(path: string): Record<string, unknown> {
+  if (!existsSync(path)) return {};
+  const parsed = JSON.parse(readFileSync(path, "utf-8"));
+  return isRecord(parsed) ? parsed : {};
+}
+
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+export function getQueueStorePaths(): { inboxPath: string; aliasesPath: string } {
+  return {
+    inboxPath: getAgentPath(STORE_DIR, INBOX_FILE),
+    aliasesPath: getAgentPath(STORE_DIR, ALIASES_FILE),
+  };
+}
+
+export function createQueueItem(input: CreateQueueItemInput): PowerlineQueueItem {
+  const now = input.now ?? Date.now();
+  const sourceSessionId = input.source.sessionId?.trim();
+  return {
+    id: randomUUID().slice(0, 8),
+    text: input.text,
+    createdAt: now,
+    updatedAt: now,
+    source: sourceSessionId
+      ? { cwd: normalizeCwd(input.source.cwd), sessionId: sourceSessionId }
+      : { cwd: normalizeCwd(input.source.cwd) },
+    target: normalizeTarget(input.target) ?? input.target,
+    intent: input.intent,
+    status: input.status ?? "queued",
+  };
+}
+
+export class PowerlineQueueStore {
+  private readonly inboxPath: string;
+  private readonly aliasesPath: string;
+
+  constructor(inboxPath: string = getQueueStorePaths().inboxPath, aliasesPath: string = getQueueStorePaths().aliasesPath) {
+    this.inboxPath = inboxPath;
+    this.aliasesPath = aliasesPath;
+  }
+
+  list(): PowerlineQueueItem[] {
+    if (!existsSync(this.inboxPath)) return [];
+    const lines = readFileSync(this.inboxPath, "utf-8").split("\n");
+    const items: PowerlineQueueItem[] = [];
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const item = normalizeItem(JSON.parse(trimmed));
+        if (item) items.push(item);
+      } catch {
+        // Ignore malformed internal lines rather than breaking the footer during startup.
+      }
+    }
+    return items.sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  add(input: CreateQueueItemInput): PowerlineQueueItem {
+    const item = createQueueItem(input);
+    return this.withStoreLock(() => {
+      this.writeItems([...this.list(), item]);
+      return item;
+    });
+  }
+
+  get(idPrefix: string): PowerlineQueueItem | null {
+    const normalized = idPrefix.trim();
+    if (!normalized) return null;
+    const matches = this.list().filter((item) => item.id === normalized || item.id.startsWith(normalized));
+    return matches.length === 1 ? matches[0] : null;
+  }
+
+  update(id: string, updates: Partial<Omit<PowerlineQueueItem, "id" | "createdAt">>): PowerlineQueueItem | null {
+    return this.withStoreLock(() => {
+      let updated: PowerlineQueueItem | null = null;
+      const next = this.list().map((item) => {
+        if (item.id !== id) return item;
+        updated = {
+          ...item,
+          ...updates,
+          updatedAt: updates.updatedAt ?? Date.now(),
+        };
+        return updated;
+      });
+      if (updated) this.writeItems(next);
+      return updated;
+    });
+  }
+
+  clear(id: string): PowerlineQueueItem | null {
+    return this.update(id, { status: "sent", error: undefined });
+  }
+
+  activeItems(context: QueueContext): PowerlineQueueItem[] {
+    return this.list().filter((item) => isActiveForContext(item, context));
+  }
+
+  queuedDeliveryItems(context: QueueContext, intent?: QueueIntent): PowerlineQueueItem[] {
+    return this.activeItems(context).filter((item) => {
+      if (item.status !== "queued") return false;
+      if (item.intent === "idea") return false;
+      return intent ? item.intent === intent : true;
+    });
+  }
+
+  summarize(context: QueueContext, compacting: boolean): QueueSummary {
+    const active = this.activeItems(context);
+    const queueItems = active.filter((item) => item.intent !== "idea");
+    const ideaItems = active.filter((item) => item.intent === "idea");
+    const blockedItems = active.filter((item) => item.status === "blocked" || item.status === "failed");
+    const leading = [...blockedItems, ...queueItems, ...ideaItems][0] ?? null;
+
+    return {
+      queueCount: queueItems.length,
+      ideaCount: ideaItems.length,
+      blockedCount: blockedItems.length,
+      compacting,
+      leadingText: leading?.text ?? null,
+    };
+  }
+
+  readAliases(): QueueAliasMap {
+    const parsed = readJsonObject(this.aliasesPath);
+    const aliases: QueueAliasMap = {};
+    for (const [alias, cwd] of Object.entries(parsed)) {
+      if (/^[a-zA-Z0-9_-]+$/.test(alias) && typeof cwd === "string" && cwd.trim()) {
+        aliases[alias] = normalizeCwd(cwd);
+      }
+    }
+    return aliases;
+  }
+
+  setAlias(alias: string, cwd: string): QueueAliasMap {
+    const normalizedAlias = alias.trim();
+    if (!/^[a-zA-Z0-9_-]+$/.test(normalizedAlias)) {
+      throw new Error("Alias must contain only letters, numbers, dashes, or underscores");
+    }
+    return this.withStoreLock(() => {
+      const aliases = { ...this.readAliases(), [normalizedAlias]: normalizeCwd(cwd) };
+      this.writeJson(this.aliasesPath, aliases);
+      return aliases;
+    });
+  }
+
+  resolveAlias(alias: string): string | null {
+    return this.readAliases()[alias] ?? null;
+  }
+
+  private withStoreLock<T>(fn: () => T): T {
+    mkdirSync(dirname(this.inboxPath), { recursive: true });
+    const lockPath = `${this.inboxPath}.lock`;
+    const startedAt = Date.now();
+
+    while (true) {
+      try {
+        mkdirSync(lockPath);
+        break;
+      } catch (error) {
+        const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+        if (code !== "EEXIST") throw error;
+
+        if (Date.now() - startedAt >= LOCK_TIMEOUT_MS) {
+          throw new Error("Timed out waiting for Powerline queue store lock");
+        }
+        sleepSync(LOCK_RETRY_MS);
+      }
+    }
+
+    try {
+      return fn();
+    } finally {
+      rmSync(lockPath, { recursive: true, force: true });
+    }
+  }
+
+  private writeItems(items: readonly PowerlineQueueItem[]): void {
+    mkdirSync(dirname(this.inboxPath), { recursive: true });
+    const activeOrRecent = items
+      .filter((item) => item.status !== "sent" || Date.now() - item.updatedAt < 24 * 60 * 60 * 1000)
+      .map((item) => JSON.stringify(item))
+      .join("\n");
+    this.writeAtomic(this.inboxPath, activeOrRecent ? `${activeOrRecent}\n` : "");
+  }
+
+  private writeJson(path: string, value: unknown): void {
+    mkdirSync(dirname(path), { recursive: true });
+    this.writeAtomic(path, `${JSON.stringify(value, null, 2)}\n`);
+  }
+
+  private writeAtomic(path: string, content: string): void {
+    const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+    writeFileSync(tempPath, content, "utf-8");
+    renameSync(tempPath, path);
+  }
+}
+
+export function currentQueueContext(cwd: string, sessionId?: string): QueueContext {
+  return sessionId?.trim()
+    ? { cwd: normalizeCwd(cwd), sessionId: sessionId.trim() }
+    : { cwd: normalizeCwd(cwd) };
+}
+
+export function isActiveForContext(item: PowerlineQueueItem, context: QueueContext): boolean {
+  if (!ACTIVE_QUEUE_STATUSES.has(item.status)) return false;
+  const currentCwd = normalizeCwd(context.cwd);
+  if (item.target.kind === "global") return true;
+  if (item.target.kind === "project") return normalizeCwd(item.target.cwd) === currentCwd;
+  if (item.source.sessionId) return context.sessionId === item.source.sessionId;
+  return item.source.cwd === currentCwd;
+}
+
+export function targetForIdea(rawTarget: string | null, store: PowerlineQueueStore, cwd: string): QueueTarget {
+  if (!rawTarget) return { kind: "project", cwd: normalizeCwd(cwd) };
+  if (rawTarget === "current") return { kind: "current-session" };
+  if (rawTarget === "global") return { kind: "global" };
+
+  const aliasCwd = store.resolveAlias(rawTarget);
+  if (!aliasCwd) {
+    throw new Error(`Unknown project alias @${rawTarget}. Use /queue alias ${rawTarget} <path> first.`);
+  }
+  return { kind: "project", cwd: aliasCwd, alias: rawTarget };
+}
+
+export function parseTargetPrefix(text: string): { target: string | null; text: string } {
+  const trimmed = text.trim();
+  const match = /^@([a-zA-Z0-9_-]+)(?:\s+|$)/.exec(trimmed);
+  if (!match) return { target: null, text: trimmed };
+  return { target: match[1], text: trimmed.slice(match[0].length).trim() };
+}

--- a/queue/types.ts
+++ b/queue/types.ts
@@ -1,0 +1,52 @@
+export type QueueIntent = "steer" | "follow-up" | "post-compact" | "idea";
+export type QueueStatus = "queued" | "blocked" | "delivering" | "sent" | "failed";
+
+export type QueueTarget =
+  | { kind: "current-session" }
+  | { kind: "project"; cwd: string; alias?: string }
+  | { kind: "global" };
+
+export interface QueueSource {
+  cwd: string;
+  sessionId?: string;
+}
+
+export interface PowerlineQueueItem {
+  id: string;
+  text: string;
+  createdAt: number;
+  updatedAt: number;
+  source: QueueSource;
+  target: QueueTarget;
+  intent: QueueIntent;
+  status: QueueStatus;
+  error?: string;
+}
+
+export interface QueueAliasMap {
+  [alias: string]: string;
+}
+
+export interface QueueSummary {
+  queueCount: number;
+  ideaCount: number;
+  blockedCount: number;
+  compacting: boolean;
+  leadingText: string | null;
+}
+
+export interface CreateQueueItemInput {
+  text: string;
+  source: QueueSource;
+  target: QueueTarget;
+  intent: QueueIntent;
+  status?: QueueStatus;
+  now?: number;
+}
+
+export interface QueueContext {
+  cwd: string;
+  sessionId?: string;
+}
+
+export const ACTIVE_QUEUE_STATUSES = new Set<QueueStatus>(["queued", "blocked", "delivering", "failed"]);

--- a/segments.ts
+++ b/segments.ts
@@ -245,6 +245,31 @@ const subagentsSegment: StatusLineSegment = {
   },
 };
 
+const queueSegment: StatusLineSegment = {
+  id: "queue",
+  render(ctx) {
+    const summary = ctx.queueSummary;
+    const parts: string[] = [];
+
+    if (summary.compacting && summary.queueCount > 0) {
+      parts.push(`compact q ${summary.queueCount}`);
+    } else if (summary.queueCount > 0) {
+      parts.push(`q ${summary.queueCount}`);
+    }
+
+    if (summary.ideaCount > 0) {
+      parts.push(`ideas ${summary.ideaCount}`);
+    }
+
+    if (summary.blockedCount > 0) {
+      parts.push(`blocked ${summary.blockedCount}`);
+    }
+
+    if (parts.length === 0) return { content: "", visible: false };
+    return { content: color(ctx, "queue", parts.join(SEP_DOT)), visible: true };
+  },
+};
+
 const tokenInSegment: StatusLineSegment = {
   id: "token_in",
   render(ctx) {
@@ -489,6 +514,7 @@ export const SEGMENTS: Record<BuiltinStatusLineSegmentId, StatusLineSegment> = {
   git: gitSegment,
   thinking: thinkingSegment,
   subagents: subagentsSegment,
+  queue: queueSegment,
   token_in: tokenInSegment,
   token_out: tokenOutSegment,
   token_total: tokenTotalSegment,

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -43,6 +43,7 @@ test("parsePowerlineConfig supports disabled segments", () => {
       preset: "default",
       customItems: [{ id: "ci" }],
       disabledSegments: [
+        "queue",
         "cost",
         " extension_statuses ",
         "custom:ci",
@@ -55,7 +56,7 @@ test("parsePowerlineConfig supports disabled segments", () => {
     ["default", "compact"],
   );
 
-  assert.deepEqual(config.disabledSegments, ["cost", "extension_statuses", "custom:ci"]);
+  assert.deepEqual(config.disabledSegments, ["queue", "cost", "extension_statuses", "custom:ci"]);
   assert.deepEqual(config.invalidDisabledSegments, ["unknown", "custom:missing", "123"]);
 });
 

--- a/tests/queue-store.test.ts
+++ b/tests/queue-store.test.ts
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { PowerlineQueueStore, currentQueueContext, parseTargetPrefix, targetForIdea } from "../queue/store.ts";
+
+function withStore(fn: (store: PowerlineQueueStore, dir: string) => void): void {
+  const dir = mkdtempSync(join(tmpdir(), "powerline-queue-"));
+  try {
+    fn(new PowerlineQueueStore(join(dir, "inbox.jsonl"), join(dir, "projects.json")), dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("queue store adds active project ideas and summarizes them", () => withStore((store) => {
+  const cwd = "/tmp/project-a";
+  store.add({
+    text: "remember deploy note",
+    source: { cwd, sessionId: "s1" },
+    target: { kind: "project", cwd },
+    intent: "idea",
+    now: 100,
+  });
+  store.add({
+    text: "run after compact",
+    source: { cwd, sessionId: "s1" },
+    target: { kind: "current-session" },
+    intent: "post-compact",
+    now: 101,
+  });
+
+  assert.equal(store.list().length, 2);
+  assert.deepEqual(store.summarize(currentQueueContext(cwd, "s1"), true), {
+    queueCount: 1,
+    ideaCount: 1,
+    blockedCount: 0,
+    compacting: true,
+    leadingText: "run after compact",
+  });
+}));
+
+test("queue store filters inactive project items", () => withStore((store) => {
+  store.add({
+    text: "other project",
+    source: { cwd: "/tmp/project-a" },
+    target: { kind: "project", cwd: "/tmp/project-a" },
+    intent: "idea",
+  });
+
+  assert.equal(store.activeItems(currentQueueContext("/tmp/project-b")).length, 0);
+  assert.equal(store.activeItems(currentQueueContext("/tmp/project-a")).length, 1);
+}));
+
+test("current-session targets stay scoped to the source session when known", () => withStore((store) => {
+  store.add({
+    text: "session only",
+    source: { cwd: "/tmp/project", sessionId: "s1" },
+    target: { kind: "current-session" },
+    intent: "post-compact",
+  });
+
+  assert.equal(store.activeItems(currentQueueContext("/tmp/project", "s1")).length, 1);
+  assert.equal(store.activeItems(currentQueueContext("/tmp/project", "s2")).length, 0);
+}));
+
+test("queue store aliases resolve idea targets", () => withStore((store) => {
+  store.setAlias("pika", "/tmp/pika");
+
+  assert.deepEqual(targetForIdea("pika", store, "/tmp/current"), {
+    kind: "project",
+    cwd: "/tmp/pika",
+    alias: "pika",
+  });
+  assert.deepEqual(targetForIdea("global", store, "/tmp/current"), { kind: "global" });
+  assert.deepEqual(targetForIdea("current", store, "/tmp/current"), { kind: "current-session" });
+  assert.throws(() => targetForIdea("missing", store, "/tmp/current"), /Unknown project alias/);
+}));
+
+test("parseTargetPrefix separates optional @target", () => {
+  assert.deepEqual(parseTargetPrefix("@pika check logs"), { target: "pika", text: "check logs" });
+  assert.deepEqual(parseTargetPrefix("plain idea"), { target: null, text: "plain idea" });
+});
+
+test("queue store clears items from active summary", () => withStore((store) => {
+  const item = store.add({
+    text: "queued prompt",
+    source: { cwd: "/tmp/project" },
+    target: { kind: "current-session" },
+    intent: "post-compact",
+  });
+
+  assert.equal(store.summarize(currentQueueContext("/tmp/project"), false).queueCount, 1);
+  store.clear(item.id);
+  assert.equal(store.summarize(currentQueueContext("/tmp/project"), false).queueCount, 0);
+}));
+
+test("queue store times out instead of stealing an existing lock", () => withStore((store, dir) => {
+  const lockPath = join(dir, "inbox.jsonl.lock");
+  mkdirSync(lockPath);
+
+  assert.throws(() => store.add({
+    text: "blocked write",
+    source: { cwd: "/tmp/project" },
+    target: { kind: "project", cwd: "/tmp/project" },
+    intent: "idea",
+  }), /Timed out waiting for Powerline queue store lock/);
+  assert.equal(existsSync(lockPath), true);
+}));

--- a/tests/usage-display.test.ts
+++ b/tests/usage-display.test.ts
@@ -41,6 +41,7 @@ function createSegmentContext(options: StatusLineSegmentOptions = {}, overrides:
     autoCompactEnabled: true,
     customCompactionEnabled: false,
     usingSubscription: false,
+    queueSummary: { queueCount: 0, ideaCount: 0, blockedCount: 0, compacting: false, leadingText: null },
     sessionStartTime: Date.now(),
     shellModeActive: false,
     shellRunning: false,
@@ -124,6 +125,29 @@ test("cache_read percent format handles zero total without NaN", () => {
   // cacheRead = 0 hides the segment entirely in both formats
   const hidden = createSegmentContext({ cache_read: { format: "percent" } });
   assert.deepEqual(renderSegment("cache_read", hidden), { content: "", visible: false });
+});
+
+// ── queue segment ──────────────────────────────────────────────────────────
+
+test("queue segment hides when empty", () => {
+  const ctx = createSegmentContext();
+  assert.deepEqual(renderSegment("queue", ctx), { content: "", visible: false });
+});
+
+test("queue segment summarizes queued ideas and blocked items", () => {
+  const ctx = createSegmentContext({}, {
+    queueSummary: { queueCount: 2, ideaCount: 3, blockedCount: 1, compacting: false, leadingText: "fix README" },
+  });
+
+  assert.equal(stripAnsi(renderSegment("queue", ctx).content), "q 2 · ideas 3 · blocked 1");
+});
+
+test("queue segment highlights compaction-held prompts", () => {
+  const ctx = createSegmentContext({}, {
+    queueSummary: { queueCount: 1, ideaCount: 0, blockedCount: 0, compacting: true, leadingText: "run after compact" },
+  });
+
+  assert.equal(stripAnsi(renderSegment("queue", ctx).content), "compact q 1");
 });
 
 // ── config parsing / merging ────────────────────────────────────────────────

--- a/theme.ts
+++ b/theme.ts
@@ -35,6 +35,7 @@ const DEFAULT_COLORS: Required<ColorScheme> = {
   contextError: "error",
   cost: "text",
   tokens: "muted",
+  queue: "accent",
   separator: "dim",
   border: "borderMuted",
 };

--- a/types.ts
+++ b/types.ts
@@ -21,6 +21,7 @@ export type SemanticColor =
   | "contextError"
   | "cost"
   | "tokens"
+  | "queue"
   | "separator"
   | "border";
 
@@ -34,6 +35,7 @@ export const BUILTIN_STATUS_LINE_SEGMENT_IDS = [
   "path",
   "git",
   "subagents",
+  "queue",
   "token_in",
   "token_out",
   "token_total",
@@ -152,6 +154,14 @@ export interface GitStatus {
 }
 
 // Usage statistics
+export interface QueueSummary {
+  queueCount: number;
+  ideaCount: number;
+  blockedCount: number;
+  compacting: boolean;
+  leadingText: string | null;
+}
+
 export interface UsageStats {
   input: number;
   output: number;
@@ -186,6 +196,7 @@ export interface SegmentContext {
   autoCompactEnabled: boolean;
   customCompactionEnabled: boolean;
   usingSubscription: boolean;
+  queueSummary: QueueSummary;
   sessionStartTime: number;
   shellModeActive: boolean;
   shellRunning: boolean;


### PR DESCRIPTION
## Summary

Adds a durable Powerline-owned queue and idea inbox for capturing prompts without interrupting the current agent. The footer now surfaces queued, idea, blocked, and compaction-held items, while `/idea`, `/ideas`, and `/queue` manage capture, aliases, retargeting, retry, send, edit, and clear flows.

The implementation also captures non-slash editor submissions during compaction and delivers them after successful compaction. Failed or cancelled compactions keep queued prompts blocked and visible instead of dropping them into Pi's fragile native compaction queue.

## Validation

- `npm test`
- `node --experimental-strip-types --check index.ts`
- `node --experimental-strip-types --check queue/store.ts`
- `git --no-pager diff --check`
- `npm pack --dry-run --json`
