### PR TITLE
refactor: remove saved idea inbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Fixed
 - **Git polling no longer takes `.git/index.lock`** — Read-only git commands now run with `GIT_OPTIONAL_LOCKS=0`, so polling `git status` stops refreshing the index as a side effect, which raced interactive git in the same repo and could leave an orphaned lock behind. Thanks to Max Kaye (@XertroV) for #156.
 
+### Removed
+- **Saved idea inbox** — Removed unused idea capture commands, sigil capture, and issue handoff. The queue now manages queued prompts only.
+
 ## [0.12.3] - 2026-08-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Customizes the default [pi](https://github.com/badlogic/pi-mono) editor with a p
 
 **Editor stash** — Press `Alt+S` to save your editor content and clear the editor, type a quick prompt, and your stashed text auto-restores when the agent finishes. Toggles between stash, pop, and update-existing-stash. A `stash` indicator appears in the powerline bar while text is stashed.
 
-**Powerline Queue + Inbox** — Capture thoughts without interrupting the current agent. Type `# <idea>` and press Enter to save an idea instead of sending it; `# @global <idea>`, `# @current <idea>`, and `# @alias <idea>` route it. Messages typed during compaction are held by Powerline and delivered after successful compaction instead of disappearing into Pi's native queue. `/idea`, `/ideas`, and `/queue` provide a file-backed inbox for current-session prompts, project ideas, aliases, retries, clears, and manual delivery. Use `/ideas next` to work the oldest active idea in the current session, or `/ideas issue` to hand it to the current agent for safe GitHub issue triage. Active queue, idea, and blocked counts appear in the `queue` segment only when there is something to show.
+**Powerline Queue** — Messages typed during compaction are held by Powerline and delivered after successful compaction instead of disappearing into Pi's native queue. `/queue` provides a file-backed queue for aliases, retries, clears, and manual delivery. Active queued and blocked counts appear in the `queue` segment only when there is something to show.
 
 **Working Vibes** — AI-generated themed loading messages. Set `/vibe star trek` and your "Working..." becomes "Running diagnostics..." or "Engaging warp drive...". Supports any theme: pirate, zen, noir, cowboy, etc.
 
@@ -51,40 +51,16 @@ Activates automatically. Toggle with `/powerline`, switch presets with `/powerli
 
 Use `/cd <path>` to continue the current conversation from another working directory. It supports relative paths, absolute paths, `~`, `~/...`, and directory completions. With no argument, `/cd` prints the current Pi session directory. The command switches into a cwd-updated session file so Pi tools and the footer path segment agree after the change.
 
-Powerline Queue + Inbox commands and capture shortcuts:
+Powerline Queue commands:
 
-- `# <text>` — capture an idea for the current project without sending it to the agent
-- `# @global <text>` — capture a global idea
-- `# @current <text>` — capture an idea targeted to the current session
-- `/queue alias <name> [path]` — save a project alias, defaulting to the current cwd when `path` is omitted
-- `# @name <text>` — capture an idea for a saved project alias
 - `/compact <text>` — compact now and queue `<text>` as the next prompt after successful compaction
-- `/idea [@target] <text>` — command form of idea capture, useful for scripts and users who disable the sigil
-- `/idea issue [id]` — hand the oldest active idea, or a specific idea, to the current agent for safe GitHub issue triage
-- `/ideas` — open the captured-ideas picker
-- `/ideas next` — send the oldest active idea to the current session
-- `/ideas issue [id]` — ask the current agent to dedupe and file a GitHub issue only when the target repo is clear and owned/controlled
-- `/ideas send <id>` — send an idea to the current session
 - `/queue` — open the queued-prompt picker
-- `/queue send [id]` / `/queue retry [id]` — deliver a queued item now
-- `/queue clear <id|all>` — clear queued prompt items
-- `/queue target <id> @name|global|current` — retarget a queued item
+- `/queue alias <name> [path]` — save a project alias, defaulting to the current cwd when `path` is omitted
+- `/queue send [id]` / `/queue retry [id]` — deliver a queued prompt now
+- `/queue clear <id|all>` — clear queued prompts
+- `/queue target <id> @name|global|current` — retarget a queued prompt
 
-The default capture sigil is `#`. When the editor text starts with `# `, the prompt glyph changes to `#`; pressing Enter saves the idea, clears the editor, and leaves the original sigil text in editor history for quick recovery. Configure or disable this under `powerline.queue.captureSigil`:
-
-```json
-{
-  "powerline": {
-    "queue": {
-      "captureSigil": "#"
-    }
-  }
-}
-```
-
-Set `captureSigil` to `false` if you often submit markdown headings and prefer `/idea` instead.
-
-Captured data is stored under the Pi agent directory in `powerline-footer/inbox.jsonl` and `powerline-footer/projects.json`. `inbox.jsonl` is a stable read surface for orchestrators and helper agents; each line is a queue item with `id`, `text`, `createdAt`, `updatedAt`, `source`, `target`, `intent`, `status`, and optional `error`. Writes should still go through Powerline commands or the store so locking and atomic writes are preserved. Ideas sent with `/ideas next` or `/ideas send <id>` include a small provenance header so the receiving agent can treat them as deferred captured context. `/idea issue` and `/ideas issue` do not file issues directly from the extension; they send a guarded handoff prompt that tells the current agent to dedupe open issues first, create a GitHub issue only for a clear owned/controlled repo, and ask before filing when the target is unclear.
+Queued data is stored under the Pi agent directory in `powerline-footer/inbox.jsonl` and `powerline-footer/projects.json`. `inbox.jsonl` is a stable read surface for orchestrators and helper agents; each line is a queue item with `id`, `text`, `createdAt`, `updatedAt`, `source`, `target`, `intent`, `status`, and optional `error`. Writes should still go through Powerline commands or the store so locking and atomic writes are preserved.
 
 - `/powerline placement below` — move the primary powerline row below the editor
 - `/powerline placement above` — restore the default placement
@@ -306,7 +282,7 @@ Prompt history now has two sources:
 - stashed prompts — up to 12 recent stashed prompts (newest first)
 - recent project prompts — up to 50 recent user-submitted prompts pulled from pi sessions in the current project folder
 
-Selecting a stashed entry lets you insert it or promote it to an idea. Project prompt history entries insert into the editor. If the editor already has text, you can choose `Replace`, `Append`, or `Cancel`.
+Selecting a stashed or project prompt-history entry inserts it into the editor. If the editor already has text, you can choose `Replace`, `Append`, or `Cancel`.
 
 ### Editor clipboard and navigation shortcuts
 
@@ -328,7 +304,6 @@ You can override shortcut keys in the agent settings file:
     "stashHistory": "ctrl+alt+h",
     "copyEditor": "ctrl+alt+c",
     "cutEditor": "ctrl+alt+x",
-    "ideaCapture": null,
     "queueOpen": "ctrl+alt+q",
     "editorStart": "cmd+shift+up",
     "editorEnd": "cmd+shift+down"

--- a/bash-mode/editor.ts
+++ b/bash-mode/editor.ts
@@ -384,24 +384,6 @@ export class BashModeEditor extends CustomEditor {
     return Array.isArray(lines) && typeof lines[0] === "string" && lines[0].startsWith("!");
   }
 
-  hasLeadingSigil(sigil: string): boolean {
-    const state = Reflect.get(this, "state");
-    const lines = state && typeof state === "object" ? Reflect.get(state, "lines") : null;
-    if (!Array.isArray(lines)) return false;
-
-    for (let index = 0; index < lines.length; index += 1) {
-      const line = typeof lines[index] === "string" ? lines[index] : "";
-      const trimmed = line.trimStart();
-      if (!trimmed) continue;
-      if (!trimmed.startsWith(sigil)) return false;
-
-      const nextCharacter = trimmed.slice(sigil.length, sigil.length + 1);
-      return nextCharacter ? /^\s$/.test(nextCharacter) : index < lines.length - 1;
-    }
-
-    return false;
-  }
-
   private moveCursorToEditorBoundary(position: "start" | "end"): void {
     const state = Reflect.get(this, "state");
     const lines = state && typeof state === "object" ? Reflect.get(state, "lines") : null;

--- a/index.ts
+++ b/index.ts
@@ -63,7 +63,7 @@ import {
   generateVibesBatch,
   parseVibeGenerateArgs,
 } from "./working-vibes.ts";
-import { PowerlineQueueStore, currentQueueContext, formatIdeaIssuePrompt, formatQueueDeliveryText, parseCompactQueuedPrompt, parseSigilIdeaCapture, parseTargetPrefix, targetForIdea } from "./queue/store.ts";
+import { PowerlineQueueStore, currentQueueContext, formatQueueDeliveryText, parseCompactQueuedPrompt } from "./queue/store.ts";
 import type { PowerlineQueueItem, QueueContext, QueueIntent, QueueSummary, QueueTarget } from "./queue/types.ts";
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -83,7 +83,6 @@ let config: PowerlineConfig = {
   invalidPlacement: null,
   welcome: true,
   stashSharpSShortcut: false,
-  queue: { captureSigil: "#" },
 };
 
 const CUSTOM_COMPACTION_STATUS_KEY = "compact-policy";
@@ -95,7 +94,6 @@ export interface PowerlineShortcuts {
   stashHistory: ShortcutBinding;
   copyEditor: ShortcutBinding;
   cutEditor: ShortcutBinding;
-  ideaCapture: ShortcutBinding;
   queueOpen: ShortcutBinding;
   editorStart: ShortcutBinding;
   editorEnd: ShortcutBinding;
@@ -106,7 +104,6 @@ type PowerlineShortcutAction =
   | { kind: "stashHistory" }
   | { kind: "copyEditor" }
   | { kind: "cutEditor" }
-  | { kind: "ideaCapture" }
   | { kind: "queueOpen" }
   | { kind: "bashMode" };
 const STASH_HISTORY_LIMIT = 12;
@@ -116,7 +113,6 @@ const DEFAULT_SHORTCUTS: PowerlineShortcuts = {
   stashHistory: "ctrl+alt+h",
   copyEditor: "ctrl+alt+c",
   cutEditor: "ctrl+alt+x",
-  ideaCapture: null,
   queueOpen: "ctrl+alt+q",
   editorStart: "super+shift+up",
   editorEnd: "super+shift+down",
@@ -126,7 +122,7 @@ const DEFAULT_BASH_MODE_SETTINGS = {
   transcriptMaxLines: 2000,
   transcriptMaxBytes: 512 * 1024,
 } as const satisfies BashModeSettings;
-const SHORTCUT_KEYS: PowerlineShortcutKey[] = ["stashHistory", "copyEditor", "cutEditor", "ideaCapture", "queueOpen", "editorStart", "editorEnd"];
+const SHORTCUT_KEYS: PowerlineShortcutKey[] = ["stashHistory", "copyEditor", "cutEditor", "queueOpen", "editorStart", "editorEnd"];
 const APP_RESERVED_SHORTCUTS = [
   "escape",
   "ctrl+c",
@@ -1308,47 +1304,6 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     return item;
   }
 
-  function captureIdeaFromParsedInput(ctx: any, parsed: { target: string | null; text: string }): PowerlineQueueItem | null {
-    const trimmed = parsed.text.trim();
-    if (!trimmed) {
-      ctx.ui.notify("Nothing to capture", "info");
-      return null;
-    }
-
-    const target = targetForIdea(parsed.target, queueStore, ctx.cwd ?? process.cwd());
-    const item = captureQueueItem(ctx, trimmed, "idea", target);
-    ctx.ui.notify(`Idea saved (${item.id}) — /ideas to review`, "info");
-    return item;
-  }
-
-  function captureIdeaFromText(ctx: any, text: string): PowerlineQueueItem | null {
-    return captureIdeaFromParsedInput(ctx, parseTargetPrefix(text));
-  }
-
-  function captureCurrentProjectIdea(ctx: any, text: string): PowerlineQueueItem | null {
-    const trimmed = text.trim();
-    if (!trimmed) {
-      ctx.ui.notify("Nothing to capture", "info");
-      return null;
-    }
-
-    const item = captureQueueItem(ctx, trimmed, "idea", { kind: "project", cwd: ctx.cwd ?? process.cwd() });
-    ctx.ui.notify(`Idea saved (${item.id}) — /ideas to review`, "info");
-    return item;
-  }
-
-  function isSigilIdeaDraft(editor: BashModeEditor): boolean {
-    const sigil = config.queue.captureSigil;
-    if (sigil === false) return false;
-    const normalizedSigil = sigil.trim();
-    return normalizedSigil.length > 0 && editor.hasLeadingSigil(normalizedSigil);
-  }
-
-  function captureSigilGlyph(): string {
-    const sigil = config.queue.captureSigil === false ? "#" : config.queue.captureSigil;
-    return Array.from(sigil)[0] ?? "#";
-  }
-
   function capturePostCompactPrompt(ctx: any, text: string): PowerlineQueueItem | null {
     const trimmed = text.trim();
     if (!trimmed) return null;
@@ -1478,12 +1433,10 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
   }
 
-  async function openQueuePicker(ctx: any, mode: "ideas" | "queue"): Promise<void> {
-    const active = queueStore.activeItems(getQueueContext(ctx)).filter((item) => (
-      mode === "ideas" ? item.intent === "idea" : item.intent !== "idea"
-    ));
+  async function openQueuePicker(ctx: any): Promise<void> {
+    const active = queueStore.activeItems(getQueueContext(ctx));
     if (active.length === 0) {
-      ctx.ui.notify(mode === "ideas" ? "No ideas captured" : "No queued items", "info");
+      ctx.ui.notify("No queued items", "info");
       return;
     }
 
@@ -1494,7 +1447,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }));
     const selected = await showSelectOverlay(
       ctx,
-      mode === "ideas" ? "Powerline ideas" : "Powerline queue",
+      "Powerline queue",
       "↑↓ navigate • enter manage • esc cancel",
       items,
       Math.min(active.length, 12),
@@ -1507,7 +1460,12 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   function resolveCommandTarget(ctx: any, spec: string): QueueTarget {
     const normalized = spec.trim().replace(/^@/, "");
-    return targetForIdea(normalized || null, queueStore, ctx.cwd ?? process.cwd());
+    if (normalized === "current") return { kind: "current-session" };
+    if (normalized === "global") return { kind: "global" };
+
+    const cwd = queueStore.resolveAlias(normalized);
+    if (!cwd) throw new Error(`Unknown project alias @${normalized}. Use /queue alias ${normalized} <path> first.`);
+    return { kind: "project", cwd, alias: normalized };
   }
 
   function sendOrRetryQueueItem(ctx: any, idPrefix: string): void {
@@ -1518,42 +1476,6 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
     const updated = queueStore.update(item.id, { status: "queued", error: undefined });
     if (updated) deliverQueueItem(ctx, updated);
-  }
-
-  function findNextIdea(ctx: any): PowerlineQueueItem | null {
-    return queueStore.activeItems(getQueueContext(ctx)).find((candidate) => candidate.intent === "idea") ?? null;
-  }
-
-  function sendIdeaIssueHandoff(ctx: any, item: PowerlineQueueItem): void {
-    queueStore.update(item.id, { status: "delivering", error: undefined });
-    requestQueueRender();
-
-    try {
-      const deliverAs = deliveryModeForItem(ctx, item);
-      const issuePrompt = formatIdeaIssuePrompt(item);
-      if (deliverAs) {
-        pi.sendUserMessage(issuePrompt, { deliverAs });
-      } else {
-        pi.sendUserMessage(issuePrompt);
-      }
-      queueStore.update(item.id, { status: "sent", error: undefined });
-      ctx.ui.notify(`Sent idea ${item.id} for issue triage`, "info");
-      requestQueueRender();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      queueStore.update(item.id, { status: "failed", error: message });
-      ctx.ui.notify(`Failed to send ${item.id}: ${message}`, "error");
-      requestQueueRender();
-    }
-  }
-
-  function sendIdeaIssueHandoffById(ctx: any, id: string | undefined): void {
-    const item = id ? queueStore.get(id) : findNextIdea(ctx);
-    if (!item || item.intent !== "idea") {
-      ctx.ui.notify(id ? `No unique idea matches ${id}` : "No ideas captured", id ? "warning" : "info");
-      return;
-    }
-    sendIdeaIssueHandoff(ctx, item);
   }
 
   // Track session start
@@ -1588,10 +1510,6 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
     if (ctx.hasUI) {
       ctx.ui.setStatus("stash", undefined);
-      const pendingIdeas = queueStore.activeItems(getQueueContext(ctx)).filter((item) => item.intent === "idea").length;
-      if (pendingIdeas > 0) {
-        ctx.ui.notify(`${pendingIdeas} idea${pendingIdeas === 1 ? "" : "s"} waiting — /ideas`, "info");
-      }
     }
 
     // Initialize vibe manager (needs modelRegistry from ctx)
@@ -1967,20 +1885,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   }
 
   async function handleSelectedStashHistoryEntry(ctx: any, selected: string): Promise<void> {
-    const action = await ctx.ui.select("Stashed prompt", ["Insert", "Promote to idea", "Cancel"]);
-
-    if (action === "Insert") {
-      await insertSelectedPromptHistoryEntry(ctx, selected);
-      return;
-    }
-
-    if (action === "Promote to idea") {
-      try {
-        captureIdeaFromText(ctx, selected);
-      } catch (error) {
-        ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
-      }
-    }
+    const action = await ctx.ui.select("Stashed prompt", ["Insert", "Cancel"]);
+    if (action === "Insert") await insertSelectedPromptHistoryEntry(ctx, selected);
   }
 
   function isStashShortcutInput(data: string): boolean {
@@ -2007,9 +1913,6 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
     if (matchesConfiguredShortcut(data, resolvedShortcuts.cutEditor)) {
       return { kind: "cutEditor" };
-    }
-    if (matchesConfiguredShortcut(data, resolvedShortcuts.ideaCapture)) {
-      return { kind: "ideaCapture" };
     }
     if (matchesConfiguredShortcut(data, resolvedShortcuts.queueOpen)) {
       return { kind: "queueOpen" };
@@ -2039,19 +1942,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       return;
     }
 
-    if (action.kind === "ideaCapture") {
-      const text = getEditorTextForClipboard(ctx);
-      if (!text) return;
-
-      const item = captureCurrentProjectIdea(ctx, text);
-      if (item) {
-        ctx.ui.setEditorText("");
-      }
-      return;
-    }
-
     if (action.kind === "queueOpen") {
-      void openQueuePicker(ctx, "queue");
+      void openQueuePicker(ctx);
       return;
     }
 
@@ -2161,98 +2053,6 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   registerCdCommand(pi, () => currentCtx?.cwd ?? process.cwd());
 
-  pi.registerCommand("idea", {
-    description: "Capture an idea without interrupting the current agent. Usage: /idea [@alias|@global|@current] <text> | /idea issue [id]",
-    handler: async (args, ctx) => {
-      currentCtx = ctx;
-      const trimmedArgs = args.trim();
-      const [action, id] = trimmedArgs.split(/\s+/).filter(Boolean);
-      if (action === "issue") {
-        sendIdeaIssueHandoffById(ctx, id);
-        return;
-      }
-
-      const raw = trimmedArgs || getCurrentEditorText(ctx, currentEditor).trim();
-      if (!raw) {
-        ctx.ui.notify("Usage: /idea [@alias|@global|@current] <text> | /idea issue [id]", "info");
-        return;
-      }
-
-      try {
-        const item = captureIdeaFromText(ctx, raw);
-        if (item && !trimmedArgs) {
-          ctx.ui.setEditorText("");
-        }
-      } catch (error) {
-        ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
-      }
-    },
-  });
-
-  pi.registerCommand("ideas", {
-    description: "Review or send captured ideas. Usage: /ideas next | /ideas issue [id] | /ideas [send|retry|clear|edit] <id>",
-    handler: async (args, ctx) => {
-      currentCtx = ctx;
-      const parts = args.trim().split(/\s+/).filter(Boolean);
-      const action = parts[0];
-      const id = parts[1];
-
-      if (!action) {
-        await openQueuePicker(ctx, "ideas");
-        return;
-      }
-
-      if (action === "next") {
-        const item = findNextIdea(ctx);
-        if (!item) {
-          ctx.ui.notify("No ideas captured", "info");
-          return;
-        }
-        const updated = queueStore.update(item.id, { status: "queued", target: { kind: "current-session" }, error: undefined });
-        if (updated) deliverQueueItem(ctx, updated);
-        return;
-      }
-
-      if (action === "issue") {
-        sendIdeaIssueHandoffById(ctx, id);
-        return;
-      }
-
-      if (!id) {
-        ctx.ui.notify("Usage: /ideas next | /ideas issue [id] | /ideas [send|retry|clear|edit] <id>", "info");
-        return;
-      }
-
-      const item = queueStore.get(id);
-      if (!item || item.intent !== "idea") {
-        ctx.ui.notify(`No unique idea matches ${id}`, "warning");
-        return;
-      }
-
-      if (action === "send" || action === "retry") {
-        const updated = queueStore.update(item.id, { status: "queued", target: { kind: "current-session" }, error: undefined });
-        if (updated) deliverQueueItem(ctx, updated);
-        return;
-      }
-
-      if (action === "edit") {
-        ctx.ui.setEditorText(item.text);
-        queueStore.clear(item.id);
-        requestQueueRender();
-        return;
-      }
-
-      if (action === "clear") {
-        queueStore.clear(item.id);
-        ctx.ui.notify(`Cleared idea ${item.id}`, "info");
-        requestQueueRender();
-        return;
-      }
-
-      ctx.ui.notify("Usage: /ideas next | /ideas issue [id] | /ideas [send|retry|clear|edit] <id>", "info");
-    },
-  });
-
   pi.registerCommand("queue", {
     description: "Manage Powerline queued prompts and project aliases",
     handler: async (args, ctx) => {
@@ -2261,7 +2061,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       const action = parts[0];
 
       if (!action) {
-        await openQueuePicker(ctx, "queue");
+        await openQueuePicker(ctx);
         return;
       }
 
@@ -2299,7 +2099,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       if (action === "clear") {
         const id = parts[1];
         if (id === "all") {
-          const active = queueStore.activeItems(getQueueContext(ctx)).filter((item) => item.intent !== "idea");
+          const active = queueStore.activeItems(getQueueContext(ctx));
           for (const item of active) queueStore.clear(item.id);
           ctx.ui.notify(`Cleared ${active.length} queued item${active.length === 1 ? "" : "s"}`, "info");
           requestQueueRender();
@@ -2310,7 +2110,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           return;
         }
         const item = queueStore.get(id);
-        if (!item || item.intent === "idea") {
+        if (!item) {
           ctx.ui.notify(`No unique queued item matches ${id}`, "warning");
           return;
         }
@@ -2769,9 +2569,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       ? "blocked: "
       : summary.leadingStatus === "delivering"
         ? "sending: "
-        : summary.leadingIntent === "idea"
-          ? "idea: "
-          : "queued: ";
+        : "queued: ";
     const text = `${prefix}${summary.leadingText.replace(/\s+/g, " ").trim()}`;
     const color = summary.leadingStatus === "blocked" || summary.leadingStatus === "failed" ? "warning" : "dim";
     return [` ${theme.fg(color, truncateToWidth(text, Math.max(1, width - 1), "…"))}`];
@@ -3012,23 +2810,6 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
         const isSubmit = keybindings.matches(data, "tui.input.submit") && !keybindings.matches(data, "tui.input.newLine");
         const isFollowUpSubmit = keybindings.matches(data, "app.message.followUp");
-        if (!bashModeActive && (isSubmit || isFollowUpSubmit)) {
-          const sigilCapture = parseSigilIdeaCapture(editor.getExpandedText(), config.queue.captureSigil);
-          if (sigilCapture) {
-            try {
-              const item = captureIdeaFromParsedInput(ctx, sigilCapture);
-              if (item) {
-                editor.addToHistory?.(editor.getExpandedText().trim());
-                editor.setText("");
-              }
-            } catch (error) {
-              ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
-            }
-            scheduleDismissWelcome(ctx);
-            return;
-          }
-        }
-
         if (!powerlineCompacting && !bashModeActive && isSubmit && typeof ctx.compact === "function") {
           const editorText = editor.getExpandedText().trim();
           const compactQueuedPrompt = parseCompactQueuedPrompt(editorText);
@@ -3099,9 +2880,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         }
 
         const bc = (s: string) => `${getFgAnsiCode("sep")}${s}${ansi.reset}`;
-        const captureDraft = !bashModeActive && isSigilIdeaDraft(editor);
-        const promptGlyph = bashModeActive ? "$" : captureDraft ? captureSigilGlyph() : ">";
-        const promptColor = captureDraft ? getFgAnsiCode("queue") : ansi.getFgAnsi(200, 200, 200);
+        const promptGlyph = bashModeActive ? "$" : ">";
+        const promptColor = ansi.getFgAnsi(200, 200, 200);
         const prompt = `${promptColor}${promptGlyph}${ansi.reset}`;
         const promptPrefix = ` ${prompt} `;
         const contPrefix = "   ";

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -16,7 +16,6 @@ export interface PowerlineConfig {
   invalidPlacement: string | null;
   welcome: boolean;
   stashSharpSShortcut: boolean;
-  queue: { captureSigil: string | false };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -88,12 +87,6 @@ function normalizeCustomPrefix(value: unknown): string | undefined {
   return normalized ? normalized : undefined;
 }
 
-function normalizeCaptureSigil(value: unknown): string | false {
-  if (value === false) return false;
-  if (typeof value !== "string") return "#";
-  const normalized = value.trim();
-  return normalized && !/\s/.test(normalized) ? normalized : "#";
-}
 
 function normalizeCustomStatusItem(raw: unknown, idOverride?: string): CustomStatusItem | null {
   if (!isRecord(raw)) return null;
@@ -312,7 +305,6 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     invalidPlacement: null,
     welcome: true,
     stashSharpSShortcut: false,
-    queue: { captureSigil: "#" },
   };
 
   const directPreset = normalizePreset(value, presets);
@@ -324,9 +316,6 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
   const { disabledSegments, invalidDisabledSegments } = normalizeDisabledSegments(value.disabledSegments, customItems);
   const { layout, invalidLayoutSegments } = normalizeLayout(value.layout, customItems);
   const { placement, invalidPlacement } = normalizePlacement(value.placement);
-  const queue = isRecord(value.queue)
-    ? { captureSigil: normalizeCaptureSigil(value.queue.captureSigil) }
-    : defaultConfig.queue;
 
   return {
     preset: normalizePreset(value.preset, presets) ?? defaultConfig.preset,
@@ -341,7 +330,6 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     invalidPlacement,
     welcome: value.welcome !== false,
     stashSharpSShortcut: value.stashSharpSShortcut === true,
-    queue,
   };
 }
 

--- a/queue/store.ts
+++ b/queue/store.ts
@@ -46,7 +46,7 @@ function normalizeTarget(value: unknown): QueueTarget | null {
 }
 
 function normalizeIntent(value: unknown): QueueIntent | null {
-  return value === "steer" || value === "follow-up" || value === "post-compact" || value === "idea"
+  return value === "steer" || value === "follow-up" || value === "post-compact"
     ? value
     : null;
 }
@@ -189,23 +189,18 @@ export class PowerlineQueueStore {
   }
 
   queuedDeliveryItems(context: QueueContext, intent?: QueueIntent): PowerlineQueueItem[] {
-    return this.activeItems(context).filter((item) => {
-      if (item.status !== "queued") return false;
-      if (item.intent === "idea") return false;
-      return intent ? item.intent === intent : true;
-    });
+    return this.activeItems(context).filter((item) => (
+      item.status === "queued" && (intent ? item.intent === intent : true)
+    ));
   }
 
   summarize(context: QueueContext, compacting: boolean): QueueSummary {
-    const active = this.activeItems(context);
-    const queueItems = active.filter((item) => item.intent !== "idea");
-    const ideaItems = active.filter((item) => item.intent === "idea");
-    const blockedItems = active.filter((item) => item.status === "blocked" || item.status === "failed");
-    const leading = [...blockedItems, ...queueItems, ...ideaItems][0] ?? null;
+    const queueItems = this.activeItems(context);
+    const blockedItems = queueItems.filter((item) => item.status === "blocked" || item.status === "failed");
+    const leading = [...blockedItems, ...queueItems][0] ?? null;
 
     return {
       queueCount: queueItems.length,
-      ideaCount: ideaItems.length,
       blockedCount: blockedItems.length,
       compacting,
       leadingText: leading?.text ?? null,
@@ -304,51 +299,8 @@ export function isActiveForContext(item: PowerlineQueueItem, context: QueueConte
   return item.source.cwd === currentCwd;
 }
 
-export function targetForIdea(rawTarget: string | null, store: PowerlineQueueStore, cwd: string): QueueTarget {
-  if (!rawTarget) return { kind: "project", cwd: normalizeCwd(cwd) };
-  if (rawTarget === "current") return { kind: "current-session" };
-  if (rawTarget === "global") return { kind: "global" };
-
-  const aliasCwd = store.resolveAlias(rawTarget);
-  if (!aliasCwd) {
-    throw new Error(`Unknown project alias @${rawTarget}. Use /queue alias ${rawTarget} <path> first.`);
-  }
-  return { kind: "project", cwd: aliasCwd, alias: rawTarget };
-}
-
-export function parseTargetPrefix(text: string): { target: string | null; text: string } {
-  const trimmed = text.trim();
-  const match = /^@([a-zA-Z0-9_-]+)(?:\s+|$)/.exec(trimmed);
-  if (!match) return { target: null, text: trimmed };
-  return { target: match[1], text: trimmed.slice(match[0].length).trim() };
-}
-
-export function parseSigilIdeaCapture(text: string, sigil: string | false): { target: string | null; text: string } | null {
-  if (sigil === false) return null;
-  const normalizedSigil = sigil.trim();
-  if (!normalizedSigil) return null;
-
-  const trimmed = text.trim();
-  if (!trimmed.startsWith(normalizedSigil)) return null;
-
-  const afterSigil = trimmed.slice(normalizedSigil.length);
-  if (!/^\s/.test(afterSigil)) return null;
-
-  const parsed = parseTargetPrefix(afterSigil.trim());
-  return parsed.text ? parsed : null;
-}
-
 export function formatQueueDeliveryText(item: PowerlineQueueItem): string {
-  if (item.intent !== "idea") return item.text;
-  return `[powerline idea ${item.id}, captured ${new Date(item.createdAt).toISOString()} from ${item.source.cwd}]\n${item.text}`;
-}
-
-export function formatIdeaIssuePrompt(item: PowerlineQueueItem): string {
-  const target = item.target.kind === "project"
-    ? `project ${item.target.alias ? `@${item.target.alias} ` : ""}${item.target.cwd}`
-    : item.target.kind;
-
-  return `Please process this saved Powerline idea as a GitHub issue candidate.\n\n${formatQueueDeliveryText(item)}\n\nIssue filing rules:\n- If subagents are available, spawn one low-budget issue-filing lane for this idea; otherwise do the same checks directly.\n- First identify the target repository from the idea target (${target}), source cwd (${item.source.cwd}), and current session context.\n- If the target repository is unclear or is not owned/controlled by the user, ask before filing anything.\n- If the target repository is clear and owned/controlled by the user, dedupe against existing open issues first.\n- If a matching open issue already exists, report it and do not create another issue.\n- If no matching issue exists, create one self-contained GitHub issue in that repository with a clear title, context, acceptance criteria, and the Powerline idea provenance above.\n- Use explicit repository targeting for GitHub commands and do not change source files for this handoff.`;
+  return item.text;
 }
 
 export function parseCompactQueuedPrompt(text: string): string | null {

--- a/queue/types.ts
+++ b/queue/types.ts
@@ -1,4 +1,4 @@
-export type QueueIntent = "steer" | "follow-up" | "post-compact" | "idea";
+export type QueueIntent = "steer" | "follow-up" | "post-compact";
 export type QueueStatus = "queued" | "blocked" | "delivering" | "sent" | "failed";
 
 export type QueueTarget =
@@ -29,7 +29,6 @@ export interface QueueAliasMap {
 
 export interface QueueSummary {
   queueCount: number;
-  ideaCount: number;
   blockedCount: number;
   compacting: boolean;
   leadingText: string | null;

--- a/segments.ts
+++ b/segments.ts
@@ -257,9 +257,6 @@ const queueSegment: StatusLineSegment = {
       parts.push(`q ${summary.queueCount}`);
     }
 
-    if (summary.ideaCount > 0) {
-      parts.push(`ideas ${summary.ideaCount}`);
-    }
 
     if (summary.blockedCount > 0) {
       parts.push(`blocked ${summary.blockedCount}`);

--- a/tests/bash-mode.test.ts
+++ b/tests/bash-mode.test.ts
@@ -934,12 +934,6 @@ test("bash editor hot path avoids full expansion and coalesces ghost work", asyn
     assert.deepEqual(resolved, ["git"]);
     editor.clearGhostSuggestion();
 
-    editor.setText("\n  \n  # idea");
-    assert.equal(editor.hasLeadingSigil("#"), true);
-    editor.setText("#");
-    assert.equal(editor.hasLeadingSigil("#"), false);
-    editor.setText("## idea");
-    assert.equal(editor.hasLeadingSigil("#"), false);
   } finally {
     links.cleanup();
   }

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -35,7 +35,6 @@ test("parsePowerlineConfig supports object config with custom items", () => {
   assert.equal(config.invalidPlacement, null);
   assert.equal(config.welcome, true);
   assert.equal(config.stashSharpSShortcut, false);
-  assert.deepEqual(config.queue, { captureSigil: "#" });
 });
 
 test("parsePowerlineConfig supports disabled segments", () => {
@@ -156,31 +155,18 @@ test("parsePowerlineConfig validates primary powerline placement", () => {
 
 
 
-test("parsePowerlineConfig supports welcome, legacy sharp-S, and queue capture settings", () => {
-  const disabled = parsePowerlineConfig(
-    { preset: "compact", welcome: false, stashSharpSShortcut: true, queue: { captureSigil: false } },
-    ["default", "compact"],
-  );
-  const customSigil = parsePowerlineConfig(
-    { preset: "compact", queue: { captureSigil: "//" } },
-    ["default", "compact"],
-  );
-  const invalidSigil = parsePowerlineConfig(
-    { preset: "compact", queue: { captureSigil: "# note" } },
+test("parsePowerlineConfig supports welcome and legacy sharp-S settings", () => {
+  const config = parsePowerlineConfig(
+    { preset: "compact", welcome: false, stashSharpSShortcut: true },
     ["default", "compact"],
   );
   const shorthand = parsePowerlineConfig("compact", ["default", "compact"]);
 
-  assert.equal(disabled.welcome, false);
-  assert.equal(disabled.stashSharpSShortcut, true);
-  assert.deepEqual(disabled.queue, { captureSigil: false });
-  assert.deepEqual(customSigil.queue, { captureSigil: "//" });
-  assert.deepEqual(invalidSigil.queue, { captureSigil: "#" });
+  assert.equal(config.welcome, false);
+  assert.equal(config.stashSharpSShortcut, true);
   assert.equal(shorthand.welcome, true);
   assert.equal(shorthand.stashSharpSShortcut, false);
-  assert.deepEqual(shorthand.queue, { captureSigil: "#" });
 });
-
 test("parsePowerlineConfig extracts supported segment options", () => {
   const config = parsePowerlineConfig(
     {

--- a/tests/jump-shortcuts.test.ts
+++ b/tests/jump-shortcuts.test.ts
@@ -8,7 +8,6 @@ test("surviving editor shortcuts resolve without app-owned chat scrolling", () =
   assert.equal(resolved.stashHistory, "ctrl+alt+h");
   assert.equal(resolved.copyEditor, "ctrl+alt+c");
   assert.equal(resolved.cutEditor, "ctrl+alt+x");
-  assert.equal(resolved.ideaCapture, null);
   assert.equal(resolved.editorStart, "super+shift+up");
   assert.equal(resolved.editorEnd, "super+shift+down");
   assert.equal(Object.keys(resolved).some((key) => key.startsWith("scroll")), false);
@@ -23,15 +22,6 @@ test("super shortcut matching and conflict normalization remain supported", () =
   assert.equal(shortcutConflictKey("super+home"), "super+up");
 });
 
-test("idea capture shortcut remains configurable", () => {
-  const resolved = resolveShortcutConfig({
-    powerlineShortcuts: {
-      ideaCapture: "ctrl+alt+i",
-    },
-  });
-
-  assert.equal(resolved.ideaCapture, "ctrl+alt+i");
-});
 
 test("editor boundary shortcuts remain configurable", () => {
   const resolved = resolveShortcutConfig({

--- a/tests/queue-store.test.ts
+++ b/tests/queue-store.test.ts
@@ -1,9 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { PowerlineQueueStore, currentQueueContext, formatIdeaIssuePrompt, formatQueueDeliveryText, parseCompactQueuedPrompt, parseSigilIdeaCapture, parseTargetPrefix, targetForIdea } from "../queue/store.ts";
+import { PowerlineQueueStore, currentQueueContext, formatQueueDeliveryText, parseCompactQueuedPrompt } from "../queue/store.ts";
 
 function withStore(fn: (store: PowerlineQueueStore, dir: string) => void): void {
   const dir = mkdtempSync(join(tmpdir(), "powerline-queue-"));
@@ -14,168 +14,44 @@ function withStore(fn: (store: PowerlineQueueStore, dir: string) => void): void 
   }
 }
 
-test("queue store adds active project ideas and summarizes them", () => withStore((store) => {
+test("queue store summarizes queued and blocked prompts", () => withStore((store) => {
   const cwd = "/tmp/project-a";
-  store.add({
-    text: "remember deploy note",
-    source: { cwd, sessionId: "s1" },
-    target: { kind: "project", cwd },
-    intent: "idea",
-    now: 100,
-  });
-  store.add({
-    text: "run after compact",
-    source: { cwd, sessionId: "s1" },
-    target: { kind: "current-session" },
-    intent: "post-compact",
-    now: 101,
-  });
+  store.add({ text: "run after compact", source: { cwd, sessionId: "s1" }, target: { kind: "current-session" }, intent: "post-compact", now: 100 });
+  const blocked = store.add({ text: "retry me", source: { cwd, sessionId: "s1" }, target: { kind: "project", cwd }, intent: "follow-up", now: 101 });
+  store.update(blocked.id, { status: "blocked" });
 
-  assert.equal(store.list().length, 2);
   assert.deepEqual(store.summarize(currentQueueContext(cwd, "s1"), true), {
-    queueCount: 1,
-    ideaCount: 1,
-    blockedCount: 0,
+    queueCount: 2,
+    blockedCount: 1,
     compacting: true,
-    leadingText: "run after compact",
-    leadingIntent: "post-compact",
-    leadingStatus: "queued",
-  });
-}));
-
-test("queue store filters inactive project items", () => withStore((store) => {
-  store.add({
-    text: "other project",
-    source: { cwd: "/tmp/project-a" },
-    target: { kind: "project", cwd: "/tmp/project-a" },
-    intent: "idea",
-  });
-
-  assert.equal(store.activeItems(currentQueueContext("/tmp/project-b")).length, 0);
-  assert.equal(store.activeItems(currentQueueContext("/tmp/project-a")).length, 1);
-}));
-
-test("queue store exposes the leading item intent for idea-only summaries", () => withStore((store) => {
-  store.add({
-    text: "saved follow-up idea",
-    source: { cwd: "/tmp/project" },
-    target: { kind: "project", cwd: "/tmp/project" },
-    intent: "idea",
-    now: 100,
-  });
-
-  assert.deepEqual(store.summarize(currentQueueContext("/tmp/project"), false), {
-    queueCount: 0,
-    ideaCount: 1,
-    blockedCount: 0,
-    compacting: false,
-    leadingText: "saved follow-up idea",
-    leadingIntent: "idea",
-    leadingStatus: "queued",
+    leadingText: "retry me",
+    leadingIntent: "follow-up",
+    leadingStatus: "blocked",
   });
 }));
 
 test("current-session targets stay scoped to the source session when known", () => withStore((store) => {
-  store.add({
-    text: "session only",
-    source: { cwd: "/tmp/project", sessionId: "s1" },
-    target: { kind: "current-session" },
-    intent: "post-compact",
-  });
-
+  store.add({ text: "session only", source: { cwd: "/tmp/project", sessionId: "s1" }, target: { kind: "current-session" }, intent: "post-compact" });
   assert.equal(store.activeItems(currentQueueContext("/tmp/project", "s1")).length, 1);
   assert.equal(store.activeItems(currentQueueContext("/tmp/project", "s2")).length, 0);
 }));
 
-test("queue store aliases resolve idea targets", () => withStore((store) => {
-  store.setAlias("pika", "/tmp/pika");
-
-  assert.deepEqual(targetForIdea("pika", store, "/tmp/current"), {
-    kind: "project",
-    cwd: resolve("/tmp/pika"),
-    alias: "pika",
-  });
-  assert.deepEqual(targetForIdea("global", store, "/tmp/current"), { kind: "global" });
-  assert.deepEqual(targetForIdea("current", store, "/tmp/current"), { kind: "current-session" });
-  assert.throws(() => targetForIdea("missing", store, "/tmp/current"), /Unknown project alias/);
-}));
-
-test("parseTargetPrefix separates optional @target", () => {
-  assert.deepEqual(parseTargetPrefix("@pika check logs"), { target: "pika", text: "check logs" });
-  assert.deepEqual(parseTargetPrefix("plain idea"), { target: null, text: "plain idea" });
-});
-
-test("parseSigilIdeaCapture turns leading sigil text into target-aware ideas", () => {
-  assert.deepEqual(parseSigilIdeaCapture("# check logs", "#"), { target: null, text: "check logs" });
-  assert.deepEqual(parseSigilIdeaCapture("# @global check logs", "#"), { target: "global", text: "check logs" });
-  assert.deepEqual(parseSigilIdeaCapture("# @pika check logs\nthen inspect events", "#"), {
-    target: "pika",
-    text: "check logs\nthen inspect events",
-  });
-  assert.deepEqual(parseSigilIdeaCapture("note # check logs", "#"), null);
-  assert.deepEqual(parseSigilIdeaCapture("## markdown heading", "#"), null);
-  assert.deepEqual(parseSigilIdeaCapture("#   ", "#"), null);
-  assert.deepEqual(parseSigilIdeaCapture("# check logs", false), null);
-  assert.deepEqual(parseSigilIdeaCapture("// check logs", "//"), { target: null, text: "check logs" });
-});
-
-test("formatQueueDeliveryText adds provenance only for ideas", () => {
-  const idea = {
-    id: "a1b2c3d4",
-    text: "check logs",
-    createdAt: 1000,
-    updatedAt: 1000,
-    source: { cwd: "/tmp/project" },
-    target: { kind: "current-session" as const },
-    intent: "idea" as const,
-    status: "queued" as const,
-  };
-  const prompt = { ...idea, intent: "follow-up" as const };
-
-  assert.equal(
-    formatQueueDeliveryText(idea),
-    "[powerline idea a1b2c3d4, captured 1970-01-01T00:00:01.000Z from /tmp/project]\ncheck logs",
-  );
-  assert.equal(formatQueueDeliveryText(prompt), "check logs");
-});
-
-test("formatIdeaIssuePrompt requires dedupe and clear owned repo before filing", () => {
-  const prompt = formatIdeaIssuePrompt({
-    id: "a1b2c3d4",
-    text: "add typed issue handoff",
-    createdAt: 1000,
-    updatedAt: 1000,
-    source: { cwd: "/tmp/project" },
-    target: { kind: "project", cwd: "/tmp/project", alias: "powerline" },
-    intent: "idea",
-    status: "queued",
-  });
-
-  assert.match(prompt, /spawn one low-budget issue-filing lane/);
-  assert.match(prompt, /target repository is unclear or is not owned\/controlled by the user, ask before filing/);
-  assert.match(prompt, /dedupe against existing open issues first/);
-  assert.match(prompt, /If a matching open issue already exists, report it and do not create another issue/);
-  assert.match(prompt, /create one self-contained GitHub issue/);
-  assert.match(prompt, /project @powerline \/tmp\/project/);
+test("queue delivery returns the prompt text", () => {
+  assert.equal(formatQueueDeliveryText({
+    id: "a1b2c3d4", text: "check logs", createdAt: 1000, updatedAt: 1000,
+    source: { cwd: "/tmp/project" }, target: { kind: "current-session" }, intent: "follow-up", status: "queued",
+  }), "check logs");
 });
 
 test("parseCompactQueuedPrompt treats /compact suffix as queued prompt text", () => {
   assert.equal(parseCompactQueuedPrompt("/compact great lets proceed"), "great lets proceed");
   assert.equal(parseCompactQueuedPrompt("  /compact   great lets proceed  "), "great lets proceed");
-  assert.equal(parseCompactQueuedPrompt("/compact\tgreat lets proceed"), "great lets proceed");
   assert.equal(parseCompactQueuedPrompt("/compact"), null);
-  assert.equal(parseCompactQueuedPrompt("/compact   "), null);
   assert.equal(parseCompactQueuedPrompt("/compactness great lets proceed"), null);
 });
 
 test("queue store clears items from active summary", () => withStore((store) => {
-  const item = store.add({
-    text: "queued prompt",
-    source: { cwd: "/tmp/project" },
-    target: { kind: "current-session" },
-    intent: "post-compact",
-  });
-
+  const item = store.add({ text: "queued prompt", source: { cwd: "/tmp/project" }, target: { kind: "current-session" }, intent: "post-compact" });
   assert.equal(store.summarize(currentQueueContext("/tmp/project"), false).queueCount, 1);
   store.clear(item.id);
   assert.equal(store.summarize(currentQueueContext("/tmp/project"), false).queueCount, 0);
@@ -184,12 +60,6 @@ test("queue store clears items from active summary", () => withStore((store) => 
 test("queue store times out instead of stealing an existing lock", () => withStore((store, dir) => {
   const lockPath = join(dir, "inbox.jsonl.lock");
   mkdirSync(lockPath);
-
-  assert.throws(() => store.add({
-    text: "blocked write",
-    source: { cwd: "/tmp/project" },
-    target: { kind: "project", cwd: "/tmp/project" },
-    intent: "idea",
-  }), /Timed out waiting for Powerline queue store lock/);
+  assert.throws(() => store.add({ text: "blocked write", source: { cwd: "/tmp/project" }, target: { kind: "project", cwd: "/tmp/project" }, intent: "follow-up" }), /Timed out waiting for Powerline queue store lock/);
   assert.equal(existsSync(lockPath), true);
 }));

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -154,12 +154,6 @@ test("post-compaction queue delivery does not read ctx.cwd from the delayed call
   assert.match(source, /if \(isStaleExtensionContextError\(error\)\) \{\r?\n\s+if \(!sent\) queueStore\.update\(item\.id, \{ status: "queued", error: undefined \}\);/);
 });
 
-test("editor render checks sigil drafts without reading the full text", () => {
-  assert.match(source, /isSigilIdeaDraft\(editor\)/);
-  assert.match(source, /editor\.hasLeadingSigil\(normalizedSigil\)/);
-  assert.doesNotMatch(source, /isSigilIdeaDraft\(editor\.get(?:Expanded)?Text\(\)\)/);
-});
-
 test("editor-adjacent widgets cache queue and last-prompt work", () => {
   assert.match(source, /const QUEUE_SUMMARY_CACHE_TTL_MS = 250;/);
   assert.match(source, /queueSummaryCache = null;\r?\n\s+requestImmediateStatusRender/);

--- a/tests/usage-display.test.ts
+++ b/tests/usage-display.test.ts
@@ -42,7 +42,7 @@ function createSegmentContext(options: StatusLineSegmentOptions = {}, overrides:
     autoCompactEnabled: true,
     customCompactionEnabled: false,
     usingSubscription: false,
-    queueSummary: { queueCount: 0, ideaCount: 0, blockedCount: 0, compacting: false, leadingText: null, leadingIntent: null, leadingStatus: null },
+    queueSummary: { queueCount: 0, blockedCount: 0, compacting: false, leadingText: null, leadingIntent: null, leadingStatus: null },
     sessionStartTime: Date.now(),
     shellModeActive: false,
     shellRunning: false,
@@ -182,17 +182,17 @@ test("queue segment hides when empty", () => {
   assert.deepEqual(renderSegment("queue", ctx), { content: "", visible: false });
 });
 
-test("queue segment summarizes queued ideas and blocked items", () => {
+test("queue segment summarizes queued and blocked items", () => {
   const ctx = createSegmentContext({}, {
-    queueSummary: { queueCount: 2, ideaCount: 3, blockedCount: 1, compacting: false, leadingText: "fix README", leadingIntent: "post-compact", leadingStatus: "blocked" },
+    queueSummary: { queueCount: 2, blockedCount: 1, compacting: false, leadingText: "fix README", leadingIntent: "post-compact", leadingStatus: "blocked" },
   });
 
-  assert.equal(stripAnsi(renderSegment("queue", ctx).content), "q 2 · ideas 3 · blocked 1");
+  assert.equal(stripAnsi(renderSegment("queue", ctx).content), "q 2 · blocked 1");
 });
 
 test("queue segment highlights compaction-held prompts", () => {
   const ctx = createSegmentContext({}, {
-    queueSummary: { queueCount: 1, ideaCount: 0, blockedCount: 0, compacting: true, leadingText: "run after compact", leadingIntent: "post-compact", leadingStatus: "queued" },
+    queueSummary: { queueCount: 1, blockedCount: 0, compacting: true, leadingText: "run after compact", leadingIntent: "post-compact", leadingStatus: "queued" },
   });
 
   assert.equal(stripAnsi(renderSegment("queue", ctx).content), "compact q 1");

--- a/types.ts
+++ b/types.ts
@@ -156,11 +156,10 @@ export interface GitStatus {
 // Usage statistics
 export interface QueueSummary {
   queueCount: number;
-  ideaCount: number;
   blockedCount: number;
   compacting: boolean;
   leadingText: string | null;
-  leadingIntent: "steer" | "follow-up" | "post-compact" | "idea" | null;
+  leadingIntent: "steer" | "follow-up" | "post-compact" | null;
   leadingStatus: "queued" | "blocked" | "delivering" | "sent" | "failed" | null;
 }
 


### PR DESCRIPTION
## Summary

- Remove the saved idea inbox, `/idea` and `/ideas` commands, sigil capture, idea queue intent, issue handoff, and related docs/tests.
- Keep normal queued prompts, `/queue`, aliases/targeting, post-compact delivery, retry/clear, stash insertion, bash mode, and editor responsiveness behavior.
- Treat old persisted `intent: "idea"` records as unsupported under the hard cutover.

## Validation

- `node --experimental-strip-types --test tests/queue-store.test.ts tests/usage-display.test.ts tests/custom-items.test.ts tests/jump-shortcuts.test.ts tests/bash-mode.test.ts tests/remaining-regressions.test.ts`
- `npm test`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Fresh review: `/Users/nicobailon/Documents/docs/pi-powerline-footer-backlog-20260811T2249Z/remove-ideas-final-review.md` reported no findings.

Release/tag authority was not used.
