### PR TITLE
Add combined cache-read display format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - **Powerline Queue + Inbox** — Added a file-backed queue and idea inbox for capturing thoughts without interrupting the current agent. Messages submitted during compaction are held by Powerline and delivered after successful compaction, while failed or cancelled compactions leave them blocked and visible. `/compact <text>` now compacts and queues `<text>` as the next prompt instead of treating it as compaction-summary instructions. New `/idea`, `/ideas`, and `/queue` commands manage captured ideas, queued prompts, project aliases, retries, clears, and current-session delivery; the `queue` segment and preview row surface active queue, idea, and blocked counts.
+- **Combined cache-read format** — Added opt-in `powerline.cache_read.format: "both"` to show raw cache-read tokens alongside the cache hit rate, for example `cache in: 12k (80%)`. Thanks to e (@edabchann) for #136.
 
 ## [0.10.0] - 2026-08-02
 

--- a/README.md
+++ b/README.md
@@ -214,13 +214,13 @@ Segment display formats (opt-in; defaults match the historical rendering):
 | Segment option | Values | Default | Effect |
 |---|---|---|---|
 | `"context": { "format" }` | `"full"` / `"percent"` | `"full"` | `"percent"` shows a bare rounded `83%` (threshold-colored, no icon) instead of `12k/200k (6.2%)` |
-| `"cache_read": { "format" }` | `"tokens"` / `"percent"` | `"tokens"` | `"percent"` shows the cache hit rate `cacheRead / (input + cacheRead)` instead of the raw token count |
+| `"cache_read": { "format" }` | `"tokens"` / `"percent"` / `"both"` | `"tokens"` | `"percent"` shows the cache hit rate `cacheRead / (input + cacheRead)` instead of the raw token count; `"both"` shows raw tokens plus the hit rate, e.g. `cache in: 12k (80%)` |
 
 ```json
 {
   "powerline": {
     "context": { "format": "percent" },
-    "cache_read": { "format": "percent" }
+    "cache_read": { "format": "both" }
   }
 }
 ```

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -264,7 +264,9 @@ function normalizeSegmentOptions(raw: Record<string, unknown>): StatusLineSegmen
 
   if (isRecord(raw.cache_read)) {
     options.cache_read = {
-      ...(raw.cache_read.format === "tokens" || raw.cache_read.format === "percent" ? { format: raw.cache_read.format } : {}),
+      ...(raw.cache_read.format === "tokens" || raw.cache_read.format === "percent" || raw.cache_read.format === "both"
+        ? { format: raw.cache_read.format }
+        : {}),
     };
   }
 

--- a/segments.ts
+++ b/segments.ts
@@ -447,17 +447,17 @@ const cacheReadSegment: StatusLineSegment = {
     const { cacheRead, input } = ctx.usageStats;
     if (!cacheRead) return { content: "", visible: false };
 
+    const format = ctx.options.cache_read?.format ?? "tokens";
+    const hitRate = input + cacheRead > 0
+      ? ((cacheRead / (input + cacheRead)) * 100).toFixed(0)
+      : "0";
+
     let content: string;
-    if (ctx.options.cache_read?.format === "percent") {
-      // Cache hit rate: cacheRead / (input + cacheRead)
-      const hitRate = input + cacheRead > 0
-        ? ((cacheRead / (input + cacheRead)) * 100).toFixed(0)
-        : "0";
+    if (format === "percent") {
       content = [icons.cache, `${hitRate}%`].filter(Boolean).join(" ");
     } else {
-      // "tokens" (default): raw cache-read token count
-      const parts = [icons.cache, icons.input, formatTokens(cacheRead)].filter(Boolean);
-      content = parts.join(" ");
+      const tokens = [icons.cache, icons.input, formatTokens(cacheRead)].filter(Boolean).join(" ");
+      content = format === "both" ? `${tokens} (${hitRate}%)` : tokens;
     }
     return { content: color(ctx, "tokens", content), visible: true };
   },

--- a/tests/usage-display.test.ts
+++ b/tests/usage-display.test.ts
@@ -116,14 +116,27 @@ test("cache_read percent format renders the cache hit rate", () => {
   assert.equal(stripAnsi(rendered.content), "cache 80%");
 });
 
-test("cache_read percent format handles zero total without NaN", () => {
-  const ctx = createSegmentContext({ cache_read: { format: "percent" } }, {
+test("cache_read both format renders raw token count and cache hit rate", () => {
+  const ctx = createSegmentContext({ cache_read: { format: "both" } }, {
+    usageStats: { input: 2000, output: 0, cacheRead: 8000, cacheWrite: 0, cost: 0, subagentCost: 0 },
+  });
+
+  const rendered = renderSegment("cache_read", ctx);
+  assert.equal(stripAnsi(rendered.content), "cache in: 8.0k (80%)");
+});
+
+test("cache_read percent and both formats handle zero input without NaN", () => {
+  const percentCtx = createSegmentContext({ cache_read: { format: "percent" } }, {
     usageStats: { input: 0, output: 0, cacheRead: 5, cacheWrite: 0, cost: 0, subagentCost: 0 },
   });
-  assert.equal(stripAnsi(renderSegment("cache_read", ctx).content), "cache 100%");
+  assert.equal(stripAnsi(renderSegment("cache_read", percentCtx).content), "cache 100%");
 
-  // cacheRead = 0 hides the segment entirely in both formats
-  const hidden = createSegmentContext({ cache_read: { format: "percent" } });
+  const bothCtx = createSegmentContext({ cache_read: { format: "both" } }, {
+    usageStats: { input: 0, output: 0, cacheRead: 5, cacheWrite: 0, cost: 0, subagentCost: 0 },
+  });
+  assert.equal(stripAnsi(renderSegment("cache_read", bothCtx).content), "cache in: 5 (100%)");
+
+  const hidden = createSegmentContext({ cache_read: { format: "both" } });
   assert.deepEqual(renderSegment("cache_read", hidden), { content: "", visible: false });
 });
 
@@ -155,11 +168,11 @@ test("queue segment highlights compaction-held prompts", () => {
 test("parsePowerlineConfig accepts context and cache_read formats", () => {
   const config = parsePowerlineConfig({
     context: { format: "percent" },
-    cache_read: { format: "percent" },
+    cache_read: { format: "both" },
   }, PRESET_NAMES);
 
   assert.equal(config.segmentOptions.context?.format, "percent");
-  assert.equal(config.segmentOptions.cache_read?.format, "percent");
+  assert.equal(config.segmentOptions.cache_read?.format, "both");
 });
 
 test("parsePowerlineConfig ignores invalid format values", () => {
@@ -181,9 +194,9 @@ test("parsePowerlineConfig defaults to upstream rendering when options are absen
 test("mergeSegmentOptions merges context and cache_read per key", () => {
   const merged = mergeSegmentOptions(
     { context: { format: "percent" }, cache_read: { format: "percent" } },
-    { context: { format: "full" } },
+    { context: { format: "full" }, cache_read: { format: "both" } },
   );
 
   assert.equal(merged.context?.format, "full");
-  assert.equal(merged.cache_read?.format, "percent");
+  assert.equal(merged.cache_read?.format, "both");
 });

--- a/types.ts
+++ b/types.ts
@@ -101,7 +101,7 @@ export interface StatusLineSegmentOptions {
   time?: { format?: "12h" | "24h"; showSeconds?: boolean };
   cost?: { subscriptionDisplay?: "subscription" | "reported-cost" | "both"; currency?: CostCurrencyCode };
   context?: { format?: "full" | "percent" };
-  cache_read?: { format?: "tokens" | "percent" };
+  cache_read?: { format?: "tokens" | "percent" | "both" };
 }
 
 export type CustomItemPosition = "left" | "right" | "secondary";


### PR DESCRIPTION
## Summary

Replacement for #136 on top of the current `main` branch.

Adds opt-in `powerline.cache_read.format: "both"`, which keeps the raw cache-read token count and appends the cache hit rate, for example:

```text
cache in: 8.0k (80%)
```

The default `tokens` format and existing `percent` format are unchanged.

## Credit

Thanks to e (@edabchann) for the original implementation in #136.

## Validation

- `node --experimental-strip-types --test tests/usage-display.test.ts`
- `node --experimental-strip-types --check segments.ts`
- `node --experimental-strip-types --check powerline-config.ts`
- `git --no-pager diff --check`
- `npm test`
- `npm pack --dry-run --json`
- Fresh read-only review found no issues.
