### PR TITLE
fix: stop git polling from taking .git/index.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - **Editor typing responsiveness** — Avoid expanding paste markers or joining full drafts in editor hot paths, debounce bash ghost completion, run git completion lookups asynchronously, and cache queue/prompt render work so typing stays smooth in large drafts and bash mode.
 
+### Fixed
+- **Git polling no longer takes `.git/index.lock`** — Read-only git commands now run with `GIT_OPTIONAL_LOCKS=0`, so polling `git status` stops refreshing the index as a side effect, which raced interactive git in the same repo and could leave an orphaned lock behind. Thanks to @XertroV for the report and attribution.
+
 ## [0.12.3] - 2026-08-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Editor typing responsiveness** — Avoid expanding paste markers or joining full drafts in editor hot paths, debounce bash ghost completion, run git completion lookups asynchronously, and cache queue/prompt render work so typing stays smooth in large drafts and bash mode.
 
 ### Fixed
-- **Git polling no longer takes `.git/index.lock`** — Read-only git commands now run with `GIT_OPTIONAL_LOCKS=0`, so polling `git status` stops refreshing the index as a side effect, which raced interactive git in the same repo and could leave an orphaned lock behind. Thanks to @XertroV for the report and attribution.
+- **Git polling no longer takes `.git/index.lock`** — Read-only git commands now run with `GIT_OPTIONAL_LOCKS=0`, so polling `git status` stops refreshing the index as a side effect, which raced interactive git in the same repo and could leave an orphaned lock behind. Thanks to Max Kaye (@XertroV) for #156.
 
 ## [0.12.3] - 2026-08-09
 

--- a/git-status.ts
+++ b/git-status.ts
@@ -83,10 +83,25 @@ function parseGitStatusOutput(output: string): { staged: number; unstaged: numbe
   return { staged, unstaged, untracked };
 }
 
+/**
+ * Environment for this module's read-only git commands.
+ *
+ * Polling `git status` otherwise refreshes the index as a side effect, taking
+ * `.git/index.lock`: that races interactive git in the same repo, and orphans
+ * the lock if we are killed mid-write. `GIT_OPTIONAL_LOCKS=0` skips the
+ * refresh; the reported counts are unchanged. Preferred over
+ * `--no-optional-locks` because it also reaches the child git processes
+ * `status` spawns for submodules.
+ */
+export function readOnlyGitEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  return { ...env, GIT_OPTIONAL_LOCKS: "0" };
+}
+
 function runGit(args: string[], timeoutMs = 200): Promise<string | null> {
   return new Promise((resolve) => {
     const proc = spawn("git", args, {
       stdio: ["ignore", "pipe", "pipe"],
+      env: readOnlyGitEnv(),
     });
 
     let stdout = "";

--- a/tests/git-optional-locks.test.ts
+++ b/tests/git-optional-locks.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readOnlyGitEnv } from "../git-status.ts";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Background fetches spawn git with up to 500ms timeouts; give them room.
+const FETCH_SETTLE_MS = 1200;
+
+test("read-only git commands opt out of git's optional index lock", () => {
+  const env = readOnlyGitEnv({ PATH: "/usr/bin" });
+  assert.equal(env.GIT_OPTIONAL_LOCKS, "0");
+  assert.equal(env.PATH, "/usr/bin", "must extend the ambient environment, not replace it");
+});
+
+test("readOnlyGitEnv overrides an inherited GIT_OPTIONAL_LOCKS=1", () => {
+  assert.equal(readOnlyGitEnv({ GIT_OPTIONAL_LOCKS: "1" }).GIT_OPTIONAL_LOCKS, "0");
+});
+
+// Guards the regression end to end, via a `git` shim on PATH: the footer polls
+// every repo the user visits, so it must never take `.git/index.lock`.
+test("the git process the footer spawns receives GIT_OPTIONAL_LOCKS=0", { skip: process.platform === "win32" ? "POSIX shim" : false }, async () => {
+  const dir = mkdtempSync(join(tmpdir(), "powerline-git-locks-"));
+  const bin = join(dir, "bin");
+  mkdirSync(bin);
+  const log = join(dir, "calls.log");
+
+  writeFileSync(
+    join(bin, "git"),
+    `#!/bin/sh\necho "GIT_OPTIONAL_LOCKS=\${GIT_OPTIONAL_LOCKS-unset} ARGS=$*" >> ${JSON.stringify(log)}\nexit 0\n`,
+    { mode: 0o755 },
+  );
+
+  const originalPath = process.env.PATH;
+  const originalOptionalLocks = process.env.GIT_OPTIONAL_LOCKS;
+  process.env.PATH = `${bin}:${originalPath ?? ""}`;
+  // Some environments export GIT_OPTIONAL_LOCKS=0 as a machine-wide workaround
+  // for this bug; force the opposite so we can't inherit a false pass.
+  process.env.GIT_OPTIONAL_LOCKS = "1";
+  try {
+    // Imported here so the module reads the shimmed PATH when it spawns.
+    const { getGitStatus, invalidateGitStatus, invalidateGitBranch } = await import("../git-status.ts");
+    invalidateGitStatus();
+    invalidateGitBranch();
+    getGitStatus("main");
+    await sleep(FETCH_SETTLE_MS);
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalOptionalLocks === undefined) delete process.env.GIT_OPTIONAL_LOCKS;
+    else process.env.GIT_OPTIONAL_LOCKS = originalOptionalLocks;
+  }
+
+  assert.ok(existsSync(log), "expected the footer to spawn git");
+  const calls = readFileSync(log, "utf8").trim().split("\n");
+  const status = calls.filter((line) => line.includes("ARGS=status --porcelain"));
+  assert.ok(status.length > 0, `expected a status call, got:\n${calls.join("\n")}`);
+  for (const call of calls) {
+    assert.match(call, /GIT_OPTIONAL_LOCKS=0/, `git spawned without the lock opt-out: ${call}`);
+  }
+});


### PR DESCRIPTION
Replacement for #156 after the contributor fork rejected a maintainer push.

This preserves Max Kaye's implementation from #156 and adds the required changelog credit as `Max Kaye (@XertroV) for #156`.

Validation after rebasing on PR #157's merge commit:
- `node --experimental-strip-types --test tests/git-optional-locks.test.ts tests/git-status.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Release/tag authority was not used.
