### PR TITLE
fix: validate custom item colors to prevent 'Unknown theme color' errors

### DIFF
--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -76,10 +76,35 @@ function normalizeCustomItemPosition(value: unknown): CustomItemPosition {
   return "right";
 }
 
+/**
+ * Valid foreground theme color names, mirrored from the pi core `ThemeColor`
+ * union. Any other string (e.g. "info") is NOT a valid theme color and would
+ * make `theme.fg()` throw "Unknown theme color" during status-line rendering.
+ */
+const VALID_THEME_COLORS = new Set<string>([
+  "accent", "border", "borderAccent", "borderMuted", "success", "error",
+  "warning", "muted", "dim", "text", "thinkingText", "userMessageText",
+  "customMessageText", "customMessageLabel", "toolTitle", "toolOutput",
+  "mdHeading", "mdLink", "mdLinkUrl", "mdCode", "mdCodeBlock",
+  "mdCodeBlockBorder", "mdQuote", "mdQuoteBorder", "mdHr", "mdListBullet",
+  "toolDiffAdded", "toolDiffRemoved", "toolDiffContext",
+  "syntaxComment", "syntaxKeyword", "syntaxFunction", "syntaxVariable",
+  "syntaxString", "syntaxNumber", "syntaxType", "syntaxOperator",
+  "syntaxPunctuation", "thinkingOff", "thinkingMinimal", "thinkingLow",
+  "thinkingMedium", "thinkingHigh", "thinkingXhigh", "thinkingMax", "bashMode",
+]);
+
 function normalizeCustomColor(value: unknown): ColorValue | undefined {
   if (typeof value !== "string") return undefined;
   const normalized = value.trim();
-  return normalized ? (normalized as ColorValue) : undefined;
+  if (!normalized) return undefined;
+  // Reject unknown theme color names (e.g. "info") before they reach theme.fg().
+  // Only hex colors and known theme colors are accepted.
+  if (!normalized.startsWith("#") && !VALID_THEME_COLORS.has(normalized)) {
+    console.debug(`[powerline-footer] Ignoring invalid custom item color "${normalized}".`);
+    return undefined;
+  }
+  return normalized as ColorValue;
 }
 
 function normalizeCustomPrefix(value: unknown): string | undefined {


### PR DESCRIPTION
## Problem

`normalizeCustomColor` in `powerline-config.ts` accepted any string as a `ColorValue` with no validation. An invalid theme color name (e.g. `"info"`) flowed straight through to `theme.fg()`, which throws `Unknown theme color: info`. The status line then forced a fallback to `"text"` (see `applyColor` in `theme.ts`) and logged a noisy debug error on every render.

## Root cause

Custom items are the only path where an arbitrary color string can reach `theme.fg()`. Built-in segments go through semantic resolution, but `custom.color` is passed through unchanged.

## Fix

Validate the color against the pi core `ThemeColor` union (mirrored here) plus hex colors, and reject unknown names at parse time — returning `undefined` so the segment renders uncolored instead of throwing.

## Notes

- Hex colors (`#......`) are still accepted.
- The valid set mirrors `ThemeColor` from `@earendil-works/pi-coding-agent`. If pi adds theme colors, this list needs a matching entry (a good candidate for pulling the runtime set from the core to avoid drift).