### PR TITLE
fix: estimate context after compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
-- **Reload context display** — Show a clearly marked one-time estimate from the active compacted context after `/reload`, instead of leaving context usage unknown until the next assistant response.
-- **Post-compaction context display** — Show Pi's unknown context state immediately after compaction instead of keeping the stale pre-compaction percentage until the next assistant response.
+- **Post-compaction context display** — Show a clearly marked estimate from the active compacted context after compaction or `/reload`, instead of stale pre-compaction usage or an unknown placeholder.
 
 ## [0.12.2] - 2026-08-08
 

--- a/context-usage.ts
+++ b/context-usage.ts
@@ -24,7 +24,7 @@ interface ContextUsageSource {
   getContextUsage(): unknown;
 }
 
-interface ReloadContextEstimateSource {
+interface UnknownContextEstimateSource {
   sessionManager: {
     buildContextEntries(): SessionEntry[];
   };
@@ -39,7 +39,7 @@ function isContextUsageSource(value: unknown): value is ContextUsageSource {
   return typeof value.sessionManager.getLeafId === "function";
 }
 
-function isReloadContextEstimateSource(value: unknown): value is ReloadContextEstimateSource {
+function isUnknownContextEstimateSource(value: unknown): value is UnknownContextEstimateSource {
   return isRecord(value)
     && typeof value.getContextUsage === "function"
     && typeof value.getSystemPrompt === "function"
@@ -102,8 +102,8 @@ export function resolveDisplayContextUsage({
   };
 }
 
-export function estimateReloadContextUsage(ctx: unknown): CoreContextUsage | null {
-  if (!isReloadContextEstimateSource(ctx)) return null;
+export function estimateUnknownContextUsage(ctx: unknown): CoreContextUsage | null {
+  if (!isUnknownContextEstimateSource(ctx)) return null;
 
   const coreContextUsage = readCoreContextUsage(ctx);
   if (!coreContextUsage || coreContextUsage.contextTokens !== null) return null;

--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,7 @@ import { WelcomeComponent, WelcomeHeader, discoverLoadedCounts, getRecentSession
 import { createWelcomeDismissScheduler } from "./welcome-dismiss.ts";
 import { createRenderScheduler } from "./render-scheduler.ts";
 import { getEditorAutocompleteProvider, passAutocompleteProviderThroughPreviousEditor } from "./editor-composition.ts";
-import { CoreContextUsageCache, estimateInitialContextTokens, estimateReloadContextUsage, resolveDisplayContextUsage, type CoreContextUsage } from "./context-usage.ts";
+import { CoreContextUsageCache, estimateInitialContextTokens, estimateUnknownContextUsage, resolveDisplayContextUsage, type CoreContextUsage } from "./context-usage.ts";
 import { isStaleExtensionContextError, shouldShowStartupWelcome } from "./lifecycle.ts";
 import { getDefaultColors } from "./theme.ts";
 import { registerCdCommand } from "./cd-command.ts";
@@ -985,7 +985,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   let getThinkingLevelFn: (() => string) | null = null;
   let currentThinkingLevel: string | null = null;
   let liveAssistantUsage: SessionAssistantUsage | null = null;
-  let reloadContextUsage: CoreContextUsage | null = null;
+  let approximateContextUsage: CoreContextUsage | null = null;
   let isStreaming = false;
   let tuiRef: any = null;
   let restoreFooterStatusRepaintHook: (() => void) | null = null;
@@ -1529,7 +1529,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     lastUserPrompt = "";
     isStreaming = false;
     liveAssistantUsage = null;
-    reloadContextUsage = event.reason === "reload" ? estimateReloadContextUsage(ctx) : null;
+    approximateContextUsage = event.reason === "reload" ? estimateUnknownContextUsage(ctx) : null;
     powerlineCompacting = false;
     deliverAfterRetrySettles = false;
     stashedEditorText = null;
@@ -1720,7 +1720,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     currentCtx = ctx;
     isStreaming = false;
     liveAssistantUsage = null;
-    reloadContextUsage = null;
+    approximateContextUsage = null;
     coreContextUsageCache.reset();
     requestQueueRender();
   });
@@ -1730,7 +1730,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     currentCtx = ctx;
     isStreaming = false;
     liveAssistantUsage = null;
-    reloadContextUsage = null;
+    approximateContextUsage = estimateUnknownContextUsage(ctx);
     coreContextUsageCache.reset();
     if (event.willRetry) {
       deliverAfterRetrySettles = true;
@@ -2593,11 +2593,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       contextPercent,
     } = resolveDisplayContextUsage({
       coreContextUsage,
-      unknownCoreFallback: reloadContextUsage,
+      unknownCoreFallback: approximateContextUsage,
       fallbackContextTokens,
       fallbackContextWindow: ctx.model?.contextWindow ?? 0,
     });
-    const contextApproximate = coreContextUsage?.contextTokens === null && reloadContextUsage !== null;
+    const contextApproximate = coreContextUsage?.contextTokens === null && approximateContextUsage !== null;
 
     const segmentOptions = mergeSegmentOptions(presetDef.segmentOptions, config.segmentOptions);
 

--- a/tests/context-usage.test.ts
+++ b/tests/context-usage.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { CoreContextUsageCache, estimateInitialContextTokens, estimateReloadContextUsage, readCoreContextUsage, resolveDisplayContextUsage } from "../context-usage.ts";
+import { CoreContextUsageCache, estimateInitialContextTokens, estimateUnknownContextUsage, readCoreContextUsage, resolveDisplayContextUsage } from "../context-usage.ts";
 
 test("readCoreContextUsage returns Pi context estimates for branch summaries", () => {
   const usage = readCoreContextUsage({
@@ -90,7 +90,7 @@ test("resolveDisplayContextUsage preserves unknown core usage over assistant fal
   });
 });
 
-test("resolveDisplayContextUsage uses the reload estimate for unknown core usage", () => {
+test("resolveDisplayContextUsage uses the approximate estimate for unknown core usage", () => {
   const reloadEstimate = { contextTokens: 1000, contextWindow: 5000, contextPercent: 20 };
   assert.equal(resolveDisplayContextUsage({
     coreContextUsage: { contextTokens: null, contextWindow: 5000, contextPercent: null },
@@ -113,8 +113,8 @@ test("resolveDisplayContextUsage computes assistant fallback usage when Pi has n
   });
 });
 
-test("estimateReloadContextUsage estimates the active compacted context", () => {
-  const usage = estimateReloadContextUsage({
+test("estimateUnknownContextUsage estimates the active compacted context", () => {
+  const usage = estimateUnknownContextUsage({
     getContextUsage: () => ({ tokens: null, contextWindow: 100, percent: null }),
     getSystemPrompt: () => "12345678",
     sessionManager: {
@@ -132,9 +132,9 @@ test("estimateReloadContextUsage estimates the active compacted context", () => 
   });
 });
 
-test("estimateReloadContextUsage skips sessions with known core usage", () => {
+test("estimateUnknownContextUsage skips sessions with known core usage", () => {
   let entryReads = 0;
-  assert.equal(estimateReloadContextUsage({
+  assert.equal(estimateUnknownContextUsage({
     getContextUsage: () => ({ tokens: 25, contextWindow: 100, percent: 25 }),
     getSystemPrompt: () => "12345678",
     sessionManager: {

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -154,10 +154,10 @@ test("post-compaction queue delivery does not read ctx.cwd from the delayed call
   assert.match(source, /if \(isStaleExtensionContextError\(error\)\) \{\r?\n\s+if \(!sent\) queueStore\.update\(item\.id, \{ status: "queued", error: undefined \}\);/);
 });
 
-test("reload estimates are scoped to reload and cleared by compaction", () => {
-  assert.match(source, /reloadContextUsage = event\.reason === "reload" \? estimateReloadContextUsage\(ctx\) : null;/);
-  assert.match(source, /unknownCoreFallback: reloadContextUsage,/);
-  assert.match(source, /contextApproximate = coreContextUsage\?\.contextTokens === null && reloadContextUsage !== null;/);
-  assert.match(source, /pi\.on\("session_before_compact", async \(_event, ctx\) => \{\r?\n\s+powerlineCompacting = true;\r?\n\s+currentCtx = ctx;\r?\n\s+isStreaming = false;\r?\n\s+liveAssistantUsage = null;\r?\n\s+reloadContextUsage = null;\r?\n\s+coreContextUsageCache\.reset\(\);/);
-  assert.match(source, /pi\.on\("session_compact", async \(event, ctx\) => \{\r?\n\s+powerlineCompacting = false;\r?\n\s+currentCtx = ctx;\r?\n\s+isStreaming = false;\r?\n\s+liveAssistantUsage = null;\r?\n\s+reloadContextUsage = null;\r?\n\s+coreContextUsageCache\.reset\(\);/);
+test("unknown context estimates are event-scoped and cleared before compaction", () => {
+  assert.match(source, /approximateContextUsage = event\.reason === "reload" \? estimateUnknownContextUsage\(ctx\) : null;/);
+  assert.match(source, /unknownCoreFallback: approximateContextUsage,/);
+  assert.match(source, /contextApproximate = coreContextUsage\?\.contextTokens === null && approximateContextUsage !== null;/);
+  assert.match(source, /pi\.on\("session_before_compact", async \(_event, ctx\) => \{\r?\n\s+powerlineCompacting = true;\r?\n\s+currentCtx = ctx;\r?\n\s+isStreaming = false;\r?\n\s+liveAssistantUsage = null;\r?\n\s+approximateContextUsage = null;\r?\n\s+coreContextUsageCache\.reset\(\);/);
+  assert.match(source, /pi\.on\("session_compact", async \(event, ctx\) => \{\r?\n\s+powerlineCompacting = false;\r?\n\s+currentCtx = ctx;\r?\n\s+isStreaming = false;\r?\n\s+liveAssistantUsage = null;\r?\n\s+approximateContextUsage = estimateUnknownContextUsage\(ctx\);\r?\n\s+coreContextUsageCache\.reset\(\);/);
 });

--- a/tests/usage-display.test.ts
+++ b/tests/usage-display.test.ts
@@ -99,7 +99,7 @@ test("context_pct renders unknown usage after compaction", () => {
   assert.equal(stripAnsi(renderSegment("context_pct", percent).content), "?");
 });
 
-test("context_pct marks reload estimates as approximate", () => {
+test("context_pct marks context estimates as approximate", () => {
   const full = createSegmentContext({}, {
     contextTokens: 18000,
     contextWindow: 272000,


### PR DESCRIPTION
## Summary

Show the approximate compacted-context estimate immediately after live compaction. This fixes the footer staying at `?/272k` until `/reload` or the next assistant response.

The same event-time estimate path now serves `/reload` and `session_compact`. It still only applies when Pi reports context usage as unknown, and it keeps the `~` marker so the value is not presented as exact.

## Validation

- `node --experimental-strip-types --test tests/context-usage.test.ts tests/usage-display.test.ts tests/remaining-regressions.test.ts tests/thinking-segment.test.ts`
- `npm run typecheck`
- `npm test` — 176 passed
- `git diff --check`
- Fresh review: no issues found
