### PR TITLE
feat: add sigil idea capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - **Powerline Queue + Inbox** — Added a file-backed queue and idea inbox for capturing thoughts without interrupting the current agent. Messages submitted during compaction are held by Powerline and delivered after successful compaction, while failed or cancelled compactions leave them blocked and visible. `/compact <text>` now compacts and queues `<text>` as the next prompt instead of treating it as compaction-summary instructions. New `/idea`, `/ideas`, and `/queue` commands manage captured ideas, queued prompts, project aliases, retries, clears, and current-session delivery; the `queue` segment and preview row surface active queue, idea, and blocked counts.
+- **Sigil idea capture** — Added leading-`#` idea capture so typing `# <idea>` and pressing Enter saves the idea instead of sending it. The sigil is configurable through `powerline.queue.captureSigil`, the editor prompt glyph switches to `#` while drafting a captured idea, stash history entries can be promoted to ideas, and delivered ideas include provenance for orchestrator handoff.
 - **Combined cache-read format** — Added opt-in `powerline.cache_read.format: "both"` to show raw cache-read tokens alongside the cache hit rate, for example `cache in: 12k (80%)`. Thanks to e (@edabchann) for #136.
 
 ## [0.10.0] - 2026-08-02

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Customizes the default [pi](https://github.com/badlogic/pi-mono) editor with a p
 
 **Editor stash** — Press `Alt+S` to save your editor content and clear the editor, type a quick prompt, and your stashed text auto-restores when the agent finishes. Toggles between stash, pop, and update-existing-stash. A `stash` indicator appears in the powerline bar while text is stashed.
 
-**Powerline Queue + Inbox** — Capture thoughts without interrupting the current agent. Messages typed during compaction are held by Powerline and delivered after successful compaction instead of disappearing into Pi's native queue. `/idea`, `/ideas`, and `/queue` provide a file-backed inbox for current-session prompts, project ideas, aliases, retries, clears, and manual delivery. Active queue, idea, and blocked counts appear in the `queue` segment only when there is something to show.
+**Powerline Queue + Inbox** — Capture thoughts without interrupting the current agent. Type `# <idea>` and press Enter to save an idea instead of sending it; `# @global <idea>`, `# @current <idea>`, and `# @alias <idea>` route it. Messages typed during compaction are held by Powerline and delivered after successful compaction instead of disappearing into Pi's native queue. `/idea`, `/ideas`, and `/queue` provide a file-backed inbox for current-session prompts, project ideas, aliases, retries, clears, and manual delivery. Active queue, idea, and blocked counts appear in the `queue` segment only when there is something to show.
 
 **Working Vibes** — AI-generated themed loading messages. Set `/vibe star trek` and your "Working..." becomes "Running diagnostics..." or "Engaging warp drive...". Supports any theme: pirate, zen, noir, cowboy, etc.
 
@@ -51,14 +51,15 @@ Activates automatically. Toggle with `/powerline`, switch presets with `/powerli
 
 Use `/cd <path>` to continue the current conversation from another working directory. It supports relative paths, absolute paths, `~`, `~/...`, and directory completions. With no argument, `/cd` prints the current Pi session directory. The command switches into a cwd-updated session file so Pi tools and the footer path segment agree after the change.
 
-Powerline Queue + Inbox commands:
+Powerline Queue + Inbox commands and capture shortcuts:
 
-- `/compact <text>` — compact now and queue `<text>` as the next prompt after successful compaction
-- `/idea <text>` — capture an idea for the current project without sending it to the agent
-- `/idea @global <text>` — capture a global idea
-- `/idea @current <text>` — capture an idea targeted to the current session
+- `# <text>` — capture an idea for the current project without sending it to the agent
+- `# @global <text>` — capture a global idea
+- `# @current <text>` — capture an idea targeted to the current session
 - `/queue alias <name> [path]` — save a project alias, defaulting to the current cwd when `path` is omitted
-- `/idea @name <text>` — capture an idea for a saved project alias
+- `# @name <text>` — capture an idea for a saved project alias
+- `/compact <text>` — compact now and queue `<text>` as the next prompt after successful compaction
+- `/idea [@target] <text>` — command form of idea capture, useful for scripts and users who disable the sigil
 - `/ideas` — open the captured-ideas picker
 - `/ideas send <id>` — send an idea to the current session
 - `/queue` — open the queued-prompt picker
@@ -66,7 +67,21 @@ Powerline Queue + Inbox commands:
 - `/queue clear <id|all>` — clear queued prompt items
 - `/queue target <id> @name|global|current` — retarget a queued item
 
-Captured data is stored under the Pi agent directory in `powerline-footer/inbox.jsonl` and `powerline-footer/projects.json`.
+The default capture sigil is `#`. When the editor text starts with `# `, the prompt glyph changes to `#`; pressing Enter saves the idea, clears the editor, and leaves the original sigil text in editor history for quick recovery. Configure or disable this under `powerline.queue.captureSigil`:
+
+```json
+{
+  "powerline": {
+    "queue": {
+      "captureSigil": "#"
+    }
+  }
+}
+```
+
+Set `captureSigil` to `false` if you often submit markdown headings and prefer `/idea` instead.
+
+Captured data is stored under the Pi agent directory in `powerline-footer/inbox.jsonl` and `powerline-footer/projects.json`. `inbox.jsonl` is a stable read surface for orchestrators and helper agents; each line is a queue item with `id`, `text`, `createdAt`, `updatedAt`, `source`, `target`, `intent`, `status`, and optional `error`. Writes should still go through Powerline commands or the store so locking and atomic writes are preserved. Ideas sent to a session include a small provenance header so the receiving agent can treat them as deferred captured context.
 
 - `/powerline placement below` — move the primary powerline row below the editor
 - `/powerline placement above` — restore the default placement
@@ -288,13 +303,12 @@ Prompt history now has two sources:
 - stashed prompts — up to 12 recent stashed prompts (newest first)
 - recent project prompts — up to 50 recent user-submitted prompts pulled from pi sessions in the current project folder
 
-Selecting an entry inserts it into the editor. If the editor already has text, you can choose `Replace`, `Append`, or `Cancel`.
+Selecting a stashed entry lets you insert it or promote it to an idea. Project prompt history entries insert into the editor. If the editor already has text, you can choose `Replace`, `Append`, or `Cancel`.
 
 ### Editor clipboard and navigation shortcuts
 
 - `ctrl+alt+c` — copy full editor content
 - `ctrl+alt+x` — cut full editor content (copy, then clear)
-- `ctrl+alt+i` — capture the current editor text as a project idea and clear the editor
 - `ctrl+alt+q` — open the queued-prompt picker
 - `cmd+shift+up` — move the editor cursor to the start of the first line
 - `cmd+shift+down` — move the editor cursor to the end of the last line
@@ -311,7 +325,7 @@ You can override shortcut keys in the agent settings file:
     "stashHistory": "ctrl+alt+h",
     "copyEditor": "ctrl+alt+c",
     "cutEditor": "ctrl+alt+x",
-    "ideaCapture": "ctrl+alt+i",
+    "ideaCapture": null,
     "queueOpen": "ctrl+alt+q",
     "editorStart": "cmd+shift+up",
     "editorEnd": "cmd+shift+down"

--- a/index.ts
+++ b/index.ts
@@ -63,7 +63,7 @@ import {
   generateVibesBatch,
   parseVibeGenerateArgs,
 } from "./working-vibes.ts";
-import { PowerlineQueueStore, currentQueueContext, parseCompactQueuedPrompt, parseTargetPrefix, targetForIdea } from "./queue/store.ts";
+import { PowerlineQueueStore, currentQueueContext, formatQueueDeliveryText, parseCompactQueuedPrompt, parseSigilIdeaCapture, parseTargetPrefix, targetForIdea } from "./queue/store.ts";
 import type { PowerlineQueueItem, QueueIntent, QueueTarget } from "./queue/types.ts";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -83,6 +83,7 @@ let config: PowerlineConfig = {
   invalidPlacement: null,
   welcome: true,
   stashSharpSShortcut: false,
+  queue: { captureSigil: "#" },
 };
 
 const CUSTOM_COMPACTION_STATUS_KEY = "compact-policy";
@@ -111,11 +112,11 @@ type PowerlineShortcutAction =
 const STASH_HISTORY_LIMIT = 12;
 const PROJECT_PROMPT_HISTORY_LIMIT = 50;
 const STASH_PREVIEW_WIDTH = 72;
-const DEFAULT_SHORTCUTS: Record<PowerlineShortcutKey, string> = {
+const DEFAULT_SHORTCUTS: PowerlineShortcuts = {
   stashHistory: "ctrl+alt+h",
   copyEditor: "ctrl+alt+c",
   cutEditor: "ctrl+alt+x",
-  ideaCapture: "ctrl+alt+i",
+  ideaCapture: null,
   queueOpen: "ctrl+alt+q",
   editorStart: "super+shift+up",
   editorEnd: "super+shift+down",
@@ -720,13 +721,13 @@ function parseShortcutSetting(value: unknown): ShortcutBinding | undefined {
 
 function findShortcutReplacement(key: PowerlineShortcutKey, used: Set<string>): string | null {
   const preferred = DEFAULT_SHORTCUTS[key];
-  if (!used.has(shortcutUsageKey(preferred))) {
+  if (preferred && !used.has(shortcutUsageKey(preferred))) {
     return preferred;
   }
 
   for (const shortcutKey of SHORTCUT_KEYS) {
     const candidate = DEFAULT_SHORTCUTS[shortcutKey];
-    if (!used.has(shortcutUsageKey(candidate))) {
+    if (candidate && !used.has(shortcutUsageKey(candidate))) {
       return candidate;
     }
   }
@@ -1266,6 +1267,23 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     return item;
   }
 
+  function captureIdeaFromParsedInput(ctx: any, parsed: { target: string | null; text: string }): PowerlineQueueItem | null {
+    const trimmed = parsed.text.trim();
+    if (!trimmed) {
+      ctx.ui.notify("Nothing to capture", "info");
+      return null;
+    }
+
+    const target = targetForIdea(parsed.target, queueStore, ctx.cwd ?? process.cwd());
+    const item = captureQueueItem(ctx, trimmed, "idea", target);
+    ctx.ui.notify(`Idea saved (${item.id}) — /ideas to review`, "info");
+    return item;
+  }
+
+  function captureIdeaFromText(ctx: any, text: string): PowerlineQueueItem | null {
+    return captureIdeaFromParsedInput(ctx, parseTargetPrefix(text));
+  }
+
   function captureCurrentProjectIdea(ctx: any, text: string): PowerlineQueueItem | null {
     const trimmed = text.trim();
     if (!trimmed) {
@@ -1274,8 +1292,22 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
 
     const item = captureQueueItem(ctx, trimmed, "idea", { kind: "project", cwd: ctx.cwd ?? process.cwd() });
-    ctx.ui.notify(`Captured idea ${item.id}`, "info");
+    ctx.ui.notify(`Idea saved (${item.id}) — /ideas to review`, "info");
     return item;
+  }
+
+  function isSigilIdeaDraft(text: string): boolean {
+    const sigil = config.queue.captureSigil;
+    if (sigil === false) return false;
+    const normalizedSigil = sigil.trim();
+    if (!normalizedSigil) return false;
+    const trimmed = text.trimStart();
+    return trimmed.startsWith(normalizedSigil) && /^\s/.test(trimmed.slice(normalizedSigil.length));
+  }
+
+  function captureSigilGlyph(): string {
+    const sigil = config.queue.captureSigil === false ? "#" : config.queue.captureSigil;
+    return Array.from(sigil)[0] ?? "#";
   }
 
   function capturePostCompactPrompt(ctx: any, text: string): PowerlineQueueItem | null {
@@ -1305,10 +1337,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
     try {
       const deliverAs = deliveryModeForItem(ctx, item);
+      const deliveryText = formatQueueDeliveryText(item);
       if (deliverAs) {
-        pi.sendUserMessage(item.text, { deliverAs });
+        pi.sendUserMessage(deliveryText, { deliverAs });
       } else {
-        pi.sendUserMessage(item.text);
+        pi.sendUserMessage(deliveryText);
       }
       queueStore.update(item.id, { status: "sent", error: undefined });
       ctx.ui.notify(`Sent queued item ${item.id}`, "info");
@@ -1453,6 +1486,10 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
     if (ctx.hasUI) {
       ctx.ui.setStatus("stash", undefined);
+      const pendingIdeas = queueStore.activeItems(getQueueContext(ctx)).filter((item) => item.intent === "idea").length;
+      if (pendingIdeas > 0) {
+        ctx.ui.notify(`${pendingIdeas} idea${pendingIdeas === 1 ? "" : "s"} waiting — /ideas`, "info");
+      }
     }
 
     // Initialize vibe manager (needs modelRegistry from ctx)
@@ -1807,6 +1844,23 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
   }
 
+  async function handleSelectedStashHistoryEntry(ctx: any, selected: string): Promise<void> {
+    const action = await ctx.ui.select("Stashed prompt", ["Insert", "Promote to idea", "Cancel"]);
+
+    if (action === "Insert") {
+      await insertSelectedPromptHistoryEntry(ctx, selected);
+      return;
+    }
+
+    if (action === "Promote to idea") {
+      try {
+        captureIdeaFromText(ctx, selected);
+      } catch (error) {
+        ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+      }
+    }
+  }
+
   function isStashShortcutInput(data: string): boolean {
     return matchesStashShortcutInput(data, { includePrintableSharpS: config.stashSharpSShortcut });
   }
@@ -1934,6 +1988,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       : await selectStashedPromptFromHistory(ctx);
     if (!selected) return;
 
+    if (source === "stash") {
+      await handleSelectedStashHistoryEntry(ctx, selected);
+      return;
+    }
+
     await insertSelectedPromptHistoryEntry(ctx, selected);
   }
 
@@ -1991,17 +2050,10 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       }
 
       try {
-        const parsed = parseTargetPrefix(raw);
-        if (!parsed.text) {
-          ctx.ui.notify("Idea text is empty", "warning");
-          return;
-        }
-        const target = targetForIdea(parsed.target, queueStore, ctx.cwd ?? process.cwd());
-        const item = captureQueueItem(ctx, parsed.text, "idea", target);
-        if (!args.trim()) {
+        const item = captureIdeaFromText(ctx, raw);
+        if (item && !args.trim()) {
           ctx.ui.setEditorText("");
         }
-        ctx.ui.notify(`Captured idea ${item.id}`, "info");
       } catch (error) {
         ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
       }
@@ -2790,6 +2842,23 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
         const isSubmit = keybindings.matches(data, "tui.input.submit") && !keybindings.matches(data, "tui.input.newLine");
         const isFollowUpSubmit = keybindings.matches(data, "app.message.followUp");
+        if (!bashModeActive && (isSubmit || isFollowUpSubmit)) {
+          const sigilCapture = parseSigilIdeaCapture(editor.getExpandedText(), config.queue.captureSigil);
+          if (sigilCapture) {
+            try {
+              const item = captureIdeaFromParsedInput(ctx, sigilCapture);
+              if (item) {
+                editor.addToHistory?.(editor.getExpandedText().trim());
+                editor.setText("");
+              }
+            } catch (error) {
+              ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+            }
+            scheduleDismissWelcome(ctx);
+            return;
+          }
+        }
+
         if (!powerlineCompacting && !bashModeActive && isSubmit && typeof ctx.compact === "function") {
           const compactQueuedPrompt = parseCompactQueuedPrompt(editor.getExpandedText());
           if (compactQueuedPrompt) {
@@ -2851,8 +2920,10 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         }
 
         const bc = (s: string) => `${getFgAnsiCode("sep")}${s}${ansi.reset}`;
-        const promptGlyph = bashModeActive ? "$" : ">";
-        const prompt = `${ansi.getFgAnsi(200, 200, 200)}${promptGlyph}${ansi.reset}`;
+        const captureDraft = !bashModeActive && isSigilIdeaDraft(editor.getExpandedText());
+        const promptGlyph = bashModeActive ? "$" : captureDraft ? captureSigilGlyph() : ">";
+        const promptColor = captureDraft ? getFgAnsiCode("queue") : ansi.getFgAnsi(200, 200, 200);
+        const prompt = `${promptColor}${promptGlyph}${ansi.reset}`;
         const promptPrefix = ` ${prompt} `;
         const contPrefix = "   ";
         const contentWidth = Math.max(1, width - 3);

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -16,6 +16,7 @@ export interface PowerlineConfig {
   invalidPlacement: string | null;
   welcome: boolean;
   stashSharpSShortcut: boolean;
+  queue: { captureSigil: string | false };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -85,6 +86,13 @@ function normalizeCustomPrefix(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const normalized = value.trim();
   return normalized ? normalized : undefined;
+}
+
+function normalizeCaptureSigil(value: unknown): string | false {
+  if (value === false) return false;
+  if (typeof value !== "string") return "#";
+  const normalized = value.trim();
+  return normalized && !/\s/.test(normalized) ? normalized : "#";
 }
 
 function normalizeCustomStatusItem(raw: unknown, idOverride?: string): CustomStatusItem | null {
@@ -304,6 +312,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     invalidPlacement: null,
     welcome: true,
     stashSharpSShortcut: false,
+    queue: { captureSigil: "#" },
   };
 
   const directPreset = normalizePreset(value, presets);
@@ -315,6 +324,9 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
   const { disabledSegments, invalidDisabledSegments } = normalizeDisabledSegments(value.disabledSegments, customItems);
   const { layout, invalidLayoutSegments } = normalizeLayout(value.layout, customItems);
   const { placement, invalidPlacement } = normalizePlacement(value.placement);
+  const queue = isRecord(value.queue)
+    ? { captureSigil: normalizeCaptureSigil(value.queue.captureSigil) }
+    : defaultConfig.queue;
 
   return {
     preset: normalizePreset(value.preset, presets) ?? defaultConfig.preset,
@@ -329,6 +341,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     invalidPlacement,
     welcome: value.welcome !== false,
     stashSharpSShortcut: value.stashSharpSShortcut === true,
+    queue,
   };
 }
 

--- a/queue/store.ts
+++ b/queue/store.ts
@@ -321,6 +321,26 @@ export function parseTargetPrefix(text: string): { target: string | null; text: 
   return { target: match[1], text: trimmed.slice(match[0].length).trim() };
 }
 
+export function parseSigilIdeaCapture(text: string, sigil: string | false): { target: string | null; text: string } | null {
+  if (sigil === false) return null;
+  const normalizedSigil = sigil.trim();
+  if (!normalizedSigil) return null;
+
+  const trimmed = text.trim();
+  if (!trimmed.startsWith(normalizedSigil)) return null;
+
+  const afterSigil = trimmed.slice(normalizedSigil.length);
+  if (!/^\s/.test(afterSigil)) return null;
+
+  const parsed = parseTargetPrefix(afterSigil.trim());
+  return parsed.text ? parsed : null;
+}
+
+export function formatQueueDeliveryText(item: PowerlineQueueItem): string {
+  if (item.intent !== "idea") return item.text;
+  return `[powerline idea ${item.id}, captured ${new Date(item.createdAt).toISOString()} from ${item.source.cwd}]\n${item.text}`;
+}
+
 export function parseCompactQueuedPrompt(text: string): string | null {
   const trimmed = text.trim();
   const match = /^\/compact\s+(.+)$/.exec(trimmed);

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -35,6 +35,7 @@ test("parsePowerlineConfig supports object config with custom items", () => {
   assert.equal(config.invalidPlacement, null);
   assert.equal(config.welcome, true);
   assert.equal(config.stashSharpSShortcut, false);
+  assert.deepEqual(config.queue, { captureSigil: "#" });
 });
 
 test("parsePowerlineConfig supports disabled segments", () => {
@@ -155,17 +156,29 @@ test("parsePowerlineConfig validates primary powerline placement", () => {
 
 
 
-test("parsePowerlineConfig supports welcome and legacy sharp-S toggles", () => {
+test("parsePowerlineConfig supports welcome, legacy sharp-S, and queue capture settings", () => {
   const disabled = parsePowerlineConfig(
-    { preset: "compact", welcome: false, stashSharpSShortcut: true },
+    { preset: "compact", welcome: false, stashSharpSShortcut: true, queue: { captureSigil: false } },
+    ["default", "compact"],
+  );
+  const customSigil = parsePowerlineConfig(
+    { preset: "compact", queue: { captureSigil: "//" } },
+    ["default", "compact"],
+  );
+  const invalidSigil = parsePowerlineConfig(
+    { preset: "compact", queue: { captureSigil: "# note" } },
     ["default", "compact"],
   );
   const shorthand = parsePowerlineConfig("compact", ["default", "compact"]);
 
   assert.equal(disabled.welcome, false);
   assert.equal(disabled.stashSharpSShortcut, true);
+  assert.deepEqual(disabled.queue, { captureSigil: false });
+  assert.deepEqual(customSigil.queue, { captureSigil: "//" });
+  assert.deepEqual(invalidSigil.queue, { captureSigil: "#" });
   assert.equal(shorthand.welcome, true);
   assert.equal(shorthand.stashSharpSShortcut, false);
+  assert.deepEqual(shorthand.queue, { captureSigil: "#" });
 });
 
 test("parsePowerlineConfig extracts supported segment options", () => {

--- a/tests/jump-shortcuts.test.ts
+++ b/tests/jump-shortcuts.test.ts
@@ -8,6 +8,7 @@ test("surviving editor shortcuts resolve without app-owned chat scrolling", () =
   assert.equal(resolved.stashHistory, "ctrl+alt+h");
   assert.equal(resolved.copyEditor, "ctrl+alt+c");
   assert.equal(resolved.cutEditor, "ctrl+alt+x");
+  assert.equal(resolved.ideaCapture, null);
   assert.equal(resolved.editorStart, "super+shift+up");
   assert.equal(resolved.editorEnd, "super+shift+down");
   assert.equal(Object.keys(resolved).some((key) => key.startsWith("scroll")), false);
@@ -20,6 +21,16 @@ test("super shortcut matching and conflict normalization remain supported", () =
   assert.equal(isSupportedSuperShortcut("super+up"), true);
   assert.equal(isSupportedSuperShortcut("super+z"), false);
   assert.equal(shortcutConflictKey("super+home"), "super+up");
+});
+
+test("idea capture shortcut remains configurable", () => {
+  const resolved = resolveShortcutConfig({
+    powerlineShortcuts: {
+      ideaCapture: "ctrl+alt+i",
+    },
+  });
+
+  assert.equal(resolved.ideaCapture, "ctrl+alt+i");
 });
 
 test("editor boundary shortcuts remain configurable", () => {

--- a/tests/queue-store.test.ts
+++ b/tests/queue-store.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { PowerlineQueueStore, currentQueueContext, parseCompactQueuedPrompt, parseTargetPrefix, targetForIdea } from "../queue/store.ts";
+import { PowerlineQueueStore, currentQueueContext, formatQueueDeliveryText, parseCompactQueuedPrompt, parseSigilIdeaCapture, parseTargetPrefix, targetForIdea } from "../queue/store.ts";
 
 function withStore(fn: (store: PowerlineQueueStore, dir: string) => void): void {
   const dir = mkdtempSync(join(tmpdir(), "powerline-queue-"));
@@ -81,6 +81,40 @@ test("queue store aliases resolve idea targets", () => withStore((store) => {
 test("parseTargetPrefix separates optional @target", () => {
   assert.deepEqual(parseTargetPrefix("@pika check logs"), { target: "pika", text: "check logs" });
   assert.deepEqual(parseTargetPrefix("plain idea"), { target: null, text: "plain idea" });
+});
+
+test("parseSigilIdeaCapture turns leading sigil text into target-aware ideas", () => {
+  assert.deepEqual(parseSigilIdeaCapture("# check logs", "#"), { target: null, text: "check logs" });
+  assert.deepEqual(parseSigilIdeaCapture("# @global check logs", "#"), { target: "global", text: "check logs" });
+  assert.deepEqual(parseSigilIdeaCapture("# @pika check logs\nthen inspect events", "#"), {
+    target: "pika",
+    text: "check logs\nthen inspect events",
+  });
+  assert.deepEqual(parseSigilIdeaCapture("note # check logs", "#"), null);
+  assert.deepEqual(parseSigilIdeaCapture("## markdown heading", "#"), null);
+  assert.deepEqual(parseSigilIdeaCapture("#   ", "#"), null);
+  assert.deepEqual(parseSigilIdeaCapture("# check logs", false), null);
+  assert.deepEqual(parseSigilIdeaCapture("// check logs", "//"), { target: null, text: "check logs" });
+});
+
+test("formatQueueDeliveryText adds provenance only for ideas", () => {
+  const idea = {
+    id: "a1b2c3d4",
+    text: "check logs",
+    createdAt: 1000,
+    updatedAt: 1000,
+    source: { cwd: "/tmp/project" },
+    target: { kind: "current-session" as const },
+    intent: "idea" as const,
+    status: "queued" as const,
+  };
+  const prompt = { ...idea, intent: "follow-up" as const };
+
+  assert.equal(
+    formatQueueDeliveryText(idea),
+    "[powerline idea a1b2c3d4, captured 1970-01-01T00:00:01.000Z from /tmp/project]\ncheck logs",
+  );
+  assert.equal(formatQueueDeliveryText(prompt), "check logs");
 });
 
 test("parseCompactQueuedPrompt treats /compact suffix as queued prompt text", () => {


### PR DESCRIPTION
## Summary

Adds the issue #140 capture UX: typing `# <idea>` and pressing Enter now saves an idea instead of sending it. The flow supports `@global`, `@current`, and saved project aliases, exposes `powerline.queue.captureSigil`, disables the default `ctrl+alt+i` binding while keeping overrides supported, lets stash history entries promote into ideas, and adds provenance headers when ideas are delivered to an agent.

Closes #140.

## Validation

- `npm test`
- `git --no-pager diff --check`
- `npm pack --dry-run --json`
- Fresh reviewer: no issues found
