### PR TITLE
fix: refresh context display after compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Post-compaction context display** — Show Pi's unknown context state immediately after compaction instead of keeping the stale pre-compaction percentage until the next assistant response.
+
 ## [0.12.2] - 2026-08-08
 
 ### Fixed

--- a/context-usage.ts
+++ b/context-usage.ts
@@ -1,7 +1,13 @@
 export interface CoreContextUsage {
-  contextTokens: number;
+  contextTokens: number | null;
   contextWindow: number;
-  contextPercent: number;
+  contextPercent: number | null;
+}
+
+interface DisplayContextUsageInput {
+  coreContextUsage: CoreContextUsage | null;
+  fallbackContextTokens: number;
+  fallbackContextWindow: number;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -61,6 +67,20 @@ export function estimateInitialContextTokens(ctx: unknown): number | null {
   return Math.ceil(prompt.length / 4);
 }
 
+export function resolveDisplayContextUsage({
+  coreContextUsage,
+  fallbackContextTokens,
+  fallbackContextWindow,
+}: DisplayContextUsageInput): CoreContextUsage {
+  if (coreContextUsage) return coreContextUsage;
+
+  return {
+    contextTokens: fallbackContextTokens,
+    contextWindow: fallbackContextWindow,
+    contextPercent: fallbackContextWindow > 0 ? (fallbackContextTokens / fallbackContextWindow) * 100 : 0,
+  };
+}
+
 export function readCoreContextUsage(ctx: unknown): CoreContextUsage | null {
   if (!isRecord(ctx) || typeof ctx.getContextUsage !== "function") {
     return null;
@@ -74,13 +94,16 @@ export function readCoreContextUsage(ctx: unknown): CoreContextUsage | null {
   const tokens = usage.tokens;
   const contextWindow = usage.contextWindow;
   if (
-    typeof tokens !== "number"
-    || !Number.isFinite(tokens)
+    !(tokens === null || (typeof tokens === "number" && Number.isFinite(tokens)))
     || typeof contextWindow !== "number"
     || !Number.isFinite(contextWindow)
     || contextWindow <= 0
   ) {
     return null;
+  }
+
+  if (tokens === null) {
+    return { contextTokens: null, contextWindow, contextPercent: null };
   }
 
   const percent = usage.percent;

--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,7 @@ import { WelcomeComponent, WelcomeHeader, discoverLoadedCounts, getRecentSession
 import { createWelcomeDismissScheduler } from "./welcome-dismiss.ts";
 import { createRenderScheduler } from "./render-scheduler.ts";
 import { getEditorAutocompleteProvider, passAutocompleteProviderThroughPreviousEditor } from "./editor-composition.ts";
-import { CoreContextUsageCache, estimateInitialContextTokens } from "./context-usage.ts";
+import { CoreContextUsageCache, estimateInitialContextTokens, resolveDisplayContextUsage } from "./context-usage.ts";
 import { isStaleExtensionContextError, shouldShowStartupWelcome } from "./lifecycle.ts";
 import { getDefaultColors } from "./theme.ts";
 import { registerCdCommand } from "./cd-command.ts";
@@ -1716,12 +1716,18 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   pi.on("session_before_compact", async (_event, ctx) => {
     powerlineCompacting = true;
     currentCtx = ctx;
+    isStreaming = false;
+    liveAssistantUsage = null;
+    coreContextUsageCache.reset();
     requestQueueRender();
   });
 
   pi.on("session_compact", async (event, ctx) => {
     powerlineCompacting = false;
     currentCtx = ctx;
+    isStreaming = false;
+    liveAssistantUsage = null;
+    coreContextUsageCache.reset();
     if (event.willRetry) {
       deliverAfterRetrySettles = true;
     } else {
@@ -2576,9 +2582,16 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     // Calculate context percentage.
     const latestUsage = isStreaming ? liveAssistantUsage ?? lastAssistant?.usage : lastAssistant?.usage;
     const coreContextUsage = isStreaming && liveAssistantUsage ? null : coreContextUsageCache.get(ctx);
-    const contextTokens = coreContextUsage?.contextTokens ?? (latestUsage ? getUsageTokenTotal(latestUsage) : 0);
-    const contextWindow = coreContextUsage?.contextWindow ?? ctx.model?.contextWindow ?? 0;
-    const contextPercent = coreContextUsage?.contextPercent ?? (contextWindow > 0 ? (contextTokens / contextWindow) * 100 : 0);
+    const fallbackContextTokens = latestUsage ? getUsageTokenTotal(latestUsage) : 0;
+    const {
+      contextTokens,
+      contextWindow,
+      contextPercent,
+    } = resolveDisplayContextUsage({
+      coreContextUsage,
+      fallbackContextTokens,
+      fallbackContextWindow: ctx.model?.contextWindow ?? 0,
+    });
 
     const segmentOptions = mergeSegmentOptions(presetDef.segmentOptions, config.segmentOptions);
 

--- a/segments.ts
+++ b/segments.ts
@@ -346,19 +346,22 @@ const contextPctSegment: StatusLineSegment = {
 
     const autoIcon = ctx.autoCompactEnabled && icons.auto ? ` ${icons.auto}` : "";
     const percentOnly = ctx.options.context?.format === "percent";
+    const hasKnownUsage = contextTokens !== null && contextPercent !== null;
     // "full" (default): tokens/window + one-decimal percentage + auto-compact icon.
     // "percent": bare rounded percentage, threshold-colored, no icons.
     const text = percentOnly
-      ? `${Math.round(contextPercent)}%`
-      : `${formatTokens(contextTokens)}/${formatTokens(contextWindow)} (${contextPercent.toFixed(1)}%)${autoIcon}`;
+      ? (hasKnownUsage ? `${Math.round(contextPercent)}%` : "?")
+      : hasKnownUsage
+        ? `${formatTokens(contextTokens)}/${formatTokens(contextWindow)} (${contextPercent.toFixed(1)}%)${autoIcon}`
+        : `?/${formatTokens(contextWindow)}${autoIcon}`;
 
     // Icon outside color, text inside - use semantic colors for thresholds
     let content: string;
     const colored = (semantic: "context" | "contextWarn" | "contextError") =>
       percentOnly ? color(ctx, semantic, text) : withIcon(icons.context, color(ctx, semantic, text));
-    if (contextPercent > 90) {
+    if (hasKnownUsage && contextPercent > 90) {
       content = colored("contextError");
-    } else if (contextPercent > 70) {
+    } else if (hasKnownUsage && contextPercent > 70) {
       content = colored("contextWarn");
     } else {
       content = colored("context");

--- a/tests/context-usage.test.ts
+++ b/tests/context-usage.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { CoreContextUsageCache, estimateInitialContextTokens, readCoreContextUsage } from "../context-usage.ts";
+import { CoreContextUsageCache, estimateInitialContextTokens, readCoreContextUsage, resolveDisplayContextUsage } from "../context-usage.ts";
 
 test("readCoreContextUsage returns Pi context estimates for branch summaries", () => {
   const usage = readCoreContextUsage({
@@ -30,10 +30,24 @@ test("readCoreContextUsage computes percent when Pi returns only token totals", 
   });
 });
 
+test("readCoreContextUsage preserves Pi's post-compaction unknown state", () => {
+  const usage = readCoreContextUsage({
+    getContextUsage() {
+      return { tokens: null, contextWindow: 5000, percent: null };
+    },
+  });
+
+  assert.deepEqual(usage, {
+    contextTokens: null,
+    contextWindow: 5000,
+    contextPercent: null,
+  });
+});
+
 test("readCoreContextUsage ignores unknown or unusable estimates", () => {
   assert.equal(readCoreContextUsage({}), null);
   assert.equal(readCoreContextUsage({ getContextUsage: () => undefined }), null);
-  assert.equal(readCoreContextUsage({ getContextUsage: () => ({ tokens: null, contextWindow: 5000, percent: null }) }), null);
+  assert.equal(readCoreContextUsage({ getContextUsage: () => ({ tokens: undefined, contextWindow: 5000, percent: null }) }), null);
   assert.equal(readCoreContextUsage({ getContextUsage: () => ({ tokens: 100, contextWindow: 0, percent: 0 }) }), null);
 });
 
@@ -61,6 +75,30 @@ test("core context usage cache reuses a leaf and supports explicit invalidation"
   tokens = 300;
   assert.equal(cache.get(ctx)?.contextTokens, 300);
   assert.equal(reads, 3);
+});
+
+test("resolveDisplayContextUsage preserves unknown core usage over fallback usage", () => {
+  assert.deepEqual(resolveDisplayContextUsage({
+    coreContextUsage: { contextTokens: null, contextWindow: 5000, contextPercent: null },
+    fallbackContextTokens: 4000,
+    fallbackContextWindow: 5000,
+  }), {
+    contextTokens: null,
+    contextWindow: 5000,
+    contextPercent: null,
+  });
+});
+
+test("resolveDisplayContextUsage computes fallback usage when Pi has no current estimate", () => {
+  assert.deepEqual(resolveDisplayContextUsage({
+    coreContextUsage: null,
+    fallbackContextTokens: 1000,
+    fallbackContextWindow: 4000,
+  }), {
+    contextTokens: 1000,
+    contextWindow: 4000,
+    contextPercent: 25,
+  });
 });
 
 test("estimateInitialContextTokens uses Pi's conservative character estimate", () => {

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -152,3 +152,8 @@ test("post-compaction queue delivery does not read ctx.cwd from the delayed call
   assert.match(source, /catch \(error\) \{\r?\n\s+if \(!isStaleExtensionContextError\(error\)\) throw error;\r?\n\s+currentCtx = null;/);
   assert.match(source, /if \(isStaleExtensionContextError\(error\)\) \{\r?\n\s+if \(!sent\) queueStore\.update\(item\.id, \{ status: "queued", error: undefined \}\);/);
 });
+
+test("compaction events clear live usage before context display can fall back", () => {
+  assert.match(source, /pi\.on\("session_before_compact", async \(_event, ctx\) => \{\r?\n\s+powerlineCompacting = true;\r?\n\s+currentCtx = ctx;\r?\n\s+isStreaming = false;\r?\n\s+liveAssistantUsage = null;\r?\n\s+coreContextUsageCache\.reset\(\);/);
+  assert.match(source, /pi\.on\("session_compact", async \(event, ctx\) => \{\r?\n\s+powerlineCompacting = false;\r?\n\s+currentCtx = ctx;\r?\n\s+isStreaming = false;\r?\n\s+liveAssistantUsage = null;\r?\n\s+coreContextUsageCache\.reset\(\);/);
+});

--- a/tests/usage-display.test.ts
+++ b/tests/usage-display.test.ts
@@ -82,6 +82,22 @@ test("context_pct percent format renders a bare rounded percentage", () => {
   assert.equal(stripAnsi(rendered.content), "6%");
 });
 
+test("context_pct renders unknown usage after compaction", () => {
+  const full = createSegmentContext({}, {
+    contextTokens: null,
+    contextWindow: 200000,
+    contextPercent: null,
+  });
+  const percent = createSegmentContext({ context: { format: "percent" } }, {
+    contextTokens: null,
+    contextWindow: 200000,
+    contextPercent: null,
+  });
+
+  assert.equal(stripAnsi(renderSegment("context_pct", full).content), "◫ ?/200k AC");
+  assert.equal(stripAnsi(renderSegment("context_pct", percent).content), "?");
+});
+
 test("context_pct percent format keeps threshold colors and drops icons", () => {
   for (const [percent, expected] of [[69, "69%"], [85, "85%"], [95, "95%"]] as const) {
     const ctx = createSegmentContext({ context: { format: "percent" } }, {

--- a/types.ts
+++ b/types.ts
@@ -192,8 +192,8 @@ export interface SegmentContext {
   
   // Computed
   usageStats: UsageStats;
-  contextTokens: number;
-  contextPercent: number;
+  contextTokens: number | null;
+  contextPercent: number | null;
   contextWindow: number;
   autoCompactEnabled: boolean;
   customCompactionEnabled: boolean;


### PR DESCRIPTION
## Summary

Fixes the footer context segment after compaction. The footer now preserves Pi's post-compaction unknown context state instead of showing the stale pre-compaction percentage until the next assistant response.

The change also clears live streaming usage when compaction events fire, so manual compaction during an active response cannot keep old usage in the footer.

## Validation

- `npm run typecheck`
- `npm test`
- `git diff --check`
- Fresh exact-head review on `dd1cca7`: No issues found.
