### PR TITLE
Queue prompt text passed to /compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- **Powerline Queue + Inbox** — Added a file-backed queue and idea inbox for capturing thoughts without interrupting the current agent. Messages submitted during compaction are held by Powerline and delivered after successful compaction, while failed or cancelled compactions leave them blocked and visible. New `/idea`, `/ideas`, and `/queue` commands manage captured ideas, queued prompts, project aliases, retries, clears, and current-session delivery; the `queue` segment and preview row surface active queue, idea, and blocked counts.
+- **Powerline Queue + Inbox** — Added a file-backed queue and idea inbox for capturing thoughts without interrupting the current agent. Messages submitted during compaction are held by Powerline and delivered after successful compaction, while failed or cancelled compactions leave them blocked and visible. `/compact <text>` now compacts and queues `<text>` as the next prompt instead of treating it as compaction-summary instructions. New `/idea`, `/ideas`, and `/queue` commands manage captured ideas, queued prompts, project aliases, retries, clears, and current-session delivery; the `queue` segment and preview row surface active queue, idea, and blocked counts.
 
 ## [0.10.0] - 2026-08-02
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Use `/cd <path>` to continue the current conversation from another working direc
 
 Powerline Queue + Inbox commands:
 
+- `/compact <text>` — compact now and queue `<text>` as the next prompt after successful compaction
 - `/idea <text>` — capture an idea for the current project without sending it to the agent
 - `/idea @global <text>` — capture a global idea
 - `/idea @current <text>` — capture an idea targeted to the current session

--- a/index.ts
+++ b/index.ts
@@ -63,7 +63,7 @@ import {
   generateVibesBatch,
   parseVibeGenerateArgs,
 } from "./working-vibes.ts";
-import { PowerlineQueueStore, currentQueueContext, parseTargetPrefix, targetForIdea } from "./queue/store.ts";
+import { PowerlineQueueStore, currentQueueContext, parseCompactQueuedPrompt, parseTargetPrefix, targetForIdea } from "./queue/store.ts";
 import type { PowerlineQueueItem, QueueIntent, QueueTarget } from "./queue/types.ts";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -2790,6 +2790,20 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
         const isSubmit = keybindings.matches(data, "tui.input.submit") && !keybindings.matches(data, "tui.input.newLine");
         const isFollowUpSubmit = keybindings.matches(data, "app.message.followUp");
+        if (!powerlineCompacting && !bashModeActive && isSubmit && typeof ctx.compact === "function") {
+          const compactQueuedPrompt = parseCompactQueuedPrompt(editor.getExpandedText());
+          if (compactQueuedPrompt) {
+            editor.addToHistory?.(editor.getExpandedText().trim());
+            editor.setText("");
+            capturePostCompactPrompt(ctx, compactQueuedPrompt);
+            ctx.compact({
+              onError: (error: Error) => ctx.ui.notify(error.message, "error"),
+            });
+            scheduleDismissWelcome(ctx);
+            return;
+          }
+        }
+
         if (powerlineCompacting && !bashModeActive && (isSubmit || isFollowUpSubmit)) {
           const text = editor.getExpandedText().trim();
           if (!text) return;

--- a/queue/store.ts
+++ b/queue/store.ts
@@ -320,3 +320,12 @@ export function parseTargetPrefix(text: string): { target: string | null; text: 
   if (!match) return { target: null, text: trimmed };
   return { target: match[1], text: trimmed.slice(match[0].length).trim() };
 }
+
+export function parseCompactQueuedPrompt(text: string): string | null {
+  const trimmed = text.trim();
+  const match = /^\/compact\s+(.+)$/.exec(trimmed);
+  if (!match) return null;
+
+  const prompt = match[1].trim();
+  return prompt ? prompt : null;
+}

--- a/tests/queue-store.test.ts
+++ b/tests/queue-store.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { PowerlineQueueStore, currentQueueContext, parseTargetPrefix, targetForIdea } from "../queue/store.ts";
+import { PowerlineQueueStore, currentQueueContext, parseCompactQueuedPrompt, parseTargetPrefix, targetForIdea } from "../queue/store.ts";
 
 function withStore(fn: (store: PowerlineQueueStore, dir: string) => void): void {
   const dir = mkdtempSync(join(tmpdir(), "powerline-queue-"));
@@ -81,6 +81,15 @@ test("queue store aliases resolve idea targets", () => withStore((store) => {
 test("parseTargetPrefix separates optional @target", () => {
   assert.deepEqual(parseTargetPrefix("@pika check logs"), { target: "pika", text: "check logs" });
   assert.deepEqual(parseTargetPrefix("plain idea"), { target: null, text: "plain idea" });
+});
+
+test("parseCompactQueuedPrompt treats /compact suffix as queued prompt text", () => {
+  assert.equal(parseCompactQueuedPrompt("/compact great lets proceed"), "great lets proceed");
+  assert.equal(parseCompactQueuedPrompt("  /compact   great lets proceed  "), "great lets proceed");
+  assert.equal(parseCompactQueuedPrompt("/compact\tgreat lets proceed"), "great lets proceed");
+  assert.equal(parseCompactQueuedPrompt("/compact"), null);
+  assert.equal(parseCompactQueuedPrompt("/compact   "), null);
+  assert.equal(parseCompactQueuedPrompt("/compactness great lets proceed"), null);
 });
 
 test("queue store clears items from active summary", () => withStore((store) => {


### PR DESCRIPTION
## Summary

Treat `/compact <text>` as a compact-and-queue shorthand in Powerline's custom editor. The suffix is captured as a post-compaction queued prompt, the editor is cleared, and manual compaction is started without passing the suffix as compaction-summary instructions.

This makes `/compact great lets proceed` compact the session first, then send `great lets proceed` after successful compaction. Failed or cancelled compactions keep the queued prompt blocked through the existing queue handling.

## Validation

- `node --experimental-strip-types --test tests/queue-store.test.ts`
- `node --experimental-strip-types --check index.ts`
- `node --experimental-strip-types --check queue/store.ts`
- `git --no-pager diff --check`
- `npm test`
- `npm pack --dry-run --json`
