### PR TITLE
refactor: make bash completions opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - **Editor typing responsiveness** — Avoid expanding paste markers or joining full drafts in editor hot paths, debounce bash ghost completion, run git completion lookups asynchronously, and cache queue/prompt render work so typing stays smooth in large drafts and bash mode.
+- **Bash completions are opt-in** — Disable Powerline bash ghost suggestions and one-off `!command` predictions by default. Set `bashMode.completions` to `true` to re-enable them.
 - **GitHub Actions runtime** — Updated checkout and Node setup actions to their Node 24 runtime versions.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Customizes the default [pi](https://github.com/badlogic/pi-mono) editor with a p
 
 **Sticky bash mode** — Toggle bash mode with `ctrl+shift+b` or `/bash-mode`. It keeps a managed shell session alive for the current pi session, shows a dedicated `shell_mode` segment, streams command output into an embedded transcript below the editor, and lets `cd` or exported state persist across commands.
 
-**Shell ghost suggestions** — Bash mode is now ghost-first. Successful per-project shell history is the primary source, while deterministic path and git continuations can still extend an existing command. Shell-native completion probes are disabled so `!command` predictions never spawn interactive shell completion subprocesses. At command position, short stems first resolve from the newest successful local command, can use guarded global shell history for high-confidence heads like `git`, and finally fall back to a tiny curated default set when history is absent. Right now that curated set is `g` → `git status` and `c` → `cd ..`. If the bash prompt is empty, bash mode shows the newest successful project-history ghost suggestion when one exists, otherwise it stays empty. The same inline predictions now also kick in for one-off `!command` and `!!command` prompts. Right Arrow or Tab accepts ghost text into the editor, and Enter runs the current shell command.
+**Shell ghost suggestions** — Optional bash-mode completions can show inline ghost suggestions from successful project shell history, deterministic path and git continuations, guarded global history for high-confidence heads like `git`, and a tiny curated default set. Right now that curated set is `g` → `git status` and `c` → `cd ..`. Shell-native completion probes stay disabled. Set `bashMode.completions` to `true` to enable bash-mode ghosts and one-off `!command` / `!!command` predictions.
 
 ## Installation
 
@@ -233,13 +233,12 @@ Reset the managed shell with `/bash-reset`.
 While bash mode is active:
 
 - Enter runs the current shell command
-- Right Arrow accepts ghost text into the editor without running it
-- Tab accepts the current ghost suggestion when one exists; otherwise it does nothing
 - Up and Down browse matching shell history
 - `escape` exits bash mode and returns to normal prompt mode
 - `ctrl+c` interrupts the active shell job before falling back to normal pi behavior
+- When `bashMode.completions` is `true`, Right Arrow or Tab accepts ghost text into the editor without running it
 
-The managed shell is persistent for the current pi session. Command output appears in a transcript below the editor, and shell cwd changes are reflected in the footer path and `shell_mode` segment. If the bash prompt is empty, bash mode shows the newest successful project-history ghost suggestion immediately when one exists, including right after mode entry or after the prompt is cleared again. One-off `!command` and `!!command` prompts reuse the same shell prediction pipeline, including ghost text. Mode entry stays quiet: there is no automatic or manual dropdown completion surface, and ghost suggestions do not run shell-native completion probes.
+The managed shell is persistent for the current pi session. Command output appears in a transcript below the editor, and shell cwd changes are reflected in the footer path and `shell_mode` segment. Bash-mode ghost suggestions and one-off `!command` / `!!command` predictions are opt-in because they add editor work. When enabled, bash mode can show the newest successful project-history ghost on an empty prompt. Mode entry stays quiet: there is no automatic or manual dropdown completion surface, and ghost suggestions do not run shell-native completion probes.
 
 ### Bash mode configuration
 
@@ -249,6 +248,7 @@ In `~/.pi/agent/settings.json` (or under `PI_CODING_AGENT_DIR` when that environ
 {
   "bashMode": {
     "toggleShortcut": "ctrl+shift+b",
+    "completions": false,
     "transcriptMaxLines": 2000,
     "transcriptMaxBytes": 524288
   }

--- a/bash-mode/editor.ts
+++ b/bash-mode/editor.ts
@@ -21,6 +21,7 @@ interface BashModeEditorOptions {
   onInterrupt: () => void;
   onNotify: (message: string, level?: "info" | "warning" | "error") => void;
   getHistoryEntries: (prefix: string) => string[];
+  areCompletionsEnabled?: () => boolean;
   resolveGhostSuggestion: (text: string, signal: AbortSignal) => Promise<GhostSuggestion | null>;
 }
 
@@ -134,7 +135,11 @@ export class BashModeEditor extends CustomEditor {
   }
 
   refreshGhostSuggestion(): void {
-    this.scheduleGhostUpdate();
+    if (this.areCompletionsEnabled()) {
+      this.scheduleGhostUpdate();
+    } else {
+      this.clearGhostSuggestion();
+    }
   }
 
   clearGhostSuggestion(): void {
@@ -375,7 +380,12 @@ export class BashModeEditor extends CustomEditor {
   }
 
   private isShellCompletionContext(): boolean {
-    return this.optionsRef.isBashModeActive() || this.isOneOffBashCommandContext();
+    return this.areCompletionsEnabled()
+      && (this.optionsRef.isBashModeActive() || this.isOneOffBashCommandContext());
+  }
+
+  private areCompletionsEnabled(): boolean {
+    return this.optionsRef.areCompletionsEnabled?.() ?? true;
   }
 
   private isOneOffBashCommandContext(): boolean {
@@ -472,6 +482,11 @@ export class BashModeEditor extends CustomEditor {
   }
 
   private scheduleGhostUpdate(): void {
+    if (!this.areCompletionsEnabled()) {
+      this.clearGhostSuggestion();
+      return;
+    }
+
     const text = this.getText();
     const currentToken = ++this.ghostToken;
     if (this.ghostTimer) clearTimeout(this.ghostTimer);

--- a/bash-mode/types.ts
+++ b/bash-mode/types.ts
@@ -1,5 +1,6 @@
 export interface BashModeSettings {
   toggleShortcut: string | null;
+  completions: boolean;
   transcriptMaxLines: number;
   transcriptMaxBytes: number;
 }

--- a/index.ts
+++ b/index.ts
@@ -119,6 +119,7 @@ const DEFAULT_SHORTCUTS: PowerlineShortcuts = {
 };
 const DEFAULT_BASH_MODE_SETTINGS = {
   toggleShortcut: "ctrl+shift+b",
+  completions: false,
   transcriptMaxLines: 2000,
   transcriptMaxBytes: 512 * 1024,
 } as const satisfies BashModeSettings;
@@ -823,6 +824,9 @@ export function parseBashModeSettings(settings: Record<string, unknown>, powerli
       `[powerline-footer] Bash mode shortcut conflict: "${configuredToggleShortcut}" replaced with "${toggleShortcut ?? "disabled"}"`,
     );
   }
+  const completions = typeof raw.completions === "boolean"
+    ? raw.completions
+    : DEFAULT_BASH_MODE_SETTINGS.completions;
   const transcriptMaxLines = typeof raw.transcriptMaxLines === "number" && Number.isFinite(raw.transcriptMaxLines)
     ? Math.max(100, Math.floor(raw.transcriptMaxLines))
     : DEFAULT_BASH_MODE_SETTINGS.transcriptMaxLines;
@@ -832,6 +836,7 @@ export function parseBashModeSettings(settings: Record<string, unknown>, powerli
 
   return {
     toggleShortcut,
+    completions,
     transcriptMaxLines,
     transcriptMaxBytes,
   };
@@ -2749,6 +2754,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         },
         onNotify: (message, level = "info") => ctx.ui.notify(message, level),
         getHistoryEntries: (prefix) => getShellHistoryEntries(prefix),
+        areCompletionsEnabled: () => bashModeSettings.completions,
         resolveGhostSuggestion: async (text, signal) => {
           const oneOffBash = getOneOffBashCommandContext(text);
           if (oneOffBash) {
@@ -2782,6 +2788,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       };
 
       const attachAutocompleteProvider = (): boolean => {
+        if (!bashModeSettings.completions) return false;
         if (editor.hasWrappedProvider()) return true;
         const defaultProvider = getInstalledAutocompleteProvider();
         if (!defaultProvider) return false;

--- a/tests/bash-mode.test.ts
+++ b/tests/bash-mode.test.ts
@@ -865,12 +865,42 @@ test("bash editor refreshGhostSuggestion reuses the ghost scheduling path", asyn
     let scheduled = false;
 
     getMethod(BashModeEditor.prototype, "refreshGhostSuggestion").call({
+      areCompletionsEnabled() {
+        return true;
+      },
       scheduleGhostUpdate() {
         scheduled = true;
       },
     });
 
     assert.equal(scheduled, true);
+  } finally {
+    links.cleanup();
+  }
+});
+
+test("bash editor refreshGhostSuggestion clears ghosts when completions are disabled", async () => {
+  const links = ensureEditorModuleLinks();
+
+  try {
+    const { BashModeEditor } = await import("../bash-mode/editor.ts");
+    let cleared = false;
+    let scheduled = false;
+
+    getMethod(BashModeEditor.prototype, "refreshGhostSuggestion").call({
+      areCompletionsEnabled() {
+        return false;
+      },
+      clearGhostSuggestion() {
+        cleared = true;
+      },
+      scheduleGhostUpdate() {
+        scheduled = true;
+      },
+    });
+
+    assert.equal(cleared, true);
+    assert.equal(scheduled, false);
   } finally {
     links.cleanup();
   }

--- a/tests/jump-shortcuts.test.ts
+++ b/tests/jump-shortcuts.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { isSupportedSuperShortcut, matchesConfiguredShortcut, shortcutConflictKey } from "../shortcuts.ts";
-import { resolveShortcutConfig } from "../index.ts";
+import { parseBashModeSettings, resolveShortcutConfig } from "../index.ts";
 
 test("surviving editor shortcuts resolve without app-owned chat scrolling", () => {
   const resolved = resolveShortcutConfig({});
@@ -33,4 +33,10 @@ test("editor boundary shortcuts remain configurable", () => {
 
   assert.equal(resolved.editorStart, "ctrl+shift+u");
   assert.equal(resolved.editorEnd, "ctrl+shift+d");
+});
+
+test("bash completions are opt-in", () => {
+  assert.equal(parseBashModeSettings({}).completions, false);
+  assert.equal(parseBashModeSettings({ bashMode: { completions: true } }).completions, true);
+  assert.equal(parseBashModeSettings({ bashMode: { completions: false } }).completions, false);
 });


### PR DESCRIPTION
Makes Powerline-added bash ghost suggestions and one-off `!command` predictions opt-in via `bashMode.completions`. The default is now `false`, so Pi-native autocomplete stays in place but Powerline no longer wraps the editor autocomplete provider or schedules bash ghost work unless users opt in.\n\nValidation:\n- `node --experimental-strip-types --test tests/jump-shortcuts.test.ts tests/bash-mode.test.ts`\n- `npm run typecheck`\n- `git diff --check`\n- `npm test`\n