### PR TITLE
feat: add strict typecheck gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install devDependencies
+        run: npm ci --ignore-scripts
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Unit tests
+        run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+- Added `/ideas next` to send the oldest active captured idea to the current session, plus `/idea issue [id]` and `/ideas issue [id]` to hand saved ideas to the current agent for guarded GitHub issue triage.
+- Added a strict source-only TypeScript gate and GitHub Actions workflow that runs typecheck before tests on Ubuntu and Windows.
+
+### Fixed
+- Switched compaction-aware queue delivery to Pi's supported `session_before_compact` and `session_compact` extension lifecycle instead of internal session events.
+
 ## [0.11.0] - 2026-08-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Customizes the default [pi](https://github.com/badlogic/pi-mono) editor with a p
 
 **Editor stash** — Press `Alt+S` to save your editor content and clear the editor, type a quick prompt, and your stashed text auto-restores when the agent finishes. Toggles between stash, pop, and update-existing-stash. A `stash` indicator appears in the powerline bar while text is stashed.
 
-**Powerline Queue + Inbox** — Capture thoughts without interrupting the current agent. Type `# <idea>` and press Enter to save an idea instead of sending it; `# @global <idea>`, `# @current <idea>`, and `# @alias <idea>` route it. Messages typed during compaction are held by Powerline and delivered after successful compaction instead of disappearing into Pi's native queue. `/idea`, `/ideas`, and `/queue` provide a file-backed inbox for current-session prompts, project ideas, aliases, retries, clears, and manual delivery. Active queue, idea, and blocked counts appear in the `queue` segment only when there is something to show.
+**Powerline Queue + Inbox** — Capture thoughts without interrupting the current agent. Type `# <idea>` and press Enter to save an idea instead of sending it; `# @global <idea>`, `# @current <idea>`, and `# @alias <idea>` route it. Messages typed during compaction are held by Powerline and delivered after successful compaction instead of disappearing into Pi's native queue. `/idea`, `/ideas`, and `/queue` provide a file-backed inbox for current-session prompts, project ideas, aliases, retries, clears, and manual delivery. Use `/ideas next` to work the oldest active idea in the current session, or `/ideas issue` to hand it to the current agent for safe GitHub issue triage. Active queue, idea, and blocked counts appear in the `queue` segment only when there is something to show.
 
 **Working Vibes** — AI-generated themed loading messages. Set `/vibe star trek` and your "Working..." becomes "Running diagnostics..." or "Engaging warp drive...". Supports any theme: pirate, zen, noir, cowboy, etc.
 
@@ -60,7 +60,10 @@ Powerline Queue + Inbox commands and capture shortcuts:
 - `# @name <text>` — capture an idea for a saved project alias
 - `/compact <text>` — compact now and queue `<text>` as the next prompt after successful compaction
 - `/idea [@target] <text>` — command form of idea capture, useful for scripts and users who disable the sigil
+- `/idea issue [id]` — hand the oldest active idea, or a specific idea, to the current agent for safe GitHub issue triage
 - `/ideas` — open the captured-ideas picker
+- `/ideas next` — send the oldest active idea to the current session
+- `/ideas issue [id]` — ask the current agent to dedupe and file a GitHub issue only when the target repo is clear and owned/controlled
 - `/ideas send <id>` — send an idea to the current session
 - `/queue` — open the queued-prompt picker
 - `/queue send [id]` / `/queue retry [id]` — deliver a queued item now
@@ -81,7 +84,7 @@ The default capture sigil is `#`. When the editor text starts with `# `, the pro
 
 Set `captureSigil` to `false` if you often submit markdown headings and prefer `/idea` instead.
 
-Captured data is stored under the Pi agent directory in `powerline-footer/inbox.jsonl` and `powerline-footer/projects.json`. `inbox.jsonl` is a stable read surface for orchestrators and helper agents; each line is a queue item with `id`, `text`, `createdAt`, `updatedAt`, `source`, `target`, `intent`, `status`, and optional `error`. Writes should still go through Powerline commands or the store so locking and atomic writes are preserved. Ideas sent to a session include a small provenance header so the receiving agent can treat them as deferred captured context.
+Captured data is stored under the Pi agent directory in `powerline-footer/inbox.jsonl` and `powerline-footer/projects.json`. `inbox.jsonl` is a stable read surface for orchestrators and helper agents; each line is a queue item with `id`, `text`, `createdAt`, `updatedAt`, `source`, `target`, `intent`, `status`, and optional `error`. Writes should still go through Powerline commands or the store so locking and atomic writes are preserved. Ideas sent with `/ideas next` or `/ideas send <id>` include a small provenance header so the receiving agent can treat them as deferred captured context. `/idea issue` and `/ideas issue` do not file issues directly from the extension; they send a guarded handoff prompt that tells the current agent to dedupe open issues first, create a GitHub issue only for a clear owned/controlled repo, and ask before filing when the target is unclear.
 
 - `/powerline placement below` — move the primary powerline row below the editor
 - `/powerline placement above` — restore the default placement

--- a/bash-mode/completion.ts
+++ b/bash-mode/completion.ts
@@ -416,7 +416,7 @@ export class BashCompletionEngine {
 }
 
 export class BashAutocompleteProvider implements AutocompleteProvider {
-  getSuggestions(): AutocompleteSuggestions | null {
+  async getSuggestions(): Promise<AutocompleteSuggestions | null> {
     return null;
   }
 
@@ -456,7 +456,7 @@ function applyExtendedCompletion(lines: string[], cursorLine: number, item: Exte
 }
 
 export class OneOffBashAutocompleteProvider implements AutocompleteProvider {
-  getSuggestions(): AutocompleteSuggestions | null {
+  async getSuggestions(): Promise<AutocompleteSuggestions | null> {
     return null;
   }
 
@@ -511,12 +511,12 @@ export class ModeAwareAutocompleteProvider implements AutocompleteProvider {
     ];
   }
 
-  getSuggestions(
+  async getSuggestions(
     lines: string[],
     cursorLine: number,
     cursorCol: number,
     options: { signal: AbortSignal; force?: boolean },
-  ): AutocompleteSuggestions | null | Promise<AutocompleteSuggestions | null> {
+  ): Promise<AutocompleteSuggestions | null> {
     if (this.isBashModeActive()) {
       return this.bashProvider.getSuggestions(lines, cursorLine, cursorCol, options);
     }

--- a/bash-mode/editor.ts
+++ b/bash-mode/editor.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath } from "node:url";
-import { CustomEditor } from "@earendil-works/pi-coding-agent";
+import { CustomEditor, type KeybindingsManager } from "@earendil-works/pi-coding-agent";
 import { isKeyRelease, matchesKey, visibleWidth, truncateToWidth } from "@earendil-works/pi-tui";
-import type { KeybindingsManager } from "@earendil-works/pi-coding-agent/dist/core/keybindings.js";
 import type { AutocompleteProvider } from "@earendil-works/pi-tui";
 import { matchesConfiguredShortcut } from "../shortcuts.ts";
 import { getOneOffBashCommandContext } from "./completion.ts";
@@ -145,8 +144,9 @@ export class BashModeEditor extends CustomEditor {
     resetShellHistoryBrowse(this);
     this.clearGhostSuggestion();
 
-    if ("cancelAutocomplete" in this && typeof this.cancelAutocomplete === "function") {
-      this.cancelAutocomplete();
+    const cancelAutocomplete = Reflect.get(this, "cancelAutocomplete");
+    if (typeof cancelAutocomplete === "function") {
+      cancelAutocomplete.call(this);
     }
     this.tui.requestRender();
   }
@@ -175,7 +175,10 @@ export class BashModeEditor extends CustomEditor {
       const oneOffBashCommand = !bashMode && this.isOneOffBashCommandContext();
 
       if (isCommandUndoShortcut(data)) {
-        this.undo();
+        const undo = Reflect.get(this, "undo");
+        if (typeof undo === "function") {
+          undo.call(this);
+        }
         resetShellHistoryBrowse(this);
         if (this.isShellCompletionContext()) {
           this.scheduleGhostUpdate();

--- a/colors.ts
+++ b/colors.ts
@@ -32,10 +32,11 @@ const THEME = {
   path: "#00afaf",        // Teal/cyan
   gitClean: "#5faf5f",    // Green
   accent: "#febc38",      // Orange
+  queue: "#febc38",       // Orange
 };
 
 // Color name to ANSI code mapping
-type ColorName = "sep" | "model" | "path" | "gitClean" | "accent";
+type ColorName = keyof typeof THEME;
 
 function getAnsiCode(color: ColorName): string {
   const value = THEME[color as keyof typeof THEME];

--- a/icons.ts
+++ b/icons.ts
@@ -110,7 +110,7 @@ function sanitizeUserIconOverrides(value: unknown): PartialIconSet {
   const sanitized: PartialIconSet = {};
   const validKeys = Object.keys(NERD_ICONS) as Array<keyof IconSet>;
   for (const key of validKeys) {
-    const icon = value[key];
+    const icon = Reflect.get(value, key);
     if (typeof icon === "string") {
       sanitized[key] = icon;
     }

--- a/index.ts
+++ b/index.ts
@@ -63,7 +63,7 @@ import {
   generateVibesBatch,
   parseVibeGenerateArgs,
 } from "./working-vibes.ts";
-import { PowerlineQueueStore, currentQueueContext, formatQueueDeliveryText, parseCompactQueuedPrompt, parseSigilIdeaCapture, parseTargetPrefix, targetForIdea } from "./queue/store.ts";
+import { PowerlineQueueStore, currentQueueContext, formatIdeaIssuePrompt, formatQueueDeliveryText, parseCompactQueuedPrompt, parseSigilIdeaCapture, parseTargetPrefix, targetForIdea } from "./queue/store.ts";
 import type { PowerlineQueueItem, QueueIntent, QueueTarget } from "./queue/types.ts";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -121,11 +121,11 @@ const DEFAULT_SHORTCUTS: PowerlineShortcuts = {
   editorStart: "super+shift+up",
   editorEnd: "super+shift+down",
 };
-const DEFAULT_BASH_MODE_SETTINGS: BashModeSettings = {
+const DEFAULT_BASH_MODE_SETTINGS = {
   toggleShortcut: "ctrl+shift+b",
   transcriptMaxLines: 2000,
   transcriptMaxBytes: 512 * 1024,
-};
+} as const satisfies BashModeSettings;
 const SHORTCUT_KEYS: PowerlineShortcutKey[] = ["stashHistory", "copyEditor", "cutEditor", "ideaCapture", "queueOpen", "editorStart", "editorEnd"];
 const APP_RESERVED_SHORTCUTS = [
   "escape",
@@ -157,7 +157,7 @@ const APP_RESERVED_SHORTCUTS = [
 ] as const;
 const EXTRA_RESERVED_SHORTCUTS = ["alt+s"] as const;
 const SHORTCUT_MODIFIER_ORDER = ["ctrl", "alt", "super", "shift"] as const;
-const SHORTCUT_MODIFIERS = new Set(SHORTCUT_MODIFIER_ORDER);
+const SHORTCUT_MODIFIERS = new Set<string>(SHORTCUT_MODIFIER_ORDER);
 const SHORTCUT_NAMED_KEYS = new Set([
   "escape", "esc", "enter", "return", "tab", "space", "backspace", "delete", "insert", "clear",
   "home", "end", "pageup", "pagedown", "up", "down", "left", "right",
@@ -176,9 +176,7 @@ const PROMPT_HISTORY_TRACKED = Symbol.for("powerlinePromptHistoryTracked");
 const PROMPT_HISTORY_STATE_KEY = Symbol.for("powerlinePromptHistoryState");
 
 interface PromptHistoryEditor {
-  history?: unknown;
-  addToHistory?: unknown;
-  [key: symbol]: unknown;
+  addToHistory?: (text: string) => void;
 }
 
 type PromptHistoryState = { savedPromptHistory: string[] };
@@ -231,7 +229,8 @@ function getPromptHistoryState(): PromptHistoryState {
 }
 
 function readPromptHistory(editor: PromptHistoryEditor | null | undefined): string[] {
-  const history = editor?.history;
+  if (!editor) return [];
+  const history = Reflect.get(editor, "history");
   if (!Array.isArray(history)) return [];
 
   const normalized: string[] = [];
@@ -265,7 +264,7 @@ function restorePromptHistory(editor: PromptHistoryEditor | null | undefined): v
 
 function trackPromptHistory(editor: PromptHistoryEditor | null | undefined): void {
   if (!editor || typeof editor.addToHistory !== "function") return;
-  if (editor[PROMPT_HISTORY_TRACKED]) {
+  if (Reflect.get(editor, PROMPT_HISTORY_TRACKED)) {
     snapshotPromptHistory(editor);
     return;
   }
@@ -275,7 +274,7 @@ function trackPromptHistory(editor: PromptHistoryEditor | null | undefined): voi
     originalAddToHistory(text);
     snapshotPromptHistory(editor);
   };
-  editor[PROMPT_HISTORY_TRACKED] = true;
+  Reflect.set(editor, PROMPT_HISTORY_TRACKED, true);
   snapshotPromptHistory(editor);
 }
 
@@ -634,7 +633,7 @@ function normalizeShortcut(value: string): string {
   const parts = value.trim().toLowerCase().split("+");
   if (parts.length <= 1) return parts[0] ?? "";
 
-  const modifierRank = new Map(SHORTCUT_MODIFIER_ORDER.map((modifier, index) => [modifier, index]));
+  const modifierRank = new Map<string, number>(SHORTCUT_MODIFIER_ORDER.map((modifier, index) => [modifier, index]));
   const modifiers = parts.slice(0, -1).sort((a, b) => (modifierRank.get(a) ?? 99) - (modifierRank.get(b) ?? 99));
   return [...modifiers, parts[parts.length - 1]].join("+");
 }
@@ -1004,6 +1003,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   let shellSession: ManagedShellSession | null = null;
   const queueStore = new PowerlineQueueStore();
   let powerlineCompacting = false;
+  let deliverAfterRetrySettles = false;
   let queueDeliveryTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Cache for the top and secondary powerline widgets.
@@ -1185,7 +1185,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     items: SelectItem[],
     maxVisible: number,
   ): Promise<SelectItem | null> {
-    return ctx.ui.custom<SelectItem | null>(
+    return ctx.ui.custom(
       (tui: any, theme: Theme, _keybindings: any, done: (result: SelectItem | null) => void) => {
         const selectList = new SelectList(items, maxVisible, overlaySelectListTheme(theme));
         const border = (text: string) => theme.fg("dim", text);
@@ -1376,6 +1376,13 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
   }
 
+  function finishFailedCompaction(ctx: any, errorMessage: string): void {
+    powerlineCompacting = false;
+    deliverAfterRetrySettles = false;
+    blockPostCompactionQueue(ctx, errorMessage);
+    requestQueueRender();
+  }
+
   async function chooseQueueAction(ctx: any, item: PowerlineQueueItem): Promise<void> {
     const actions: SelectItem[] = [
       { value: "send", label: "Send to current session", description: "Deliver as prompt/follow-up" },
@@ -1454,6 +1461,42 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     if (updated) deliverQueueItem(ctx, updated);
   }
 
+  function findNextIdea(ctx: any): PowerlineQueueItem | null {
+    return queueStore.activeItems(getQueueContext(ctx)).find((candidate) => candidate.intent === "idea") ?? null;
+  }
+
+  function sendIdeaIssueHandoff(ctx: any, item: PowerlineQueueItem): void {
+    queueStore.update(item.id, { status: "delivering", error: undefined });
+    requestQueueRender();
+
+    try {
+      const deliverAs = deliveryModeForItem(ctx, item);
+      const issuePrompt = formatIdeaIssuePrompt(item);
+      if (deliverAs) {
+        pi.sendUserMessage(issuePrompt, { deliverAs });
+      } else {
+        pi.sendUserMessage(issuePrompt);
+      }
+      queueStore.update(item.id, { status: "sent", error: undefined });
+      ctx.ui.notify(`Sent idea ${item.id} for issue triage`, "info");
+      requestQueueRender();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      queueStore.update(item.id, { status: "failed", error: message });
+      ctx.ui.notify(`Failed to send ${item.id}: ${message}`, "error");
+      requestQueueRender();
+    }
+  }
+
+  function sendIdeaIssueHandoffById(ctx: any, id: string | undefined): void {
+    const item = id ? queueStore.get(id) : findNextIdea(ctx);
+    if (!item || item.intent !== "idea") {
+      ctx.ui.notify(id ? `No unique idea matches ${id}` : "No ideas captured", id ? "warning" : "info");
+      return;
+    }
+    sendIdeaIssueHandoff(ctx, item);
+  }
+
   // Track session start
   pi.on("session_start", async (event, ctx) => {
     shellSession?.dispose();
@@ -1466,6 +1509,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     isStreaming = false;
     liveAssistantUsage = null;
     powerlineCompacting = false;
+    deliverAfterRetrySettles = false;
     stashedEditorText = null;
 
     const settings = readSettings(ctx.cwd);
@@ -1479,10 +1523,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     bashTranscript = new BashTranscriptStore(bashModeSettings);
     bashCompletionEngine = new BashCompletionEngine();
 
-    getThinkingLevelFn = typeof ctx.getThinkingLevel === "function"
-      ? () => ctx.getThinkingLevel()
-      : null;
-    currentThinkingLevel = getThinkingLevelFn?.() ?? null;
+    getThinkingLevelFn = () => ctx.thinkingLevel ?? "off";
+    currentThinkingLevel = getThinkingLevelFn();
 
     if (ctx.hasUI) {
       ctx.ui.setStatus("stash", undefined);
@@ -1529,6 +1571,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       queueDeliveryTimer = null;
     }
     powerlineCompacting = false;
+    deliverAfterRetrySettles = false;
     bashModeActive = false;
     currentCtx = null;
     footerDataRef = null;
@@ -1650,22 +1693,33 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     requestImmediateStatusRender({ deferDuringTyping: false });
   });
 
-  pi.on("compaction_start", async (_event, ctx) => {
+  pi.on("session_before_compact", async (_event, ctx) => {
     powerlineCompacting = true;
     currentCtx = ctx;
     requestQueueRender();
   });
 
-  pi.on("compaction_end", async (event, ctx) => {
+  pi.on("session_compact", async (event, ctx) => {
     powerlineCompacting = false;
     currentCtx = ctx;
-    const errorMessage = event.errorMessage || (event.aborted ? "Compaction cancelled" : "Compaction did not complete");
-    if (event.aborted || !event.result) {
-      blockPostCompactionQueue(ctx, errorMessage);
-    } else if (!event.willRetry) {
+    if (event.willRetry) {
+      deliverAfterRetrySettles = true;
+    } else {
+      deliverAfterRetrySettles = false;
       schedulePostCompactionDelivery(ctx);
     }
     requestQueueRender();
+  });
+
+  pi.on("agent_settled", async (_event, ctx) => {
+    if (powerlineCompacting) {
+      finishFailedCompaction(ctx, "Compaction did not complete");
+      return;
+    }
+    if (deliverAfterRetrySettles) {
+      deliverAfterRetrySettles = false;
+      schedulePostCompactionDelivery(ctx);
+    }
   });
 
   // Also dismiss on tool calls (agent is working) + refresh vibe if rate limit allows
@@ -2032,7 +2086,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
 
     requestStatusRender();
-    if (!powerlineCompacting) {
+    if (!powerlineCompacting && !deliverAfterRetrySettles) {
       schedulePostCompactionDelivery(ctx);
     }
   });
@@ -2040,18 +2094,25 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   registerCdCommand(pi, () => currentCtx?.cwd ?? process.cwd());
 
   pi.registerCommand("idea", {
-    description: "Capture an idea without interrupting the current agent. Usage: /idea [@alias|@global|@current] <text>",
+    description: "Capture an idea without interrupting the current agent. Usage: /idea [@alias|@global|@current] <text> | /idea issue [id]",
     handler: async (args, ctx) => {
       currentCtx = ctx;
-      const raw = args.trim() || getCurrentEditorText(ctx, currentEditor).trim();
+      const trimmedArgs = args.trim();
+      const [action, id] = trimmedArgs.split(/\s+/).filter(Boolean);
+      if (action === "issue") {
+        sendIdeaIssueHandoffById(ctx, id);
+        return;
+      }
+
+      const raw = trimmedArgs || getCurrentEditorText(ctx, currentEditor).trim();
       if (!raw) {
-        ctx.ui.notify("Usage: /idea [@alias|@global|@current] <text>", "info");
+        ctx.ui.notify("Usage: /idea [@alias|@global|@current] <text> | /idea issue [id]", "info");
         return;
       }
 
       try {
         const item = captureIdeaFromText(ctx, raw);
-        if (item && !args.trim()) {
+        if (item && !trimmedArgs) {
           ctx.ui.setEditorText("");
         }
       } catch (error) {
@@ -2061,7 +2122,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   });
 
   pi.registerCommand("ideas", {
-    description: "Review or send captured ideas. Usage: /ideas [send|retry|clear|edit] <id>",
+    description: "Review or send captured ideas. Usage: /ideas next | /ideas issue [id] | /ideas [send|retry|clear|edit] <id>",
     handler: async (args, ctx) => {
       currentCtx = ctx;
       const parts = args.trim().split(/\s+/).filter(Boolean);
@@ -2073,8 +2134,24 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         return;
       }
 
+      if (action === "next") {
+        const item = findNextIdea(ctx);
+        if (!item) {
+          ctx.ui.notify("No ideas captured", "info");
+          return;
+        }
+        const updated = queueStore.update(item.id, { status: "queued", target: { kind: "current-session" }, error: undefined });
+        if (updated) deliverQueueItem(ctx, updated);
+        return;
+      }
+
+      if (action === "issue") {
+        sendIdeaIssueHandoffById(ctx, id);
+        return;
+      }
+
       if (!id) {
-        ctx.ui.notify("Usage: /ideas [send|retry|clear|edit] <id>", "info");
+        ctx.ui.notify("Usage: /ideas next | /ideas issue [id] | /ideas [send|retry|clear|edit] <id>", "info");
         return;
       }
 
@@ -2104,7 +2181,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         return;
       }
 
-      ctx.ui.notify("Usage: /ideas [send|retry|clear|edit] <id>", "info");
+      ctx.ui.notify("Usage: /ideas next | /ideas issue [id] | /ideas [send|retry|clear|edit] <id>", "info");
     },
   });
 
@@ -2860,13 +2937,22 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         }
 
         if (!powerlineCompacting && !bashModeActive && isSubmit && typeof ctx.compact === "function") {
-          const compactQueuedPrompt = parseCompactQueuedPrompt(editor.getExpandedText());
-          if (compactQueuedPrompt) {
-            editor.addToHistory?.(editor.getExpandedText().trim());
+          const editorText = editor.getExpandedText().trim();
+          const compactQueuedPrompt = parseCompactQueuedPrompt(editorText);
+          if (editorText === "/compact" || compactQueuedPrompt) {
+            editor.addToHistory?.(editorText);
             editor.setText("");
-            capturePostCompactPrompt(ctx, compactQueuedPrompt);
+            if (compactQueuedPrompt) {
+              capturePostCompactPrompt(ctx, compactQueuedPrompt);
+            }
+            powerlineCompacting = true;
+            deliverAfterRetrySettles = false;
+            requestQueueRender();
             ctx.compact({
-              onError: (error: Error) => ctx.ui.notify(error.message, "error"),
+              onError: (error: Error) => {
+                finishFailedCompaction(ctx, error.message);
+                ctx.ui.notify(error.message, "error");
+              },
             });
             scheduleDismissWelcome(ctx);
             return;
@@ -3096,7 +3182,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
             horizontalAlign: "center",
           }),
         },
-      ).catch((error) => {
+      ).catch((error: unknown) => {
         console.debug("[powerline-footer] Welcome overlay failed:", error);
       });
     }, 100);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.83.0",
         "@earendil-works/pi-coding-agent": "^0.83.0",
-        "@earendil-works/pi-tui": "^0.83.0"
+        "@earendil-works/pi-tui": "^0.83.0",
+        "@types/node": "24.13.3",
+        "typescript": "5.9.3"
       },
       "peerDependencies": {
         "@earendil-works/pi-ai": ">=0.81.0 <0.84.0",
@@ -663,9 +665,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -683,9 +682,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -703,9 +699,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -723,9 +716,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -743,9 +733,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1130,6 +1117,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1327,11 +1315,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.6.2",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/retry": {
@@ -1768,8 +1758,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici-types": {
-      "version": "7.19.2",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1821,6 +1827,7 @@
       "version": "4.4.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "git+https://github.com/nicobailon/pi-powerline-footer.git"
   },
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "test": "node --experimental-strip-types --test tests/**/*.test.ts"
   },
   "peerDependencies": {
@@ -36,7 +37,9 @@
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.83.0",
     "@earendil-works/pi-coding-agent": "^0.83.0",
-    "@earendil-works/pi-tui": "^0.83.0"
+    "@earendil-works/pi-tui": "^0.83.0",
+    "@types/node": "24.13.3",
+    "typescript": "5.9.3"
   },
   "pi": {
     "extensions": [

--- a/queue/store.ts
+++ b/queue/store.ts
@@ -341,6 +341,14 @@ export function formatQueueDeliveryText(item: PowerlineQueueItem): string {
   return `[powerline idea ${item.id}, captured ${new Date(item.createdAt).toISOString()} from ${item.source.cwd}]\n${item.text}`;
 }
 
+export function formatIdeaIssuePrompt(item: PowerlineQueueItem): string {
+  const target = item.target.kind === "project"
+    ? `project ${item.target.alias ? `@${item.target.alias} ` : ""}${item.target.cwd}`
+    : item.target.kind;
+
+  return `Please process this saved Powerline idea as a GitHub issue candidate.\n\n${formatQueueDeliveryText(item)}\n\nIssue filing rules:\n- If subagents are available, spawn one low-budget issue-filing lane for this idea; otherwise do the same checks directly.\n- First identify the target repository from the idea target (${target}), source cwd (${item.source.cwd}), and current session context.\n- If the target repository is unclear or is not owned/controlled by the user, ask before filing anything.\n- If the target repository is clear and owned/controlled by the user, dedupe against existing open issues first.\n- If a matching open issue already exists, report it and do not create another issue.\n- If no matching issue exists, create one self-contained GitHub issue in that repository with a clear title, context, acceptance criteria, and the Powerline idea provenance above.\n- Use explicit repository targeting for GitHub commands and do not change source files for this handoff.`;
+}
+
 export function parseCompactQueuedPrompt(text: string): string | null {
   const trimmed = text.trim();
   const match = /^\/compact\s+(.+)$/.exec(trimmed);

--- a/segments.ts
+++ b/segments.ts
@@ -552,8 +552,12 @@ function renderCustomSegment(id: `custom:${string}`, ctx: SegmentContext): Rende
   return { content, visible: true };
 }
 
+function isCustomSegmentId(id: StatusLineSegmentId): id is `custom:${string}` {
+  return id.startsWith("custom:");
+}
+
 export function renderSegment(id: StatusLineSegmentId, ctx: SegmentContext): RenderedSegment {
-  if (id.startsWith("custom:")) {
+  if (isCustomSegmentId(id)) {
     return renderCustomSegment(id, ctx);
   }
 

--- a/shortcuts.ts
+++ b/shortcuts.ts
@@ -1,4 +1,4 @@
-import { isKeyRelease, matchesKey } from "@earendil-works/pi-tui";
+import { isKeyRelease, matchesKey, type KeyId } from "@earendil-works/pi-tui";
 
 const SUPER_SHORTCUT_PATTERNS = new Map<string, RegExp>([
   ["super+up", /^\x1b\[(?:1;9(?::[12])?[AH]|574(?:19|23);9(?::[12])?u|7;9(?::[12])?~|27;9;65~)$/],
@@ -45,7 +45,7 @@ export function matchesConfiguredShortcut(data: string, shortcut: string | null 
     return SUPER_SHORTCUT_PATTERNS.get(normalizedShortcut)?.test(data) ?? false;
   }
 
-  return matchesKey(data, shortcut);
+  return matchesKey(data, shortcut as KeyId);
 }
 
 export function matchesStashShortcutInput(data: string, options: { includePrintableSharpS?: boolean } = {}): boolean {

--- a/tests/bash-mode.test.ts
+++ b/tests/bash-mode.test.ts
@@ -24,6 +24,13 @@ function getMethod(target: object, name: string): Function {
   return method;
 }
 
+function resolveManagedShellPath(): string | null {
+  for (const shellPath of ["/bin/zsh", "/bin/bash"]) {
+    if (existsSync(shellPath)) return shellPath;
+  }
+  return null;
+}
+
 function ensureEditorModuleLinks(): { cleanup: () => void } {
   const nodeModulesDir = join(process.cwd(), "node_modules", "@earendil-works");
   mkdirSync(nodeModulesDir, { recursive: true });
@@ -473,12 +480,18 @@ test("deterministic path completion handles bash argument position", async () =>
   assert.equal(suggestion?.source, "path");
 });
 
-test("managed shell session preserves cwd changes across commands", async () => {
+test("managed shell session preserves cwd changes across commands", async (t) => {
+  const shellPath = resolveManagedShellPath();
+  if (!shellPath) {
+    t.skip("requires zsh or bash");
+    return;
+  }
+
   const cwd = mkdtempSync(join(tmpdir(), "powerline-shell-"));
   const childDir = join(cwd, "child");
   mkdirSync(childDir, { recursive: true });
   const store = new BashTranscriptStore({ transcriptMaxLines: 100, transcriptMaxBytes: 64 * 1024 });
-  const session = new ManagedShellSession("/bin/zsh", cwd, store, () => {}, () => {});
+  const session = new ManagedShellSession(shellPath, cwd, store, () => {}, () => {});
 
   try {
     await session.ensureReady();
@@ -505,10 +518,16 @@ test("managed shell session preserves cwd changes across commands", async () => 
   }
 });
 
-test("managed shell session recovers cleanly after interrupt", async () => {
+test("managed shell session recovers cleanly after interrupt", async (t) => {
+  const shellPath = resolveManagedShellPath();
+  if (!shellPath) {
+    t.skip("requires zsh or bash");
+    return;
+  }
+
   const cwd = mkdtempSync(join(tmpdir(), "powerline-shell-interrupt-"));
   const store = new BashTranscriptStore({ transcriptMaxLines: 100, transcriptMaxBytes: 64 * 1024 });
-  const session = new ManagedShellSession("/bin/zsh", cwd, store, () => {}, () => {});
+  const session = new ManagedShellSession(shellPath, cwd, store, () => {}, () => {});
 
   const waitForCommand = async () => {
     const start = Date.now();
@@ -684,7 +703,12 @@ test("bash editor refreshes shell ghost state after a bracketed paste completes"
   }
 });
 
-test("bash editor inserts Finder file drops as path strings", async () => {
+test("bash editor inserts Finder file drops as path strings", async (t) => {
+  if (process.platform === "win32") {
+    t.skip("Finder file drops are macOS/POSIX paths");
+    return;
+  }
+
   const links = ensureEditorModuleLinks();
 
   try {
@@ -756,28 +780,26 @@ test("one-off bash autocomplete provider stays inactive even inside bang command
   assert.equal(suggestions, null);
 });
 
-test("bash autocomplete providers return null synchronously in shell contexts", () => {
+test("bash autocomplete providers return null in shell contexts", async () => {
   const signal = new AbortController().signal;
 
-  const bashSuggestions = new BashAutocompleteProvider().getSuggestions(["git st"], 0, 6, { signal });
-  const oneOffSuggestions = new OneOffBashAutocompleteProvider().getSuggestions(["!git st"], 0, 7, { signal });
+  const bashSuggestions = await new BashAutocompleteProvider().getSuggestions(["git st"], 0, 6, { signal });
+  const oneOffSuggestions = await new OneOffBashAutocompleteProvider().getSuggestions(["!git st"], 0, 7, { signal });
 
   assert.equal(bashSuggestions, null);
   assert.equal(oneOffSuggestions, null);
-  assert.equal(bashSuggestions instanceof Promise, false);
-  assert.equal(oneOffSuggestions instanceof Promise, false);
 });
 
-test("mode-aware autocomplete provider preserves synchronous default results", () => {
+test("mode-aware autocomplete provider preserves default results", async () => {
   const signal = new AbortController().signal;
-  const syncResult = {
+  const result = {
     items: [{ value: "status", label: "status" }],
     prefix: "st",
   };
   const provider = new ModeAwareAutocompleteProvider(
     {
-      getSuggestions() {
-        return syncResult;
+      async getSuggestions() {
+        return result;
       },
       applyCompletion(lines: string[], cursorLine: number, cursorCol: number) {
         return { lines, cursorLine, cursorCol };
@@ -788,10 +810,9 @@ test("mode-aware autocomplete provider preserves synchronous default results", (
     () => false,
   );
 
-  const suggestions = provider.getSuggestions(["st"], 0, 2, { signal });
+  const suggestions = await provider.getSuggestions(["st"], 0, 2, { signal });
 
-  assert.equal(suggestions, syncResult);
-  assert.equal(suggestions instanceof Promise, false);
+  assert.equal(suggestions, result);
 });
 
 test("one-off bash autocomplete provider stays inactive before the bang command starts", async () => {

--- a/tests/cd-command.test.ts
+++ b/tests/cd-command.test.ts
@@ -41,10 +41,12 @@ test("cd argument completions suggest directories and quick picks", () => {
   assert.ok(rootCompletions.some((item) => item.value === "My\\ Folder/" && item.label === "My Folder/"));
   assert.ok(!rootCompletions.some((item) => item.label === "file.txt"));
 
-  assert.deepEqual(
-    getCdArgumentCompletions("~/p", root, home).map((item) => item.value),
-    ["~/project/"],
-  );
+  if (process.platform !== "win32") {
+    assert.deepEqual(
+      getCdArgumentCompletions("~/p", root, home).map((item) => item.value),
+      ["~/project/"],
+    );
+  }
 });
 
 test("cd command cleans up the forked session when switching is cancelled", async () => {

--- a/tests/queue-store.test.ts
+++ b/tests/queue-store.test.ts
@@ -1,9 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { PowerlineQueueStore, currentQueueContext, formatQueueDeliveryText, parseCompactQueuedPrompt, parseSigilIdeaCapture, parseTargetPrefix, targetForIdea } from "../queue/store.ts";
+import { PowerlineQueueStore, currentQueueContext, formatIdeaIssuePrompt, formatQueueDeliveryText, parseCompactQueuedPrompt, parseSigilIdeaCapture, parseTargetPrefix, targetForIdea } from "../queue/store.ts";
 
 function withStore(fn: (store: PowerlineQueueStore, dir: string) => void): void {
   const dir = mkdtempSync(join(tmpdir(), "powerline-queue-"));
@@ -70,7 +70,7 @@ test("queue store aliases resolve idea targets", () => withStore((store) => {
 
   assert.deepEqual(targetForIdea("pika", store, "/tmp/current"), {
     kind: "project",
-    cwd: "/tmp/pika",
+    cwd: resolve("/tmp/pika"),
     alias: "pika",
   });
   assert.deepEqual(targetForIdea("global", store, "/tmp/current"), { kind: "global" });
@@ -115,6 +115,26 @@ test("formatQueueDeliveryText adds provenance only for ideas", () => {
     "[powerline idea a1b2c3d4, captured 1970-01-01T00:00:01.000Z from /tmp/project]\ncheck logs",
   );
   assert.equal(formatQueueDeliveryText(prompt), "check logs");
+});
+
+test("formatIdeaIssuePrompt requires dedupe and clear owned repo before filing", () => {
+  const prompt = formatIdeaIssuePrompt({
+    id: "a1b2c3d4",
+    text: "add typed issue handoff",
+    createdAt: 1000,
+    updatedAt: 1000,
+    source: { cwd: "/tmp/project" },
+    target: { kind: "project", cwd: "/tmp/project", alias: "powerline" },
+    intent: "idea",
+    status: "queued",
+  });
+
+  assert.match(prompt, /spawn one low-budget issue-filing lane/);
+  assert.match(prompt, /target repository is unclear or is not owned\/controlled by the user, ask before filing/);
+  assert.match(prompt, /dedupe against existing open issues first/);
+  assert.match(prompt, /If a matching open issue already exists, report it and do not create another issue/);
+  assert.match(prompt, /create one self-contained GitHub issue/);
+  assert.match(prompt, /project @powerline \/tmp\/project/);
 });
 
 test("parseCompactQueuedPrompt treats /compact suffix as queued prompt text", () => {

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -135,13 +135,13 @@ test("startup welcome predicate respects powerline.welcome false", () => {
   assert.equal(shouldShowStartupWelcome("startup", true), true);
   assert.equal(shouldShowStartupWelcome("startup", false), false);
   assert.equal(shouldShowStartupWelcome("resume", true), false);
-  assert.match(source, /setupCustomEditor\(ctx\);\n\s+if \(shouldShowStartupWelcome\(event\.reason, config\.welcome\)\)/);
+  assert.match(source, /setupCustomEditor\(ctx\);\r?\n\s+if \(shouldShowStartupWelcome\(event\.reason, config\.welcome\)\)/);
 });
 
 test("stale ctx guard handles old and new Pi messages on agent_end", () => {
   assert.equal(isStaleExtensionContextError(new Error("This extension instance is stale after session replacement or reload.")), true);
   assert.equal(isStaleExtensionContextError(new Error("This extension ctx is stale after session replacement or reload.")), true);
   assert.equal(isStaleExtensionContextError(new Error("ctx.hasUI failed for another reason")), false);
-  assert.match(source, /let hasUI = false;\n\s+try \{\n\s+hasUI = Boolean\(ctx\.hasUI\);/);
-  assert.match(source, /if \(!isStaleExtensionContextError\(error\)\) throw error;\n\s+currentCtx = null;\n\s+return;/);
+  assert.match(source, /let hasUI = false;\r?\n\s+try \{\r?\n\s+hasUI = Boolean\(ctx\.hasUI\);/);
+  assert.match(source, /if \(!isStaleExtensionContextError\(error\)\) throw error;\r?\n\s+currentCtx = null;\r?\n\s+return;/);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "allowImportingTsExtensions": true
+  },
+  "include": ["*.ts", "bash-mode/**/*.ts", "queue/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Adds the strict TypeScript quality gate from `nicobailon/pi-subagents#749` to this extension and fixes the source issues it exposed. The branch pins TypeScript 5.9.3 and `@types/node` 24.13.3, adds a source-only `tsconfig.json`, and adds GitHub Actions on Ubuntu and Windows with typecheck before tests.

It also moves compaction queue delivery off unsupported internal `compaction_start`/`compaction_end` events and onto Pi's public `session_before_compact`/`session_compact` lifecycle, with failure blocking and retry-settled delivery preserved. Captured ideas now have `/ideas next` plus `/idea issue [id]` and `/ideas issue [id]` for guarded issue-triage handoff through the current agent rather than direct GitHub mutation.

## Validation

- `npm ci --ignore-scripts`
- `npm run typecheck`
- `npm test` (164 tests)
- `git diff --check`
- `npm pack --dry-run --json`
- Fresh reviewer pass; targeted follow-up reviewer reported no findings after the retry-delivery fix.
