### PR TITLE
fix: estimate context usage after reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Reload context display** — Show a clearly marked one-time estimate from the active compacted context after `/reload`, instead of leaving context usage unknown until the next assistant response.
 - **Post-compaction context display** — Show Pi's unknown context state immediately after compaction instead of keeping the stale pre-compaction percentage until the next assistant response.
 
 ## [0.12.2] - 2026-08-08

--- a/context-usage.ts
+++ b/context-usage.ts
@@ -1,3 +1,5 @@
+import { estimateTokens, sessionEntryToContextMessages, type SessionEntry } from "@earendil-works/pi-coding-agent";
+
 export interface CoreContextUsage {
   contextTokens: number | null;
   contextWindow: number;
@@ -6,6 +8,7 @@ export interface CoreContextUsage {
 
 interface DisplayContextUsageInput {
   coreContextUsage: CoreContextUsage | null;
+  unknownCoreFallback: CoreContextUsage | null;
   fallbackContextTokens: number;
   fallbackContextWindow: number;
 }
@@ -21,11 +24,27 @@ interface ContextUsageSource {
   getContextUsage(): unknown;
 }
 
+interface ReloadContextEstimateSource {
+  sessionManager: {
+    buildContextEntries(): SessionEntry[];
+  };
+  getContextUsage(): unknown;
+  getSystemPrompt(): string;
+}
+
 function isContextUsageSource(value: unknown): value is ContextUsageSource {
   if (!isRecord(value) || typeof value.getContextUsage !== "function" || !isRecord(value.sessionManager)) {
     return false;
   }
   return typeof value.sessionManager.getLeafId === "function";
+}
+
+function isReloadContextEstimateSource(value: unknown): value is ReloadContextEstimateSource {
+  return isRecord(value)
+    && typeof value.getContextUsage === "function"
+    && typeof value.getSystemPrompt === "function"
+    && isRecord(value.sessionManager)
+    && typeof value.sessionManager.buildContextEntries === "function";
 }
 
 export class CoreContextUsageCache {
@@ -69,15 +88,35 @@ export function estimateInitialContextTokens(ctx: unknown): number | null {
 
 export function resolveDisplayContextUsage({
   coreContextUsage,
+  unknownCoreFallback,
   fallbackContextTokens,
   fallbackContextWindow,
 }: DisplayContextUsageInput): CoreContextUsage {
+  if (coreContextUsage?.contextTokens === null && unknownCoreFallback) return unknownCoreFallback;
   if (coreContextUsage) return coreContextUsage;
 
   return {
     contextTokens: fallbackContextTokens,
     contextWindow: fallbackContextWindow,
     contextPercent: fallbackContextWindow > 0 ? (fallbackContextTokens / fallbackContextWindow) * 100 : 0,
+  };
+}
+
+export function estimateReloadContextUsage(ctx: unknown): CoreContextUsage | null {
+  if (!isReloadContextEstimateSource(ctx)) return null;
+
+  const coreContextUsage = readCoreContextUsage(ctx);
+  if (!coreContextUsage || coreContextUsage.contextTokens !== null) return null;
+
+  const messageTokens = ctx.sessionManager.buildContextEntries()
+    .flatMap(sessionEntryToContextMessages)
+    .reduce((total, message) => total + estimateTokens(message), 0);
+  const contextTokens = (estimateInitialContextTokens(ctx) ?? 0) + messageTokens;
+
+  return {
+    contextTokens,
+    contextWindow: coreContextUsage.contextWindow,
+    contextPercent: (contextTokens / coreContextUsage.contextWindow) * 100,
   };
 }
 

--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,7 @@ import { WelcomeComponent, WelcomeHeader, discoverLoadedCounts, getRecentSession
 import { createWelcomeDismissScheduler } from "./welcome-dismiss.ts";
 import { createRenderScheduler } from "./render-scheduler.ts";
 import { getEditorAutocompleteProvider, passAutocompleteProviderThroughPreviousEditor } from "./editor-composition.ts";
-import { CoreContextUsageCache, estimateInitialContextTokens, resolveDisplayContextUsage } from "./context-usage.ts";
+import { CoreContextUsageCache, estimateInitialContextTokens, estimateReloadContextUsage, resolveDisplayContextUsage, type CoreContextUsage } from "./context-usage.ts";
 import { isStaleExtensionContextError, shouldShowStartupWelcome } from "./lifecycle.ts";
 import { getDefaultColors } from "./theme.ts";
 import { registerCdCommand } from "./cd-command.ts";
@@ -985,6 +985,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   let getThinkingLevelFn: (() => string) | null = null;
   let currentThinkingLevel: string | null = null;
   let liveAssistantUsage: SessionAssistantUsage | null = null;
+  let reloadContextUsage: CoreContextUsage | null = null;
   let isStreaming = false;
   let tuiRef: any = null;
   let restoreFooterStatusRepaintHook: (() => void) | null = null;
@@ -1528,6 +1529,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     lastUserPrompt = "";
     isStreaming = false;
     liveAssistantUsage = null;
+    reloadContextUsage = event.reason === "reload" ? estimateReloadContextUsage(ctx) : null;
     powerlineCompacting = false;
     deliverAfterRetrySettles = false;
     stashedEditorText = null;
@@ -1718,6 +1720,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     currentCtx = ctx;
     isStreaming = false;
     liveAssistantUsage = null;
+    reloadContextUsage = null;
     coreContextUsageCache.reset();
     requestQueueRender();
   });
@@ -1727,6 +1730,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     currentCtx = ctx;
     isStreaming = false;
     liveAssistantUsage = null;
+    reloadContextUsage = null;
     coreContextUsageCache.reset();
     if (event.willRetry) {
       deliverAfterRetrySettles = true;
@@ -2589,9 +2593,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       contextPercent,
     } = resolveDisplayContextUsage({
       coreContextUsage,
+      unknownCoreFallback: reloadContextUsage,
       fallbackContextTokens,
       fallbackContextWindow: ctx.model?.contextWindow ?? 0,
     });
+    const contextApproximate = coreContextUsage?.contextTokens === null && reloadContextUsage !== null;
 
     const segmentOptions = mergeSegmentOptions(presetDef.segmentOptions, config.segmentOptions);
 
@@ -2619,6 +2625,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       contextTokens,
       contextPercent,
       contextWindow,
+      contextApproximate,
       autoCompactEnabled: ctx.settingsManager?.getCompactionSettings?.()?.enabled ?? true,
       customCompactionEnabled: customCompactionEnabled || extensionStatuses.has(CUSTOM_COMPACTION_STATUS_KEY),
       usingSubscription,

--- a/segments.ts
+++ b/segments.ts
@@ -347,12 +347,13 @@ const contextPctSegment: StatusLineSegment = {
     const autoIcon = ctx.autoCompactEnabled && icons.auto ? ` ${icons.auto}` : "";
     const percentOnly = ctx.options.context?.format === "percent";
     const hasKnownUsage = contextTokens !== null && contextPercent !== null;
+    const approximate = ctx.contextApproximate ? "~" : "";
     // "full" (default): tokens/window + one-decimal percentage + auto-compact icon.
     // "percent": bare rounded percentage, threshold-colored, no icons.
     const text = percentOnly
-      ? (hasKnownUsage ? `${Math.round(contextPercent)}%` : "?")
+      ? (hasKnownUsage ? `${approximate}${Math.round(contextPercent)}%` : "?")
       : hasKnownUsage
-        ? `${formatTokens(contextTokens)}/${formatTokens(contextWindow)} (${contextPercent.toFixed(1)}%)${autoIcon}`
+        ? `${approximate}${formatTokens(contextTokens)}/${formatTokens(contextWindow)} (${contextPercent.toFixed(1)}%)${autoIcon}`
         : `?/${formatTokens(contextWindow)}${autoIcon}`;
 
     // Icon outside color, text inside - use semantic colors for thresholds

--- a/tests/context-usage.test.ts
+++ b/tests/context-usage.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { CoreContextUsageCache, estimateInitialContextTokens, readCoreContextUsage, resolveDisplayContextUsage } from "../context-usage.ts";
+import { CoreContextUsageCache, estimateInitialContextTokens, estimateReloadContextUsage, readCoreContextUsage, resolveDisplayContextUsage } from "../context-usage.ts";
 
 test("readCoreContextUsage returns Pi context estimates for branch summaries", () => {
   const usage = readCoreContextUsage({
@@ -77,9 +77,10 @@ test("core context usage cache reuses a leaf and supports explicit invalidation"
   assert.equal(reads, 3);
 });
 
-test("resolveDisplayContextUsage preserves unknown core usage over fallback usage", () => {
+test("resolveDisplayContextUsage preserves unknown core usage over assistant fallback usage", () => {
   assert.deepEqual(resolveDisplayContextUsage({
     coreContextUsage: { contextTokens: null, contextWindow: 5000, contextPercent: null },
+    unknownCoreFallback: null,
     fallbackContextTokens: 4000,
     fallbackContextWindow: 5000,
   }), {
@@ -89,9 +90,20 @@ test("resolveDisplayContextUsage preserves unknown core usage over fallback usag
   });
 });
 
-test("resolveDisplayContextUsage computes fallback usage when Pi has no current estimate", () => {
+test("resolveDisplayContextUsage uses the reload estimate for unknown core usage", () => {
+  const reloadEstimate = { contextTokens: 1000, contextWindow: 5000, contextPercent: 20 };
+  assert.equal(resolveDisplayContextUsage({
+    coreContextUsage: { contextTokens: null, contextWindow: 5000, contextPercent: null },
+    unknownCoreFallback: reloadEstimate,
+    fallbackContextTokens: 4000,
+    fallbackContextWindow: 5000,
+  }), reloadEstimate);
+});
+
+test("resolveDisplayContextUsage computes assistant fallback usage when Pi has no current estimate", () => {
   assert.deepEqual(resolveDisplayContextUsage({
     coreContextUsage: null,
+    unknownCoreFallback: null,
     fallbackContextTokens: 1000,
     fallbackContextWindow: 4000,
   }), {
@@ -99,6 +111,40 @@ test("resolveDisplayContextUsage computes fallback usage when Pi has no current 
     contextWindow: 4000,
     contextPercent: 25,
   });
+});
+
+test("estimateReloadContextUsage estimates the active compacted context", () => {
+  const usage = estimateReloadContextUsage({
+    getContextUsage: () => ({ tokens: null, contextWindow: 100, percent: null }),
+    getSystemPrompt: () => "12345678",
+    sessionManager: {
+      buildContextEntries: () => [
+        { type: "compaction", summary: "12345678", tokensBefore: 90, timestamp: "2026-08-08T00:00:00.000Z" },
+        { type: "message", message: { role: "user", content: "1234", timestamp: 0 } },
+      ],
+    },
+  });
+
+  assert.deepEqual(usage, {
+    contextTokens: 5,
+    contextWindow: 100,
+    contextPercent: 5,
+  });
+});
+
+test("estimateReloadContextUsage skips sessions with known core usage", () => {
+  let entryReads = 0;
+  assert.equal(estimateReloadContextUsage({
+    getContextUsage: () => ({ tokens: 25, contextWindow: 100, percent: 25 }),
+    getSystemPrompt: () => "12345678",
+    sessionManager: {
+      buildContextEntries() {
+        entryReads += 1;
+        return [];
+      },
+    },
+  }), null);
+  assert.equal(entryReads, 0);
 });
 
 test("estimateInitialContextTokens uses Pi's conservative character estimate", () => {

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -37,6 +37,7 @@ function createSegmentContext(overrides: Partial<SegmentContext> = {}): SegmentC
     contextTokens: 0,
     contextPercent: 0,
     contextWindow: 0,
+    contextApproximate: false,
     autoCompactEnabled: true,
     customCompactionEnabled: false,
     usingSubscription: false,
@@ -153,7 +154,10 @@ test("post-compaction queue delivery does not read ctx.cwd from the delayed call
   assert.match(source, /if \(isStaleExtensionContextError\(error\)\) \{\r?\n\s+if \(!sent\) queueStore\.update\(item\.id, \{ status: "queued", error: undefined \}\);/);
 });
 
-test("compaction events clear live usage before context display can fall back", () => {
-  assert.match(source, /pi\.on\("session_before_compact", async \(_event, ctx\) => \{\r?\n\s+powerlineCompacting = true;\r?\n\s+currentCtx = ctx;\r?\n\s+isStreaming = false;\r?\n\s+liveAssistantUsage = null;\r?\n\s+coreContextUsageCache\.reset\(\);/);
-  assert.match(source, /pi\.on\("session_compact", async \(event, ctx\) => \{\r?\n\s+powerlineCompacting = false;\r?\n\s+currentCtx = ctx;\r?\n\s+isStreaming = false;\r?\n\s+liveAssistantUsage = null;\r?\n\s+coreContextUsageCache\.reset\(\);/);
+test("reload estimates are scoped to reload and cleared by compaction", () => {
+  assert.match(source, /reloadContextUsage = event\.reason === "reload" \? estimateReloadContextUsage\(ctx\) : null;/);
+  assert.match(source, /unknownCoreFallback: reloadContextUsage,/);
+  assert.match(source, /contextApproximate = coreContextUsage\?\.contextTokens === null && reloadContextUsage !== null;/);
+  assert.match(source, /pi\.on\("session_before_compact", async \(_event, ctx\) => \{\r?\n\s+powerlineCompacting = true;\r?\n\s+currentCtx = ctx;\r?\n\s+isStreaming = false;\r?\n\s+liveAssistantUsage = null;\r?\n\s+reloadContextUsage = null;\r?\n\s+coreContextUsageCache\.reset\(\);/);
+  assert.match(source, /pi\.on\("session_compact", async \(event, ctx\) => \{\r?\n\s+powerlineCompacting = false;\r?\n\s+currentCtx = ctx;\r?\n\s+isStreaming = false;\r?\n\s+liveAssistantUsage = null;\r?\n\s+reloadContextUsage = null;\r?\n\s+coreContextUsageCache\.reset\(\);/);
 });

--- a/tests/thinking-segment.test.ts
+++ b/tests/thinking-segment.test.ts
@@ -21,6 +21,7 @@ function createSegmentContext(thinkingLevel: string, colors: ColorScheme): Segme
     contextTokens: 0,
     contextPercent: 0,
     contextWindow: 0,
+    contextApproximate: false,
     autoCompactEnabled: true,
     customCompactionEnabled: false,
     usingSubscription: false,

--- a/tests/usage-display.test.ts
+++ b/tests/usage-display.test.ts
@@ -38,6 +38,7 @@ function createSegmentContext(options: StatusLineSegmentOptions = {}, overrides:
     contextTokens: 0,
     contextPercent: 0,
     contextWindow: 0,
+    contextApproximate: false,
     autoCompactEnabled: true,
     customCompactionEnabled: false,
     usingSubscription: false,
@@ -96,6 +97,24 @@ test("context_pct renders unknown usage after compaction", () => {
 
   assert.equal(stripAnsi(renderSegment("context_pct", full).content), "◫ ?/200k AC");
   assert.equal(stripAnsi(renderSegment("context_pct", percent).content), "?");
+});
+
+test("context_pct marks reload estimates as approximate", () => {
+  const full = createSegmentContext({}, {
+    contextTokens: 18000,
+    contextWindow: 272000,
+    contextPercent: 6.6176,
+    contextApproximate: true,
+  });
+  const percent = createSegmentContext({ context: { format: "percent" } }, {
+    contextTokens: 18000,
+    contextWindow: 272000,
+    contextPercent: 6.6176,
+    contextApproximate: true,
+  });
+
+  assert.equal(stripAnsi(renderSegment("context_pct", full).content), "◫ ~18k/272k (6.6%) AC");
+  assert.equal(stripAnsi(renderSegment("context_pct", percent).content), "~7%");
 });
 
 test("context_pct percent format keeps threshold colors and drops icons", () => {

--- a/types.ts
+++ b/types.ts
@@ -195,6 +195,7 @@ export interface SegmentContext {
   contextTokens: number | null;
   contextPercent: number | null;
   contextWindow: number;
+  contextApproximate: boolean;
   autoCompactEnabled: boolean;
   customCompactionEnabled: boolean;
   usingSubscription: boolean;


### PR DESCRIPTION
## Summary

Estimate context usage once when `/reload` starts and Pi reports post-compaction usage as unknown. The footer marks this value with `~`, such as `~18k/272k`, then replaces it with Pi's normal usage after a fresh assistant response.

The estimate uses the active compacted context. It does not use stale pre-compaction assistant usage, add polling, or scan the session from the render path.

## Validation

- `npm run typecheck`
- `npm test` — 176 passed
- `git diff --check`
- Fresh review: no issues found
- API compatibility checked against Pi `v0.81.0`, `v0.82.0`, and installed `v0.83.0`
