### PR TITLE
fix: cache unreadable global shell history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Global shell history fallback** — Cache unreadable global history files as empty until their fingerprint changes, so bash mode keeps working without logging a stack on every keypress. Thanks to @RomainMuller for #143.
 - **Post-compaction queue delivery** — Snapshot the queue context before delayed delivery so a reload or session replacement cannot crash by reading a stale extension context. Thanks to @pascalandy for the report in nicobailon/pi-subagents#897.
 
 ## [0.12.1] - 2026-08-04

--- a/bash-mode/history.ts
+++ b/bash-mode/history.ts
@@ -161,8 +161,9 @@ export function readGlobalShellHistory(shellPath: string): string[] {
     return [];
   }
 
+  let stat: FileFingerprint | undefined;
   try {
-    const stat = statSync(filePath);
+    stat = statSync(filePath);
     const cached = globalHistoryCache.get(cacheKey);
     if (cached && matchesFingerprint(cached, stat)) {
       return cached.entries;
@@ -174,18 +175,13 @@ export function readGlobalShellHistory(shellPath: string): string[] {
       : shellName.includes("fish")
         ? parseFishHistory(raw).reverse()
         : parseBashHistory(raw.split("\n")).reverse();
-    globalHistoryCache.set(cacheKey, {
-      ctimeMs: stat.ctimeMs,
-      mtimeMs: stat.mtimeMs,
-      mode: stat.mode,
-      size: stat.size,
-      entries,
-    });
+    globalHistoryCache.set(cacheKey, { ...stat, entries });
     return entries;
   } catch (error) {
-    // Global shell history is optional recall data. If it is unavailable, shell predictions
-    // should degrade to other sources instead of failing the editor.
-    console.debug(`[powerline-footer] Failed to read global shell history for ${shellName}:`, error);
+    if (stat) {
+      globalHistoryCache.set(cacheKey, { ...stat, entries: [] });
+      console.debug(`[powerline-footer] Failed to read global shell history for ${shellName}:`, error);
+    }
     return [];
   }
 }

--- a/tests/bash-mode.test.ts
+++ b/tests/bash-mode.test.ts
@@ -84,6 +84,38 @@ test("project history is stored newest-first and global zsh history parses histf
   assert.deepEqual(global, ["plain-command", "git pull", "git fetch"]);
 });
 
+test("global history caches an unreadable file until its fingerprint changes", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "powerline-unreadable-history-"));
+  const historyPath = join(cwd, ".zsh_history");
+  const originalHistfile = process.env.HISTFILE;
+  const originalDebug = console.debug;
+  let debugCalls = 0;
+
+  try {
+    mkdirSync(historyPath);
+    process.env.HISTFILE = historyPath;
+    console.debug = () => {
+      debugCalls += 1;
+    };
+
+    assert.deepEqual(readGlobalShellHistory("/bin/zsh"), []);
+    assert.deepEqual(readGlobalShellHistory("/bin/zsh"), []);
+    assert.equal(debugCalls, 1);
+
+    rmSync(historyPath, { recursive: true });
+    writeFileSync(historyPath, ": 1711111111:0;git status\n");
+    assert.deepEqual(readGlobalShellHistory("/bin/zsh"), ["git status"]);
+  } finally {
+    console.debug = originalDebug;
+    if (originalHistfile === undefined) {
+      delete process.env.HISTFILE;
+    } else {
+      process.env.HISTFILE = originalHistfile;
+    }
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 test("matchHistoryEntries returns newest entries when the prefix is empty", () => {
   const matches = matchHistoryEntries([
     "git stash",


### PR DESCRIPTION
Closes #143.

This caches an unreadable global shell history file as empty under its current file fingerprint, so bash mode keeps using project history and deterministic suggestions without logging a stack for every keypress. If the file permissions or content change, the fingerprint changes and the reader retries.

Validation:
- `git diff --check origin/main...HEAD`
- `node --experimental-strip-types --test tests/bash-mode.test.ts`
- `npm test`
- `npm run typecheck`

Fresh review: `/tmp/pi-powerline-backlog-20260808080851/issue-143/review.md` reported no findings.

Credit: thanks to @RomainMuller for the report in #143.