### PR TITLE
fix: guard queued compaction delivery after reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Post-compaction queue delivery** — Snapshot the queue context before delayed delivery so a reload or session replacement cannot crash by reading a stale extension context. Thanks to @pascalandy for the report in nicobailon/pi-subagents#897.
+
 ## [0.12.1] - 2026-08-04
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -64,7 +64,7 @@ import {
   parseVibeGenerateArgs,
 } from "./working-vibes.ts";
 import { PowerlineQueueStore, currentQueueContext, formatIdeaIssuePrompt, formatQueueDeliveryText, parseCompactQueuedPrompt, parseSigilIdeaCapture, parseTargetPrefix, targetForIdea } from "./queue/store.ts";
-import type { PowerlineQueueItem, QueueIntent, QueueTarget } from "./queue/types.ts";
+import type { PowerlineQueueItem, QueueContext, QueueIntent, QueueTarget } from "./queue/types.ts";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Configuration
@@ -1237,7 +1237,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     return typeof sessionId === "string" && sessionId.trim() ? sessionId : undefined;
   }
 
-  function getQueueContext(ctx: any) {
+  function getQueueContext(ctx: any): QueueContext {
     return currentQueueContext(ctx.cwd ?? process.cwd(), getQueueSessionId(ctx));
   }
 
@@ -1335,6 +1335,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     queueStore.update(item.id, { status: "delivering", error: undefined });
     requestQueueRender();
 
+    let sent = false;
     try {
       const deliverAs = deliveryModeForItem(ctx, item);
       const deliveryText = formatQueueDeliveryText(item);
@@ -1343,11 +1344,22 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       } else {
         pi.sendUserMessage(deliveryText);
       }
+      sent = true;
       queueStore.update(item.id, { status: "sent", error: undefined });
-      ctx.ui.notify(`Sent queued item ${item.id}`, "info");
+      try {
+        ctx.ui.notify(`Sent queued item ${item.id}`, "info");
+      } catch (error) {
+        if (!isStaleExtensionContextError(error)) throw error;
+        currentCtx = null;
+      }
       requestQueueRender();
       return true;
     } catch (error) {
+      if (isStaleExtensionContextError(error)) {
+        if (!sent) queueStore.update(item.id, { status: "queued", error: undefined });
+        currentCtx = null;
+        throw error;
+      }
       const message = error instanceof Error ? error.message : String(error);
       queueStore.update(item.id, { status: "failed", error: message });
       ctx.ui.notify(`Failed to send ${item.id}: ${message}`, "error");
@@ -1358,10 +1370,18 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   function schedulePostCompactionDelivery(ctx: any): void {
     if (queueDeliveryTimer) clearTimeout(queueDeliveryTimer);
+    const queueContext = getQueueContext(ctx);
+    const scheduledGeneration = sessionGeneration;
     queueDeliveryTimer = setTimeout(() => {
       queueDeliveryTimer = null;
-      const item = queueStore.queuedDeliveryItems(getQueueContext(ctx), "post-compact")[0];
-      if (item) deliverQueueItem(ctx, item);
+      if (scheduledGeneration !== sessionGeneration) return;
+      try {
+        const item = queueStore.queuedDeliveryItems(queueContext, "post-compact")[0];
+        if (item) deliverQueueItem(ctx, item);
+      } catch (error) {
+        if (!isStaleExtensionContextError(error)) throw error;
+        currentCtx = null;
+      }
     }, 50);
   }
 

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -145,3 +145,10 @@ test("stale ctx guard handles old and new Pi messages on agent_end", () => {
   assert.match(source, /let hasUI = false;\r?\n\s+try \{\r?\n\s+hasUI = Boolean\(ctx\.hasUI\);/);
   assert.match(source, /if \(!isStaleExtensionContextError\(error\)\) throw error;\r?\n\s+currentCtx = null;\r?\n\s+return;/);
 });
+
+test("post-compaction queue delivery does not read ctx.cwd from the delayed callback", () => {
+  assert.match(source, /const queueContext = getQueueContext\(ctx\);\r?\n\s+const scheduledGeneration = sessionGeneration;\r?\n\s+queueDeliveryTimer = setTimeout/);
+  assert.match(source, /if \(scheduledGeneration !== sessionGeneration\) return;\r?\n\s+try \{\r?\n\s+const item = queueStore\.queuedDeliveryItems\(queueContext, "post-compact"\)\[0\];/);
+  assert.match(source, /catch \(error\) \{\r?\n\s+if \(!isStaleExtensionContextError\(error\)\) throw error;\r?\n\s+currentCtx = null;/);
+  assert.match(source, /if \(isStaleExtensionContextError\(error\)\) \{\r?\n\s+if \(!sent\) queueStore\.update\(item\.id, \{ status: "queued", error: undefined \}\);/);
+});


### PR DESCRIPTION
## Summary

Fixes the delayed post-compaction queue delivery path that could read a stale extension context after reload or session replacement.

The delivery timer now snapshots the queue context before scheduling work, skips delivery when the session generation changes, and keeps queued items queued when a stale context race happens before the message is sent. If the stale context happens only while showing the success notification after send, the item stays sent.

Addresses nicobailon/pi-subagents#897.

## Validation

- `node --experimental-strip-types --test tests/remaining-regressions.test.ts`
- `npm test`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

## Review

Fresh read-only review passed on `05926a3dc3bbf68149faa688915f20b0aeffe639` after one blocker fix.

## Credit

Thanks to @pascalandy for the report in nicobailon/pi-subagents#897.
