### PR TITLE
test: stabilize git status cache assertion

### DIFF
--- a/tests/git-status.test.ts
+++ b/tests/git-status.test.ts
@@ -24,11 +24,18 @@ test("invalidateGitStatus serves stale counts while refreshing (no flicker to ze
 
   invalidateGitStatus();
   const afterInvalidate = getGitStatus("provider-branch");
-  assert.deepEqual(afterInvalidate, seeded);
+  assert.deepEqual(
+    { staged: afterInvalidate.staged, unstaged: afterInvalidate.unstaged, untracked: afterInvalidate.untracked },
+    { staged: seeded.staged, unstaged: seeded.unstaged, untracked: seeded.untracked },
+  );
 
   // The background refresh converges to real data again (repo is unchanged).
   await sleep(FETCH_SETTLE_MS);
-  assert.deepEqual(getGitStatus("provider-branch"), seeded);
+  const refreshed = getGitStatus("provider-branch");
+  assert.deepEqual(
+    { staged: refreshed.staged, unstaged: refreshed.unstaged, untracked: refreshed.untracked },
+    { staged: seeded.staged, unstaged: seeded.unstaged, untracked: seeded.untracked },
+  );
 });
 
 test("invalidateGitBranch keeps serving the last known branch while refreshing", async () => {


### PR DESCRIPTION
This is a fix-forward for the failed exact-merge CI run on `main` after #149.

Windows failed `tests/git-status.test.ts` because the status-cache test compared the branch value, but branch data is owned by a separate cache and can refresh independently. The test now keeps the contract it owns: staged, unstaged, and untracked counts stay stable while status refreshes. Runtime code is unchanged.

Validation:
- `git diff --check`
- `node --experimental-strip-types --test tests/git-status.test.ts`
- `npm test`
- `npm run typecheck`

Fresh review: `/tmp/pi-powerline-backlog-20260808080851/fix-main-git-status-test/review.md` reported no findings.