### PR TITLE
fix: stop git polling from taking .git/index.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Git polling no longer takes `.git/index.lock`** — Read-only git commands now run with `GIT_OPTIONAL_LOCKS=0`, so polling `git status` stops refreshing the index as a side effect, which raced interactive git in the same repo and could leave an orphaned lock behind. Thanks to @XertroV for the report and attribution.
+
 ## [0.12.3] - 2026-08-09
 
 ### Fixed

--- a/git-status.ts
+++ b/git-status.ts
@@ -83,10 +83,25 @@ function parseGitStatusOutput(output: string): { staged: number; unstaged: numbe
   return { staged, unstaged, untracked };
 }
 
+/**
+ * Environment for this module's read-only git commands.
+ *
+ * Polling `git status` otherwise refreshes the index as a side effect, taking
+ * `.git/index.lock`: that races interactive git in the same repo, and orphans
+ * the lock if we are killed mid-write. `GIT_OPTIONAL_LOCKS=0` skips the
+ * refresh; the reported counts are unchanged. Preferred over
+ * `--no-optional-locks` because it also reaches the child git processes
+ * `status` spawns for submodules.
+ */
+export function readOnlyGitEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  return { ...env, GIT_OPTIONAL_LOCKS: "0" };
+}
+
 function runGit(args: string[], timeoutMs = 200): Promise<string | null> {
   return new Promise((resolve) => {
     const proc = spawn("git", args, {
       stdio: ["ignore", "pipe", "pipe"],
+      env: readOnlyGitEnv(),
     });
 
     let stdout = "";

--- a/tests/git-optional-locks.test.ts
+++ b/tests/git-optional-locks.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readOnlyGitEnv } from "../git-status.ts";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Background fetches spawn git with up to 500ms timeouts; give them room.
+const FETCH_SETTLE_MS = 1200;
+
+test("read-only git commands opt out of git's optional index lock", () => {
+  const env = readOnlyGitEnv({ PATH: "/usr/bin" });
+  assert.equal(env.GIT_OPTIONAL_LOCKS, "0");
+  assert.equal(env.PATH, "/usr/bin", "must extend the ambient environment, not replace it");
+});
+
+test("readOnlyGitEnv overrides an inherited GIT_OPTIONAL_LOCKS=1", () => {
+  assert.equal(readOnlyGitEnv({ GIT_OPTIONAL_LOCKS: "1" }).GIT_OPTIONAL_LOCKS, "0");
+});
+
+// Guards the regression end to end, via a `git` shim on PATH: the footer polls
+// every repo the user visits, so it must never take `.git/index.lock`.
+test("the git process the footer spawns receives GIT_OPTIONAL_LOCKS=0", { skip: process.platform === "win32" ? "POSIX shim" : false }, async () => {
+  const dir = mkdtempSync(join(tmpdir(), "powerline-git-locks-"));
+  const bin = join(dir, "bin");
+  mkdirSync(bin);
+  const log = join(dir, "calls.log");
+
+  writeFileSync(
+    join(bin, "git"),
+    `#!/bin/sh\necho "GIT_OPTIONAL_LOCKS=\${GIT_OPTIONAL_LOCKS-unset} ARGS=$*" >> ${JSON.stringify(log)}\nexit 0\n`,
+    { mode: 0o755 },
+  );
+
+  const originalPath = process.env.PATH;
+  const originalOptionalLocks = process.env.GIT_OPTIONAL_LOCKS;
+  process.env.PATH = `${bin}:${originalPath ?? ""}`;
+  // Some environments export GIT_OPTIONAL_LOCKS=0 as a machine-wide workaround
+  // for this bug; force the opposite so we can't inherit a false pass.
+  process.env.GIT_OPTIONAL_LOCKS = "1";
+  try {
+    // Imported here so the module reads the shimmed PATH when it spawns.
+    const { getGitStatus, invalidateGitStatus, invalidateGitBranch } = await import("../git-status.ts");
+    invalidateGitStatus();
+    invalidateGitBranch();
+    getGitStatus("main");
+    await sleep(FETCH_SETTLE_MS);
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalOptionalLocks === undefined) delete process.env.GIT_OPTIONAL_LOCKS;
+    else process.env.GIT_OPTIONAL_LOCKS = originalOptionalLocks;
+  }
+
+  assert.ok(existsSync(log), "expected the footer to spawn git");
+  const calls = readFileSync(log, "utf8").trim().split("\n");
+  const status = calls.filter((line) => line.includes("ARGS=status --porcelain"));
+  assert.ok(status.length > 0, `expected a status call, got:\n${calls.join("\n")}`);
+  for (const call of calls) {
+    assert.match(call, /GIT_OPTIONAL_LOCKS=0/, `git spawned without the lock opt-out: ${call}`);
+  }
+});


### PR DESCRIPTION
## The problem

The git segment polls `git status --porcelain` in whatever repo the user is in. `git status` doesn't just read — when the index is stale it refreshes cached stat information and writes the index back, taking the real `.git/index.lock` to do so. For a status bar polling every repo the user visits, that has two costs for *other* processes:

- **Contention** — it races the user's own git in that repo, which then fails with `Unable to create '.git/index.lock': File exists`. This is the common, everyday symptom.
- **Orphaned locks** — git holds the lock only briefly, but if the process tree is killed inside that window (editor/agent exit, hook timeout, OOM) the lock is left behind and blocks the repo until it's deleted by hand.

This showed up as recurring stuck `index.lock` files across many repos on a machine running Pi alongside other agents. Attribution took a while because the footer polls constantly, so it appears in process snapshots whether or not it's the culprit — so I verified the mechanism directly rather than by correlation.

## Mechanism, as measured

On git 2.55.0, with inotify watching `.git`:

- `git status --porcelain` takes `index.lock` **only when the index is stat-stale** — i.e. a file's mtime/ctime differs from the cached stat. That's the normal state of any repo an editor or agent is writing to. In a settled repo it takes no lock, which is why this is intermittent.
- The lock is taken **late and held briefly** — roughly 140–150 ms into a ~160 ms run on a 30k-file repo, not for the whole run.
- **SIGTERM is safe** (git's handler removes the lock), so this module's own 500 ms `proc.kill()` timeout doesn't orphan anything by itself. **SIGKILL inside the window does** orphan it.
- With `GIT_OPTIONAL_LOCKS=0` the lock is never created, so it can't be orphaned by any signal, and the reported counts are identical.
- The module's other commands (`branch --show-current`, `rev-parse`, `remote get-url`) never touch the index.

### Reproduction

Needs `inotify-tools`. Run it somewhere that does **not** export `GIT_OPTIONAL_LOCKS` — some setups already export `0` machine-wide as a workaround for this bug, which silently turns the "before" case green.

```sh
git init -q /tmp/lockdemo && cd /tmp/lockdemo
git config user.email t@t && git config user.name t
for i in $(seq 1 200); do echo "line $i" > f$i.txt; done
git add -A && git commit -qm init && git status --porcelain >/dev/null

# make the index stat-stale, as an editor/agent rewriting files does
for i in $(seq 1 200); do echo "line $i" > f$i.txt; done && sleep 1.1

inotifywait -q -m -e create --format '%f' -o /tmp/ev.log .git & sleep 0.5
git status --porcelain >/dev/null      # what the footer runs
sleep 0.5 && kill %1
grep -c index.lock /tmp/ev.log         # 1  -> lock taken

# same again, with the opt-out:
#   GIT_OPTIONAL_LOCKS=0 git status --porcelain   -> 0
```

## What this PR does

Adds `readOnlyGitEnv()` in `git-status.ts`, which sets `GIT_OPTIONAL_LOCKS=0` for every git command the module spawns. `tests/git-optional-locks.test.ts` covers it end to end with a `git` shim on `PATH`; it forces `GIT_OPTIONAL_LOCKS=1` first so an ambient workaround can't produce a false pass.

`GIT_OPTIONAL_LOCKS` is git's documented switch for this exact case — "processes running in the background which do not want to cause lock contention with other operations on the repository".

I used the environment variable rather than passing `--no-optional-locks` because it behaves identically, works on git versions predating that flag (2.15), and is inherited by the child git processes `status` spawns in repos with submodules. Happy to switch to the flag if you'd rather have it visible at the call site.

## Tradeoff, and other designs you may prefer

The one thing given up: `status` no longer writes the refreshed index back, so the next git command needing a fresh index redoes that stat work. In effect the footer was warming the index for the user's subsequent commands. On a large repo that's a real (if small) saving, and it's a legitimate reason to want the old behaviour — hence flagging it rather than assuming.

Alternatives, if you'd prefer a different shape:

1. **Config option** — e.g. `powerline.git.optionalLocks` (default off, opt in to the refreshing behaviour), or fold it into the existing `gitPolling` setting as a fourth mode. Happy to rewrite it this way; I went with an unconditional change because the lock contention affects processes outside Pi that can't opt out, and the counts shown are unaffected.
2. **Scope it to `status` only** — I applied it uniformly in `runGit` for consistency, but only `status` can take the lock; the other three are plumbing.
3. **Use `--no-optional-locks`** instead of the env var (see caveats above).
4. **Leave the write, harden the kill** — not sufficient on its own: it narrows the orphan window but does nothing about contention with the user's interactive git, which is the more frequent symptom.

Tests: 179 pass, `tsc --noEmit` clean, `git diff --check` clean. `CHANGELOG.md` updated under `[Unreleased]` per CONTRIBUTING.
