### PR TITLE
ci: update actions to Node 24 runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - **Editor typing responsiveness** — Avoid expanding paste markers or joining full drafts in editor hot paths, debounce bash ghost completion, run git completion lookups asynchronously, and cache queue/prompt render work so typing stays smooth in large drafts and bash mode.
+- **GitHub Actions runtime** — Updated checkout and Node setup actions to their Node 24 runtime versions.
 
 ### Fixed
 - **Git polling no longer takes `.git/index.lock`** — Read-only git commands now run with `GIT_OPTIONAL_LOCKS=0`, so polling `git status` stops refreshing the index as a side effect, which raced interactive git in the same repo and could leave an orphaned lock behind. Thanks to Max Kaye (@XertroV) for #156.


### PR DESCRIPTION
Updates the Test workflow from `actions/checkout@v4` and `actions/setup-node@v4` to their Node 24 runtime majors. This removes the GitHub Actions runtime deprecation annotation seen on recent CI runs.\n\nValidation:\n- `git diff --check`\n- Verified both action metadata files declare `using: node24`\n