### PR TITLE
fix: align fullscreen footer height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Fullscreen footer height** — Return one blank footer line so the Powerline footer matches Pi fullscreen dock sizing at startup. Thanks to @acidnik for #144.
 - **Global shell history fallback** — Cache unreadable global history files as empty until their fingerprint changes, so bash mode keeps working without logging a stack on every keypress. Thanks to @RomainMuller for #143.
 - **Post-compaction queue delivery** — Snapshot the queue context before delayed delivery so a reload or session replacement cannot crash by reading a stale extension context. Thanks to @pascalandy for the report in nicobailon/pi-subagents#897.
 

--- a/index.ts
+++ b/index.ts
@@ -3096,7 +3096,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           requestStatusRender();
         },
         render(): string[] {
-          return [];
+          return [""];
         },
       };
     });


### PR DESCRIPTION
Closes #144.

Powerline registers a custom footer component that Pi fullscreen mode reserves at `minSize: 1`. The component now returns one blank rendered line, so its intrinsic height matches that reserved footer row and the top powerline widget is not clipped at startup.

Validation:
- `git diff --check origin/main...HEAD`
- `npm test`
- `npm run typecheck`

Fresh reviews:
- `/tmp/pi-powerline-backlog-20260808080851/issue-144/review.md`
- `/tmp/pi-powerline-backlog-20260808080851/issue-144/final-review.md`

Credit: thanks to @acidnik for the precise report and root-cause analysis in #144.