### PR TITLE
fix: label saved ideas in queue preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Queue preview labels** — Saved ideas now show an `idea:` preview label instead of looking like normal queued prompts, while deliverable, sending, and blocked queue items keep distinct labels.
+
 ## [0.12.0] - 2026-08-03
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -2687,9 +2687,15 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const summary = queueStore.summarize(getQueueContext(currentCtx), powerlineCompacting);
     if (!summary.leadingText) return [];
 
-    const prefix = summary.blockedCount > 0 ? "blocked: " : "queued: ";
+    const prefix = summary.leadingStatus === "blocked" || summary.leadingStatus === "failed"
+      ? "blocked: "
+      : summary.leadingStatus === "delivering"
+        ? "sending: "
+        : summary.leadingIntent === "idea"
+          ? "idea: "
+          : "queued: ";
     const text = `${prefix}${summary.leadingText.replace(/\s+/g, " ").trim()}`;
-    const color = summary.blockedCount > 0 ? "warning" : "dim";
+    const color = summary.leadingStatus === "blocked" || summary.leadingStatus === "failed" ? "warning" : "dim";
     return [` ${theme.fg(color, truncateToWidth(text, Math.max(1, width - 1), "…"))}`];
   }
 

--- a/queue/store.ts
+++ b/queue/store.ts
@@ -209,6 +209,8 @@ export class PowerlineQueueStore {
       blockedCount: blockedItems.length,
       compacting,
       leadingText: leading?.text ?? null,
+      leadingIntent: leading?.intent ?? null,
+      leadingStatus: leading?.status ?? null,
     };
   }
 

--- a/queue/types.ts
+++ b/queue/types.ts
@@ -33,6 +33,8 @@ export interface QueueSummary {
   blockedCount: number;
   compacting: boolean;
   leadingText: string | null;
+  leadingIntent: QueueIntent | null;
+  leadingStatus: QueueStatus | null;
 }
 
 export interface CreateQueueItemInput {

--- a/tests/queue-store.test.ts
+++ b/tests/queue-store.test.ts
@@ -38,6 +38,8 @@ test("queue store adds active project ideas and summarizes them", () => withStor
     blockedCount: 0,
     compacting: true,
     leadingText: "run after compact",
+    leadingIntent: "post-compact",
+    leadingStatus: "queued",
   });
 }));
 
@@ -51,6 +53,26 @@ test("queue store filters inactive project items", () => withStore((store) => {
 
   assert.equal(store.activeItems(currentQueueContext("/tmp/project-b")).length, 0);
   assert.equal(store.activeItems(currentQueueContext("/tmp/project-a")).length, 1);
+}));
+
+test("queue store exposes the leading item intent for idea-only summaries", () => withStore((store) => {
+  store.add({
+    text: "saved follow-up idea",
+    source: { cwd: "/tmp/project" },
+    target: { kind: "project", cwd: "/tmp/project" },
+    intent: "idea",
+    now: 100,
+  });
+
+  assert.deepEqual(store.summarize(currentQueueContext("/tmp/project"), false), {
+    queueCount: 0,
+    ideaCount: 1,
+    blockedCount: 0,
+    compacting: false,
+    leadingText: "saved follow-up idea",
+    leadingIntent: "idea",
+    leadingStatus: "queued",
+  });
 }));
 
 test("current-session targets stay scoped to the source session when known", () => withStore((store) => {

--- a/tests/usage-display.test.ts
+++ b/tests/usage-display.test.ts
@@ -41,7 +41,7 @@ function createSegmentContext(options: StatusLineSegmentOptions = {}, overrides:
     autoCompactEnabled: true,
     customCompactionEnabled: false,
     usingSubscription: false,
-    queueSummary: { queueCount: 0, ideaCount: 0, blockedCount: 0, compacting: false, leadingText: null },
+    queueSummary: { queueCount: 0, ideaCount: 0, blockedCount: 0, compacting: false, leadingText: null, leadingIntent: null, leadingStatus: null },
     sessionStartTime: Date.now(),
     shellModeActive: false,
     shellRunning: false,
@@ -149,7 +149,7 @@ test("queue segment hides when empty", () => {
 
 test("queue segment summarizes queued ideas and blocked items", () => {
   const ctx = createSegmentContext({}, {
-    queueSummary: { queueCount: 2, ideaCount: 3, blockedCount: 1, compacting: false, leadingText: "fix README" },
+    queueSummary: { queueCount: 2, ideaCount: 3, blockedCount: 1, compacting: false, leadingText: "fix README", leadingIntent: "post-compact", leadingStatus: "blocked" },
   });
 
   assert.equal(stripAnsi(renderSegment("queue", ctx).content), "q 2 · ideas 3 · blocked 1");
@@ -157,7 +157,7 @@ test("queue segment summarizes queued ideas and blocked items", () => {
 
 test("queue segment highlights compaction-held prompts", () => {
   const ctx = createSegmentContext({}, {
-    queueSummary: { queueCount: 1, ideaCount: 0, blockedCount: 0, compacting: true, leadingText: "run after compact" },
+    queueSummary: { queueCount: 1, ideaCount: 0, blockedCount: 0, compacting: true, leadingText: "run after compact", leadingIntent: "post-compact", leadingStatus: "queued" },
   });
 
   assert.equal(stripAnsi(renderSegment("queue", ctx).content), "compact q 1");

--- a/types.ts
+++ b/types.ts
@@ -160,6 +160,8 @@ export interface QueueSummary {
   blockedCount: number;
   compacting: boolean;
   leadingText: string | null;
+  leadingIntent: "steer" | "follow-up" | "post-compact" | "idea" | null;
+  leadingStatus: "queued" | "blocked" | "delivering" | "sent" | "failed" | null;
 }
 
 export interface UsageStats {


### PR DESCRIPTION
## Summary

Saved ideas now show an `idea:` preview label instead of looking like normal queued prompts. Deliverable, sending, and blocked queue items keep distinct labels.

## Validation

- `npm run typecheck`
- `npm test -- tests/queue-store.test.ts`
- `git diff --check`
- Fresh-context reviewer: no issues found