### PR TITLE
perf: smooth editor typing hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Editor typing responsiveness** — Avoid expanding paste markers or joining full drafts in editor hot paths, debounce bash ghost completion, run git completion lookups asynchronously, and cache queue/prompt render work so typing stays smooth in large drafts and bash mode.
+
 ## [0.12.3] - 2026-08-09
 
 ### Fixed

--- a/bash-mode/completion.ts
+++ b/bash-mode/completion.ts
@@ -1,5 +1,5 @@
 import { readdirSync } from "node:fs";
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import type { AutocompleteItem, AutocompleteProvider, AutocompleteSuggestions } from "@earendil-works/pi-tui";
 import { matchHistoryEntries, readGlobalShellHistory, readProjectHistory } from "./history.ts";
@@ -208,22 +208,28 @@ function getPathSuggestions(token: string, cwd: string): ExtendedCompletionItem[
   }
 }
 
-function runGit(args: string[], cwd: string): string[] {
-  try {
-    const result = spawnSync("git", args, {
-      cwd,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    if (result.status !== 0 || !result.stdout) return [];
-    return result.stdout.split("\n").map((line) => line.trim()).filter(Boolean);
-  } catch {
-    // Git-aware completions are optional and should not break the main completion flow.
-    return [];
-  }
+function runGit(args: string[], cwd: string, signal: AbortSignal): Promise<string[]> {
+  return new Promise((resolve) => {
+    try {
+      execFile("git", args, { cwd, encoding: "utf8", signal }, (error, stdout) => {
+        if (error || !stdout) {
+          resolve([]);
+          return;
+        }
+        resolve(stdout.split("\n").map((line) => line.trim()).filter(Boolean));
+      });
+    } catch {
+      // Git-aware completions are optional and should not break the main completion flow.
+      resolve([]);
+    }
+  });
 }
 
-function getGitSuggestions(ctx: TokenContext, cwd: string): ExtendedCompletionItem[] {
+async function getGitSuggestions(
+  ctx: TokenContext,
+  cwd: string,
+  signal: AbortSignal,
+): Promise<ExtendedCompletionItem[]> {
   const tokens = ctx.previousTokens;
   if (tokens[0] !== "git") return [];
 
@@ -246,12 +252,13 @@ function getGitSuggestions(ctx: TokenContext, cwd: string): ExtendedCompletionIt
     return [];
   }
 
-  const refs = [
-    ...runGit(["branch", "--format=%(refname:short)"], cwd),
-    ...runGit(["tag", "--list"], cwd),
-  ];
+  const [branches, tags] = await Promise.all([
+    runGit(["branch", "--format=%(refname:short)"], cwd, signal),
+    runGit(["tag", "--list"], cwd, signal),
+  ]);
+  if (signal.aborted) return [];
 
-  return [...new Set(refs)]
+  return [...new Set([...branches, ...tags])]
     .filter((ref) => ref.startsWith(ctx.token))
     .slice(0, 100)
     .map((ref) => ({
@@ -365,7 +372,8 @@ export class BashCompletionEngine {
       return this.getCommandPositionGhostSuggestion(line, readGlobalShellHistory(shellPath));
     }
 
-    const deterministic = this.getDeterministicInlineSuggestions(ctx, cwd);
+    const deterministic = await this.getDeterministicInlineSuggestions(ctx, cwd, signal);
+    if (signal.aborted) return null;
     const globalHistory = matchHistoryEntries(readGlobalShellHistory(shellPath), line, 5);
     const ranked = boostValidatedItemsFromGlobalHistory(
       line,
@@ -397,10 +405,17 @@ export class BashCompletionEngine {
     return getCuratedCommandFallback(line);
   }
 
-  private getDeterministicInlineSuggestions(ctx: TokenContext, cwd: string): ExtendedCompletionItem[] {
-    const items: ExtendedCompletionItem[] = [];
-    items.push(...withRange(getGitSuggestions(ctx, cwd), ctx.tokenStart, ctx.tokenEnd));
-    items.push(...withRange(getPathSuggestions(ctx.token, cwd), ctx.tokenStart, ctx.tokenEnd));
+  private async getDeterministicInlineSuggestions(
+    ctx: TokenContext,
+    cwd: string,
+    signal: AbortSignal,
+  ): Promise<ExtendedCompletionItem[]> {
+    const gitSuggestions = getGitSuggestions(ctx, cwd, signal);
+    const pathSuggestions = getPathSuggestions(ctx.token, cwd);
+    const items = [
+      ...withRange(await gitSuggestions, ctx.tokenStart, ctx.tokenEnd),
+      ...withRange(pathSuggestions, ctx.tokenStart, ctx.tokenEnd),
+    ];
 
     return uniqueByReplacement(items);
   }

--- a/bash-mode/editor.ts
+++ b/bash-mode/editor.ts
@@ -3,7 +3,6 @@ import { CustomEditor, type KeybindingsManager } from "@earendil-works/pi-coding
 import { isKeyRelease, matchesKey, visibleWidth, truncateToWidth } from "@earendil-works/pi-tui";
 import type { AutocompleteProvider } from "@earendil-works/pi-tui";
 import { matchesConfiguredShortcut } from "../shortcuts.ts";
-import { getOneOffBashCommandContext } from "./completion.ts";
 import type { GhostSuggestion } from "./types.ts";
 
 interface EditorBoundaryShortcuts {
@@ -29,6 +28,8 @@ const DEFAULT_EDITOR_BOUNDARY_SHORTCUTS: EditorBoundaryShortcuts = {
   start: "super+shift+up",
   end: "super+shift+down",
 };
+
+const GHOST_UPDATE_DEBOUNCE_MS = 50;
 
 function isPrintableInput(data: string): boolean {
   return data.length === 1 && data.charCodeAt(0) >= 32;
@@ -104,7 +105,9 @@ export class BashModeEditor extends CustomEditor {
   private promptHistoryDraft: string | null = null;
   private ghost: GhostSuggestion | null = null;
   private ghostAbort: AbortController | null = null;
+  private ghostTimer: ReturnType<typeof setTimeout> | null = null;
   private ghostToken = 0;
+  private plainBoundInputs: Set<string> | null = null;
 
   constructor(tui: any, theme: any, keybindings: KeybindingsManager, options: BashModeEditorOptions) {
     super(tui, theme, keybindings);
@@ -135,8 +138,11 @@ export class BashModeEditor extends CustomEditor {
   }
 
   clearGhostSuggestion(): void {
+    if (this.ghostTimer) clearTimeout(this.ghostTimer);
+    this.ghostTimer = null;
     this.ghostAbort?.abort();
     this.ghostAbort = null;
+    this.ghostToken += 1;
     this.ghost = null;
   }
 
@@ -152,6 +158,8 @@ export class BashModeEditor extends CustomEditor {
   }
 
   handleInput(data: string): void {
+    if (BashModeEditor.prototype.tryFastPrintableInput.call(this, data)) return;
+
     const droppedPathText = droppedPathTextFromInput(data);
     if (droppedPathText !== null) {
       this.insertTextAtCursor(droppedPathText);
@@ -309,6 +317,36 @@ export class BashModeEditor extends CustomEditor {
     }
   }
 
+  private tryFastPrintableInput(data: string): boolean {
+    if (!/^[a-z0-9 ]$/.test(data)) return false;
+    if (Reflect.get(this, "isInPaste") === true || Reflect.get(this, "jumpMode") !== null) return false;
+
+    if (!this.plainBoundInputs) {
+      this.plainBoundInputs = new Set<string>();
+      for (const binding of Object.values(this.keybindingsRef.getEffectiveConfig())) {
+        if (!binding) continue;
+        for (const key of Array.isArray(binding) ? binding : [binding]) {
+          if (key.length === 1) this.plainBoundInputs.add(key);
+          if (key === "space") this.plainBoundInputs.add(" ");
+        }
+      }
+    }
+    if (this.plainBoundInputs.has(data)) return false;
+    if (this.onExtensionShortcut?.(data)) return true;
+
+    const insertCharacter = Reflect.get(this, "insertCharacter");
+    if (typeof insertCharacter !== "function") return false;
+    insertCharacter.call(this, data);
+
+    resetShellHistoryBrowse(this);
+    if (this.isShellCompletionContext()) {
+      this.scheduleGhostUpdate();
+    } else {
+      this.clearGhostSuggestion();
+    }
+    return true;
+  }
+
   render(width: number): string[] {
     const lines = super.render(width);
     if (!this.isShellCompletionContext()) return lines;
@@ -341,7 +379,27 @@ export class BashModeEditor extends CustomEditor {
   }
 
   private isOneOffBashCommandContext(): boolean {
-    return getOneOffBashCommandContext(this.getExpandedText()) !== null;
+    const state = Reflect.get(this, "state");
+    const lines = state && typeof state === "object" ? Reflect.get(state, "lines") : null;
+    return Array.isArray(lines) && typeof lines[0] === "string" && lines[0].startsWith("!");
+  }
+
+  hasLeadingSigil(sigil: string): boolean {
+    const state = Reflect.get(this, "state");
+    const lines = state && typeof state === "object" ? Reflect.get(state, "lines") : null;
+    if (!Array.isArray(lines)) return false;
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = typeof lines[index] === "string" ? lines[index] : "";
+      const trimmed = line.trimStart();
+      if (!trimmed) continue;
+      if (!trimmed.startsWith(sigil)) return false;
+
+      const nextCharacter = trimmed.slice(sigil.length, sigil.length + 1);
+      return nextCharacter ? /^\s$/.test(nextCharacter) : index < lines.length - 1;
+    }
+
+    return false;
   }
 
   private moveCursorToEditorBoundary(position: "start" | "end"): void {
@@ -368,7 +426,7 @@ export class BashModeEditor extends CustomEditor {
 
   private acceptGhostSuggestion(): boolean {
     if (!this.ghost) return false;
-    const text = this.getExpandedText();
+    const text = this.getText();
     if (text.includes("\n")) return false;
 
     const cursor = this.getCursor();
@@ -432,21 +490,27 @@ export class BashModeEditor extends CustomEditor {
   }
 
   private scheduleGhostUpdate(): void {
-    const text = this.getExpandedText();
+    const text = this.getText();
     const currentToken = ++this.ghostToken;
+    if (this.ghostTimer) clearTimeout(this.ghostTimer);
     this.ghostAbort?.abort();
 
     const controller = new AbortController();
     this.ghostAbort = controller;
-    this.optionsRef.resolveGhostSuggestion(text, controller.signal)
-      .then((ghost) => {
-        if (controller.signal.aborted || currentToken !== this.ghostToken) return;
-        this.ghost = ghost;
-        this.tui.requestRender();
-      })
-      .catch((error) => {
-        if (error instanceof Error && error.message === "aborted") return;
-        console.debug("[powerline-footer] Failed to resolve bash ghost suggestion:", error);
-      });
+    this.ghostTimer = setTimeout(() => {
+      this.ghostTimer = null;
+      if (controller.signal.aborted || currentToken !== this.ghostToken) return;
+
+      this.optionsRef.resolveGhostSuggestion(text, controller.signal)
+        .then((ghost) => {
+          if (controller.signal.aborted || currentToken !== this.ghostToken) return;
+          this.ghost = ghost;
+          this.tui.requestRender();
+        })
+        .catch((error) => {
+          if (controller.signal.aborted) return;
+          console.debug("[powerline-footer] Failed to resolve bash ghost suggestion:", error);
+        });
+    }, GHOST_UPDATE_DEBOUNCE_MS);
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -64,7 +64,7 @@ import {
   parseVibeGenerateArgs,
 } from "./working-vibes.ts";
 import { PowerlineQueueStore, currentQueueContext, formatIdeaIssuePrompt, formatQueueDeliveryText, parseCompactQueuedPrompt, parseSigilIdeaCapture, parseTargetPrefix, targetForIdea } from "./queue/store.ts";
-import type { PowerlineQueueItem, QueueContext, QueueIntent, QueueTarget } from "./queue/types.ts";
+import type { PowerlineQueueItem, QueueContext, QueueIntent, QueueSummary, QueueTarget } from "./queue/types.ts";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Configuration
@@ -172,6 +172,7 @@ const STREAMING_LAYOUT_CACHE_TTL_MS = 1000;
 const STATUS_RENDER_DEBOUNCE_MS = 33;
 const CONTEXT_STATUS_RENDER_MS = 250;
 const EDITOR_STATUS_DEFER_MS = 150;
+const QUEUE_SUMMARY_CACHE_TTL_MS = 250;
 const PROMPT_HISTORY_TRACKED = Symbol.for("powerlinePromptHistoryTracked");
 const PROMPT_HISTORY_STATE_KEY = Symbol.for("powerlinePromptHistoryState");
 
@@ -995,6 +996,13 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   let welcomeOverlayShouldDismiss = false;
   let lastUserPrompt = "";
   let showLastPrompt = true;
+  let lastPromptRenderCache: {
+    source: string;
+    compact: string;
+    width: number;
+    color: string;
+    lines: string[];
+  } | null = null;
   let stashedEditorText: string | null = null;
   let stashedPromptHistory: string[] = readPersistedStashHistory();
   let currentEditor: any = null;
@@ -1003,6 +1011,13 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   let bashCompletionEngine = new BashCompletionEngine();
   let shellSession: ManagedShellSession | null = null;
   const queueStore = new PowerlineQueueStore();
+  let queueSummaryCache: {
+    cwd: string;
+    sessionId?: string;
+    compacting: boolean;
+    expiresAt: number;
+    summary: QueueSummary;
+  } | null = null;
   let powerlineCompacting = false;
   let deliverAfterRetrySettles = false;
   let queueDeliveryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1242,7 +1257,32 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     return currentQueueContext(ctx.cwd ?? process.cwd(), getQueueSessionId(ctx));
   }
 
+  function getQueueSummary(ctx: any): QueueSummary {
+    const context = getQueueContext(ctx);
+    const now = Date.now();
+    if (
+      queueSummaryCache
+      && queueSummaryCache.cwd === context.cwd
+      && queueSummaryCache.sessionId === context.sessionId
+      && queueSummaryCache.compacting === powerlineCompacting
+      && now < queueSummaryCache.expiresAt
+    ) {
+      return queueSummaryCache.summary;
+    }
+
+    const summary = queueStore.summarize(context, powerlineCompacting);
+    queueSummaryCache = {
+      cwd: context.cwd,
+      ...(context.sessionId ? { sessionId: context.sessionId } : {}),
+      compacting: powerlineCompacting,
+      expiresAt: now + QUEUE_SUMMARY_CACHE_TTL_MS,
+      summary,
+    };
+    return summary;
+  }
+
   function requestQueueRender(): void {
+    queueSummaryCache = null;
     requestImmediateStatusRender({ deferDuringTyping: false });
   }
 
@@ -1297,13 +1337,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     return item;
   }
 
-  function isSigilIdeaDraft(text: string): boolean {
+  function isSigilIdeaDraft(editor: BashModeEditor): boolean {
     const sigil = config.queue.captureSigil;
     if (sigil === false) return false;
     const normalizedSigil = sigil.trim();
-    if (!normalizedSigil) return false;
-    const trimmed = text.trimStart();
-    return trimmed.startsWith(normalizedSigil) && /^\s/.test(trimmed.slice(normalizedSigil.length));
+    return normalizedSigil.length > 0 && editor.hasLeadingSigil(normalizedSigil);
   }
 
   function captureSigilGlyph(): string {
@@ -2614,7 +2652,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       : false;
 
     const thinkingLevel = currentThinkingLevel ?? thinkingLevelFromSession ?? getThinkingLevelFn?.() ?? "off";
-    const queueSummary = queueStore.summarize(getQueueContext(ctx), powerlineCompacting);
+    const queueSummary = getQueueSummary(ctx);
 
     return {
       model: ctx.model,
@@ -2724,7 +2762,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   function renderPowerlineQueuePreviewLines(width: number, theme: Theme): string[] {
     if (!currentCtx) return [];
-    const summary = queueStore.summarize(getQueueContext(currentCtx), powerlineCompacting);
+    const summary = getQueueSummary(currentCtx);
     if (!summary.leadingText) return [];
 
     const prefix = summary.leadingStatus === "blocked" || summary.leadingStatus === "failed"
@@ -2773,18 +2811,27 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   function renderLastPromptLines(width: number): string[] {
     if (bashModeActive || !showLastPrompt || !lastUserPrompt) return [];
 
-    const prefix = ` ${getFgAnsiCode("sep")}↳${ansi.reset} `;
+    const color = getFgAnsiCode("sep");
+    if (
+      lastPromptRenderCache
+      && lastPromptRenderCache.source === lastUserPrompt
+      && lastPromptRenderCache.width === width
+      && lastPromptRenderCache.color === color
+    ) {
+      return lastPromptRenderCache.lines;
+    }
+
+    const compact = lastPromptRenderCache?.source === lastUserPrompt
+      ? lastPromptRenderCache.compact
+      : lastUserPrompt.replace(/\s+/g, " ").trim();
+    const prefix = ` ${color}↳${ansi.reset} `;
     const availableWidth = width - visibleWidth(prefix);
-    if (availableWidth < 10) return [];
+    const lines = compact && availableWidth >= 10
+      ? [truncateToWidth(`${prefix}${color}${truncateToWidth(compact, availableWidth, "…")}${ansi.reset}`, width, "…")]
+      : [];
 
-    let promptText = lastUserPrompt.replace(/\s+/g, " ").trim();
-    if (!promptText) return [];
-
-    promptText = truncateToWidth(promptText, availableWidth, "…");
-
-    const styledPrompt = `${getFgAnsiCode("sep")}${promptText}${ansi.reset}`;
-    const line = `${prefix}${styledPrompt}`;
-    return [truncateToWidth(line, width, "…")];
+    lastPromptRenderCache = { source: lastUserPrompt, compact, width, color, lines };
+    return lines;
   }
 
   function installPowerlineWidgets(ctx: any) {
@@ -3052,7 +3099,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         }
 
         const bc = (s: string) => `${getFgAnsiCode("sep")}${s}${ansi.reset}`;
-        const captureDraft = !bashModeActive && isSigilIdeaDraft(editor.getExpandedText());
+        const captureDraft = !bashModeActive && isSigilIdeaDraft(editor);
         const promptGlyph = bashModeActive ? "$" : captureDraft ? captureSigilGlyph() : ">";
         const promptColor = captureDraft ? getFgAnsiCode("queue") : ansi.getFgAnsi(200, 200, 200);
         const prompt = `${promptColor}${promptGlyph}${ansi.reset}`;

--- a/tests/bash-mode.test.ts
+++ b/tests/bash-mode.test.ts
@@ -876,6 +876,116 @@ test("bash editor refreshGhostSuggestion reuses the ghost scheduling path", asyn
   }
 });
 
+test("bash editor hot path avoids full expansion and coalesces ghost work", async () => {
+  const links = ensureEditorModuleLinks();
+
+  try {
+    const { BashModeEditor } = await import("../bash-mode/editor.ts");
+    const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
+    const keybindings = KeybindingsManager.create();
+    const resolved: string[] = [];
+    let bashModeActive = false;
+    const editor = new BashModeEditor(
+      { requestRender() {}, terminal: { columns: 80, rows: 24 } },
+      { borderColor: (text: string) => text },
+      keybindings,
+      {
+        keybindings,
+        isBashModeActive: () => bashModeActive,
+        isShellRunning: () => false,
+        onExitBashMode() {},
+        onSubmitCommand() {},
+        onInterrupt() {},
+        onNotify() {},
+        getHistoryEntries: () => [],
+        resolveGhostSuggestion: async (text) => {
+          resolved.push(text);
+          return null;
+        },
+      },
+    );
+
+    (editor as { getExpandedText(): string }).getExpandedText = () => {
+      throw new Error("expanded text should not be read while typing");
+    };
+    const insertCharacter = Reflect.get(editor, "insertCharacter").bind(editor);
+    let fastInserts = 0;
+    Reflect.set(editor, "insertCharacter", (character: string) => {
+      fastInserts += 1;
+      insertCharacter(character);
+    });
+
+    editor.handleInput("a");
+    assert.equal(fastInserts, 1);
+    editor.onExtensionShortcut = (data) => data === "b";
+    editor.handleInput("b");
+    assert.equal(editor.getText(), "a");
+    assert.equal(fastInserts, 1);
+    editor.onExtensionShortcut = undefined;
+    editor.render(80);
+
+    bashModeActive = true;
+    editor.setText("");
+    editor.handleInput("g");
+    editor.handleInput("i");
+    editor.handleInput("t");
+    assert.deepEqual(resolved, []);
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    assert.deepEqual(resolved, ["git"]);
+    editor.clearGhostSuggestion();
+
+    editor.setText("\n  \n  # idea");
+    assert.equal(editor.hasLeadingSigil("#"), true);
+    editor.setText("#");
+    assert.equal(editor.hasLeadingSigil("#"), false);
+    editor.setText("## idea");
+    assert.equal(editor.hasLeadingSigil("#"), false);
+  } finally {
+    links.cleanup();
+  }
+});
+
+test("bash editor fast path preserves plain custom keybindings", async () => {
+  const links = ensureEditorModuleLinks();
+
+  try {
+    const { BashModeEditor } = await import("../bash-mode/editor.ts");
+    const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
+    const { getKeybindings, setKeybindings } = await import(new URL("../node_modules/@earendil-works/pi-tui/dist/index.js", import.meta.url).href);
+    const previousKeybindings = getKeybindings();
+    const keybindings = new KeybindingsManager({ "tui.editor.cursorLeft": "a" });
+
+    try {
+      setKeybindings(keybindings);
+      const editor = new BashModeEditor(
+        { requestRender() {}, terminal: { columns: 80, rows: 24 } },
+        { borderColor: (text: string) => text },
+        keybindings,
+        {
+          keybindings,
+          isBashModeActive: () => false,
+          isShellRunning: () => false,
+          onExitBashMode() {},
+          onSubmitCommand() {},
+          onInterrupt() {},
+          onNotify() {},
+          getHistoryEntries: () => [],
+          resolveGhostSuggestion: async () => null,
+        },
+      );
+
+      editor.setText("x");
+      editor.handleInput("a");
+      assert.equal(editor.getText(), "x");
+      assert.deepEqual(editor.getCursor(), { line: 0, col: 0 });
+    } finally {
+      setKeybindings(previousKeybindings);
+    }
+  } finally {
+    links.cleanup();
+  }
+});
+
 test("bash editor dismiss clears autocomplete when mode turns off", async () => {
   const links = ensureEditorModuleLinks();
 
@@ -1332,6 +1442,7 @@ test("bash editor command-z resets shell history and updates ghost state", async
     Reflect.set(shellEditor, "shellHistoryItems", ["git status"]);
     Reflect.set(shellEditor, "shellHistoryDraft", "git");
     shellEditor.handleInput("\x1b[122;9u");
+    await new Promise((resolve) => setTimeout(resolve, 75));
 
     assert.equal(shellEditor.getText(), "a");
     assert.equal(Reflect.get(shellEditor, "shellHistoryIndex"), -1);
@@ -1602,7 +1713,7 @@ test("bash editor does not accept a hidden ghost suggestion when the cursor is n
     const { BashModeEditor } = await import("../bash-mode/editor.ts");
     const accepted = getMethod(BashModeEditor.prototype, "acceptGhostSuggestion").call({
       ghost: { value: "git status", source: "project-history" },
-      getExpandedText() {
+      getText() {
         return "git st";
       },
       getCursor() {

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -154,6 +154,18 @@ test("post-compaction queue delivery does not read ctx.cwd from the delayed call
   assert.match(source, /if \(isStaleExtensionContextError\(error\)\) \{\r?\n\s+if \(!sent\) queueStore\.update\(item\.id, \{ status: "queued", error: undefined \}\);/);
 });
 
+test("editor render checks sigil drafts without reading the full text", () => {
+  assert.match(source, /isSigilIdeaDraft\(editor\)/);
+  assert.match(source, /editor\.hasLeadingSigil\(normalizedSigil\)/);
+  assert.doesNotMatch(source, /isSigilIdeaDraft\(editor\.get(?:Expanded)?Text\(\)\)/);
+});
+
+test("editor-adjacent widgets cache queue and last-prompt work", () => {
+  assert.match(source, /const QUEUE_SUMMARY_CACHE_TTL_MS = 250;/);
+  assert.match(source, /queueSummaryCache = null;\r?\n\s+requestImmediateStatusRender/);
+  assert.match(source, /lastPromptRenderCache\.source === lastUserPrompt/);
+});
+
 test("unknown context estimates are event-scoped and cleared before compaction", () => {
   assert.match(source, /approximateContextUsage = event\.reason === "reload" \? estimateUnknownContextUsage\(ctx\) : null;/);
   assert.match(source, /unknownCoreFallback: approximateContextUsage,/);


### PR DESCRIPTION
## Summary

- Avoid expanded paste-marker reads and full-draft joins in editor render and prefix checks.
- Debounce bash ghost completion and move git completion lookups to cancellable async calls.
- Cache queue and previous-prompt render work, while keeping local queue updates immediate.
- Add regressions for paste hot paths, ghost coalescing, shortcut preservation, and render cache wiring.

## Validation

- `npm test` — 180/180 passed
- `npm run typecheck`
- `git diff --check`
- Benchmark: common input path remains 7.3x faster after shortcut guard fix
