### PR TITLE
perf: speed up long-line editor input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Changed
-- **Editor typing responsiveness** — Avoid expanding paste markers or joining full drafts in editor hot paths, debounce bash ghost completion, run git completion lookups asynchronously, cache queue/prompt render work, and use a bounded fast render path for large editor drafts so typing stays smooth.
+- **Editor typing responsiveness** — Avoid expanding paste markers or joining full drafts in editor hot paths, debounce bash ghost completion, run git completion lookups asynchronously, cache queue/prompt render work, use a bounded fast render path for large editor drafts, and avoid full grapheme scans when deleting plain ASCII from long lines. Opt-in profiling and render A/B flags now identify remaining editor costs without affecting normal sessions.
 - **Bash completions are opt-in** — Disable Powerline bash ghost suggestions and one-off `!command` predictions by default. Set `bashMode.completions` to `true` to re-enable them.
 - **GitHub Actions runtime** — Updated checkout and Node setup actions to their Node 24 runtime versions.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ You can also set it in the agent settings file (`~/.pi/agent/settings.json` by d
 
 **Environment:** `POWERLINE_NERD_FONTS=1` to force Nerd Fonts, `=0` for ASCII.
 
+For typing diagnostics, start Pi with `POWERLINE_DEBUG_PERF=1`, reproduce the slow editor case, then run `/powerline-perf`. Use `/powerline-perf reset` before a focused run. Profiling is off by default. While it is enabled, these A/B flags can disable one render seam before `/reload`:
+
+- `POWERLINE_PERF_FAST_RENDER=0`
+- `POWERLINE_PERF_EDITOR_CHROME=0`
+- `POWERLINE_PERF_WIDGETS=0`
+- `POWERLINE_PERF_BASH_WIDGETS=0`
+- `POWERLINE_PERF_LAST_PROMPT=0`
+
 Preset selection is saved under `powerline` in the agent settings file and restored on startup.
 Run `/powerline default` to switch back to the default preset.
 

--- a/bash-mode/editor.ts
+++ b/bash-mode/editor.ts
@@ -31,9 +31,17 @@ const DEFAULT_EDITOR_BOUNDARY_SHORTCUTS: EditorBoundaryShortcuts = {
 };
 
 const GHOST_UPDATE_DEBOUNCE_MS = 50;
+const FAST_BACKSPACE_COLUMN_THRESHOLD = 1200;
 
-function isPrintableInput(data: string): boolean {
-  return data.length === 1 && data.charCodeAt(0) >= 32;
+export function isPrintableInput(data: string): boolean {
+  if (data.length === 1) {
+    const code = data.charCodeAt(0);
+    return code >= 0x20 && (code < 0x7f || code > 0x9f) && (code < 0xd800 || code > 0xdfff);
+  }
+  if (data.length !== 2) return false;
+  const first = data.charCodeAt(0);
+  const second = data.charCodeAt(1);
+  return first >= 0xd800 && first <= 0xdbff && second >= 0xdc00 && second <= 0xdfff;
 }
 
 function isCommandUndoShortcut(data: string): boolean {
@@ -109,6 +117,7 @@ export class BashModeEditor extends CustomEditor {
   private ghostTimer: ReturnType<typeof setTimeout> | null = null;
   private ghostToken = 0;
   private plainBoundInputs: Set<string> | null = null;
+  private readonly backspaceBindingConflicts = new Map<string, boolean>();
 
   constructor(tui: any, theme: any, keybindings: KeybindingsManager, options: BashModeEditorOptions) {
     super(tui, theme, keybindings);
@@ -164,6 +173,7 @@ export class BashModeEditor extends CustomEditor {
 
   handleInput(data: string): void {
     if (BashModeEditor.prototype.tryFastPrintableInput.call(this, data)) return;
+    if (BashModeEditor.prototype.tryFastAsciiBackspace.call(this, data)) return;
 
     const droppedPathText = droppedPathTextFromInput(data);
     if (droppedPathText !== null) {
@@ -323,7 +333,7 @@ export class BashModeEditor extends CustomEditor {
   }
 
   private tryFastPrintableInput(data: string): boolean {
-    if (!/^[a-z0-9 ]$/.test(data)) return false;
+    if (!isPrintableInput(data)) return false;
     if (Reflect.get(this, "isInPaste") === true || Reflect.get(this, "jumpMode") !== null) return false;
 
     if (!this.plainBoundInputs) {
@@ -331,8 +341,9 @@ export class BashModeEditor extends CustomEditor {
       for (const binding of Object.values(this.keybindingsRef.getEffectiveConfig())) {
         if (!binding) continue;
         for (const key of Array.isArray(binding) ? binding : [binding]) {
-          if (key.length === 1) this.plainBoundInputs.add(key);
+          if (isPrintableInput(key)) this.plainBoundInputs.add(key);
           if (key === "space") this.plainBoundInputs.add(" ");
+          if (/^shift\+[a-z]$/.test(key)) this.plainBoundInputs.add(key.at(-1)!.toUpperCase());
         }
       }
     }
@@ -342,6 +353,66 @@ export class BashModeEditor extends CustomEditor {
     const insertCharacter = Reflect.get(this, "insertCharacter");
     if (typeof insertCharacter !== "function") return false;
     insertCharacter.call(this, data);
+
+    resetShellHistoryBrowse(this);
+    if (this.isShellCompletionContext()) {
+      this.scheduleGhostUpdate();
+    } else {
+      this.clearGhostSuggestion();
+    }
+    return true;
+  }
+
+  private tryFastAsciiBackspace(data: string): boolean {
+    if (!this.keybindingsRef.matches(data, "tui.editor.deleteCharBackward")) return false;
+    let hasBindingConflict = this.backspaceBindingConflicts.get(data);
+    if (hasBindingConflict === undefined) {
+      hasBindingConflict = Object.entries(this.keybindingsRef.getEffectiveConfig()).some(([id, binding]) => {
+        if (id === "tui.editor.deleteCharBackward" || !binding) return false;
+        return (Array.isArray(binding) ? binding : [binding]).some((key) => matchesKey(data, key));
+      });
+      this.backspaceBindingConflicts.set(data, hasBindingConflict);
+    }
+    if (hasBindingConflict) return false;
+    if (Reflect.get(this, "isInPaste") === true || Reflect.get(this, "jumpMode") !== null) return false;
+    if (Reflect.get(this, "autocompleteState") !== null) return false;
+
+    const state = Reflect.get(this, "state");
+    const lines = state && typeof state === "object" ? Reflect.get(state, "lines") : null;
+    const cursorLine = state && typeof state === "object" ? Reflect.get(state, "cursorLine") : null;
+    const cursorCol = state && typeof state === "object" ? Reflect.get(state, "cursorCol") : null;
+    if (!Array.isArray(lines) || lines.length !== 1 || cursorLine !== 0 || typeof cursorCol !== "number") return false;
+
+    const line = lines[0];
+    if (typeof line !== "string" || cursorCol < FAST_BACKSPACE_COLUMN_THRESHOLD || cursorCol !== line.length) return false;
+    const previousCode = line.charCodeAt(cursorCol - 2);
+    const deletedCode = line.charCodeAt(cursorCol - 1);
+    if (previousCode < 0x20 || previousCode > 0x7e || deletedCode < 0x20 || deletedCode > 0x7e) return false;
+
+    const pastes = Reflect.get(this, "pastes") as Map<number, string> | undefined;
+    if (pastes?.size) return false;
+
+    const nextLine = line.slice(0, -1);
+    const nextBeforeCursor = nextLine;
+    const isInSlashCommandContext = Reflect.get(this, "isInSlashCommandContext");
+    if (typeof isInSlashCommandContext === "function" && isInSlashCommandContext.call(this, nextBeforeCursor)) return false;
+    const autocompleteTriggerPattern = Reflect.get(this, "autocompleteTriggerPattern") as RegExp | undefined;
+    if (autocompleteTriggerPattern?.test(nextBeforeCursor)) return false;
+
+    const exitHistoryBrowsing = Reflect.get(this, "exitHistoryBrowsing");
+    const pushUndoSnapshot = Reflect.get(this, "pushUndoSnapshot");
+    const setCursorCol = Reflect.get(this, "setCursorCol");
+    if (typeof exitHistoryBrowsing !== "function" || typeof pushUndoSnapshot !== "function" || typeof setCursorCol !== "function") {
+      return false;
+    }
+    if (this.onExtensionShortcut?.(data)) return true;
+
+    exitHistoryBrowsing.call(this);
+    pushUndoSnapshot.call(this);
+    Reflect.set(this, "lastAction", null);
+    lines[0] = nextLine;
+    setCursorCol.call(this, cursorCol - 1);
+    this.onChange?.(nextLine);
 
     resetShellHistoryBrowse(this);
     if (this.isShellCompletionContext()) {

--- a/editor-performance.ts
+++ b/editor-performance.ts
@@ -1,0 +1,99 @@
+export interface EditorPerfOptions {
+  enabled: boolean;
+  fastRender: boolean;
+  editorChrome: boolean;
+  widgets: boolean;
+  bashWidgets: boolean;
+  lastPrompt: boolean;
+}
+
+interface EditorPerfMetric {
+  count: number;
+  totalMs: number;
+  maxMs: number;
+}
+
+export function readEditorPerfOptions(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): EditorPerfOptions {
+  const enabled = env.POWERLINE_DEBUG_PERF === "1";
+  return {
+    enabled,
+    fastRender: !enabled || env.POWERLINE_PERF_FAST_RENDER !== "0",
+    editorChrome: !enabled || env.POWERLINE_PERF_EDITOR_CHROME !== "0",
+    widgets: !enabled || env.POWERLINE_PERF_WIDGETS !== "0",
+    bashWidgets: !enabled || env.POWERLINE_PERF_BASH_WIDGETS !== "0",
+    lastPrompt: !enabled || env.POWERLINE_PERF_LAST_PROMPT !== "0",
+  };
+}
+
+export class EditorPerfProfiler {
+  readonly options: EditorPerfOptions;
+  private readonly metrics = new Map<string, EditorPerfMetric>();
+  private startedAt = Date.now();
+  private maxDraftChars = 0;
+  private draftObservationCount = 0;
+
+  constructor(options: EditorPerfOptions) {
+    this.options = options;
+  }
+
+  measure<T>(name: string, operation: () => T): T {
+    const startedAt = performance.now();
+    try {
+      return operation();
+    } finally {
+      this.record(name, performance.now() - startedAt);
+    }
+  }
+
+  count(name: string): void {
+    const metric = this.metrics.get(name) ?? { count: 0, totalMs: 0, maxMs: 0 };
+    metric.count += 1;
+    this.metrics.set(name, metric);
+  }
+
+  observeDraft(lines: readonly unknown[]): void {
+    this.draftObservationCount += 1;
+    if (lines.length > 1 && this.draftObservationCount % 32 !== 1) return;
+
+    let chars = Math.max(0, lines.length - 1);
+    for (const line of lines) {
+      if (typeof line === "string") chars += line.length;
+    }
+    this.maxDraftChars = Math.max(this.maxDraftChars, chars);
+  }
+
+  reset(): void {
+    this.metrics.clear();
+    this.startedAt = Date.now();
+    this.maxDraftChars = 0;
+    this.draftObservationCount = 0;
+  }
+
+  report(): string {
+    const inputCount = this.metrics.get("input.total")?.count ?? 0;
+    const renderCount = this.metrics.get("editor.render.total")?.count ?? 0;
+    const lines = [
+      `Powerline editor perf (${((Date.now() - this.startedAt) / 1000).toFixed(1)}s)`,
+      `A/B: fast-render=${this.options.fastRender ? "on" : "off"}, editor-chrome=${this.options.editorChrome ? "on" : "off"}, widgets=${this.options.widgets ? "on" : "off"}, bash-widgets=${this.options.bashWidgets ? "on" : "off"}, last-prompt=${this.options.lastPrompt ? "on" : "off"}`,
+      `inputs=${inputCount}, editor-renders=${renderCount}, renders/input=${inputCount > 0 ? (renderCount / inputCount).toFixed(2) : "0.00"}, max-draft=${this.maxDraftChars}`,
+    ];
+
+    for (const [name, metric] of [...this.metrics].sort(([left], [right]) => left.localeCompare(right))) {
+      lines.push(metric.totalMs === 0 && metric.maxMs === 0
+        ? `${name}: n=${metric.count}`
+        : `${name}: n=${metric.count}, avg=${(metric.totalMs / metric.count).toFixed(3)}ms, max=${metric.maxMs.toFixed(3)}ms, total=${metric.totalMs.toFixed(1)}ms`);
+    }
+
+    return lines.join("\n");
+  }
+
+  private record(name: string, durationMs: number): void {
+    const metric = this.metrics.get(name) ?? { count: 0, totalMs: 0, maxMs: 0 };
+    metric.count += 1;
+    metric.totalMs += durationMs;
+    metric.maxMs = Math.max(metric.maxMs, durationMs);
+    this.metrics.set(name, metric);
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,7 @@ import {
   ModeAwareAutocompleteProvider,
   OneOffBashAutocompleteProvider,
 } from "./bash-mode/completion.ts";
-import { BashModeEditor } from "./bash-mode/editor.ts";
+import { BashModeEditor, isPrintableInput } from "./bash-mode/editor.ts";
 import { ManagedShellSession } from "./bash-mode/shell-session.ts";
 import { matchHistoryEntries, readGlobalShellHistory, readProjectHistory, appendProjectHistory } from "./bash-mode/history.ts";
 import type { BashModeSettings } from "./bash-mode/types.ts";
@@ -35,6 +35,7 @@ import { WelcomeComponent, WelcomeHeader, discoverLoadedCounts, getRecentSession
 import { createWelcomeDismissScheduler } from "./welcome-dismiss.ts";
 import { createRenderScheduler } from "./render-scheduler.ts";
 import { getEditorAutocompleteProvider, passAutocompleteProviderThroughPreviousEditor } from "./editor-composition.ts";
+import { EditorPerfProfiler, readEditorPerfOptions } from "./editor-performance.ts";
 import { CoreContextUsageCache, estimateInitialContextTokens, estimateUnknownContextUsage, resolveDisplayContextUsage, type CoreContextUsage } from "./context-usage.ts";
 import { isStaleExtensionContextError, shouldShowStartupWelcome } from "./lifecycle.ts";
 import { getDefaultColors } from "./theme.ts";
@@ -603,10 +604,6 @@ function hasNonWhitespaceText(text: string): boolean {
   return text.trim().length > 0;
 }
 
-function isPlainPrintableInput(data: string): boolean {
-  return data.length === 1 && data.charCodeAt(0) >= 32;
-}
-
 function getCurrentEditorText(ctx: any, editor: any): string {
   const editorText = editor?.getExpandedText?.();
   if (typeof editorText === "string" && editorText.length > 0) return editorText;
@@ -1137,6 +1134,7 @@ function warnInvalidSegmentSettings(ctx: any): void {
 }
 
 export default function powerlineFooter(pi: ExtensionAPI) {
+  const editorPerf = new EditorPerfProfiler(readEditorPerfOptions());
   const startupSettings = readSettings();
   config = parsePowerlineConfig(startupSettings.powerline, PRESET_NAMES);
   let resolvedShortcuts = resolveShortcutConfig(startupSettings);
@@ -2438,6 +2436,22 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     },
   });
 
+  pi.registerCommand("powerline-perf", {
+    description: "Show or reset opt-in editor performance profiling",
+    handler: async (args, ctx) => {
+      if (!editorPerf.options.enabled) {
+        ctx.ui.notify("Set POWERLINE_DEBUG_PERF=1 and reload to enable editor profiling", "info");
+        return;
+      }
+      if (args.trim().toLowerCase() === "reset") {
+        editorPerf.reset();
+        ctx.ui.notify("Powerline editor performance counters reset", "info");
+        return;
+      }
+      ctx.ui.notify(editorPerf.report(), "info");
+    },
+  });
+
   pi.registerCommand("bash-reset", {
     description: "Reset the managed bash session",
     handler: async (_args, ctx) => {
@@ -2675,7 +2689,9 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const presetDef = getPreset(config.preset);
     let segmentCtx: SegmentContext;
     try {
-      segmentCtx = buildSegmentContext(currentCtx, theme);
+      segmentCtx = editorPerf.options.enabled
+        ? editorPerf.measure("layout.segment-context", () => buildSegmentContext(currentCtx, theme))
+        : buildSegmentContext(currentCtx, theme);
     } catch (error) {
       if (!isStaleExtensionContextError(error)) throw error;
       currentCtx = null;
@@ -2801,13 +2817,19 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   }
 
   function installPowerlineWidgets(ctx: any) {
+    if (!editorPerf.options.widgets) return;
+
+    const measureWidget = (name: string, render: () => string[]): string[] => {
+      return editorPerf.options.enabled ? editorPerf.measure(`widget.${name}`, render) : render();
+    };
+
     ctx.ui.setWidget("powerline-status", () => ({
       dispose() {},
       invalidate() {
         requestStatusRender();
       },
       render(width: number): string[] {
-        return renderPowerlineStatusLines(width);
+        return measureWidget("status", () => renderPowerlineStatusLines(width));
       },
     }), { placement: "aboveEditor" });
 
@@ -2817,7 +2839,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         resetLayoutCache();
       },
       render(width: number): string[] {
-        return renderPowerlinePrimaryLines(width, theme);
+        return measureWidget("primary", () => renderPowerlinePrimaryLines(width, theme));
       },
     }), { placement: config.placement === "below" ? "belowEditor" : "aboveEditor" });
 
@@ -2827,33 +2849,37 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         resetLayoutCache();
       },
       render(width: number): string[] {
-        return renderPowerlineSecondaryLines(width, theme);
+        return measureWidget("secondary", () => renderPowerlineSecondaryLines(width, theme));
       },
     }), { placement: "belowEditor" });
 
-    ctx.ui.setWidget("powerline-bash-transcript", (_tui: any, theme: Theme) => ({
-      dispose() {},
-      invalidate() {},
-      render(width: number): string[] {
-        return renderBashTranscriptLines(width, theme);
-      },
-    }), { placement: "belowEditor" });
+    if (editorPerf.options.bashWidgets) {
+      ctx.ui.setWidget("powerline-bash-transcript", (_tui: any, theme: Theme) => ({
+        dispose() {},
+        invalidate() {},
+        render(width: number): string[] {
+          return measureWidget("bash-transcript", () => renderBashTranscriptLines(width, theme));
+        },
+      }), { placement: "belowEditor" });
+    }
 
     ctx.ui.setWidget("powerline-queue-preview", (_tui: any, theme: Theme) => ({
       dispose() {},
       invalidate() {},
       render(width: number): string[] {
-        return renderPowerlineQueuePreviewLines(width, theme);
+        return measureWidget("queue-preview", () => renderPowerlineQueuePreviewLines(width, theme));
       },
     }), { placement: "belowEditor" });
 
-    ctx.ui.setWidget("powerline-last-prompt", () => ({
-      dispose() {},
-      invalidate() {},
-      render(width: number): string[] {
-        return renderLastPromptLines(width);
-      },
-    }), { placement: "belowEditor" });
+    if (editorPerf.options.lastPrompt) {
+      ctx.ui.setWidget("powerline-last-prompt", () => ({
+        dispose() {},
+        invalidate() {},
+        render(width: number): string[] {
+          return measureWidget("last-prompt", () => renderLastPromptLines(width));
+        },
+      }), { placement: "belowEditor" });
+    }
   }
 
   function setupCustomEditor(ctx: any) {
@@ -2974,11 +3000,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       restorePromptHistory(editor);
       attachAutocompleteProvider();
 
-      const originalHandleInput = editor.handleInput.bind(editor);
-      editor.handleInput = (data: string) => {
+      const baseHandleInput = editor.handleInput.bind(editor);
+      const originalHandleInput = editorPerf.options.enabled
+        ? (data: string) => editorPerf.measure("input.base-editor", () => baseHandleInput(data))
+        : baseHandleInput;
+      const handlePowerlineEditorInput = (data: string) => {
         lastEditorInputAt = Date.now();
 
-        if (isPlainPrintableInput(data)) {
+        if (isPrintableInput(data)) {
           scheduleDismissWelcome(ctx);
           originalHandleInput(data);
           return;
@@ -3050,58 +3079,92 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         scheduleDismissWelcome(ctx);
         originalHandleInput(data);
       };
+      editor.handleInput = editorPerf.options.enabled
+        ? (data: string) => {
+            editorPerf.measure("input.total", () => handlePowerlineEditorInput(data));
+            const state = Reflect.get(editor, "state");
+            const lines = state && typeof state === "object" ? Reflect.get(state, "lines") : null;
+            if (Array.isArray(lines)) editorPerf.observeDraft(lines);
+          }
+        : handlePowerlineEditorInput;
 
       const originalRender = editor.render.bind(editor);
       editor.render = (width: number): string[] => {
-        const fastLines = renderFastPowerlineEditor(editor, width, {
-          bashModeActive,
-          completionsEnabled: bashModeSettings.completions,
-        });
-        if (fastLines) return fastLines;
-
-        if (width < 10) {
-          return originalRender(width);
-        }
-
-        const bc = (s: string) => `${getFgAnsiCode("sep")}${s}${ansi.reset}`;
-        const promptGlyph = bashModeActive ? "$" : ">";
-        const promptColor = ansi.getFgAnsi(200, 200, 200);
-        const prompt = `${promptColor}${promptGlyph}${ansi.reset}`;
-        const promptPrefix = ` ${prompt} `;
-        const contPrefix = "   ";
-        const contentWidth = Math.max(1, width - 3);
-        const lines = originalRender(contentWidth);
-
-        if (lines.length === 0) return lines;
-
-        let bottomBorderIndex = lines.length - 1;
-        for (let i = lines.length - 1; i >= 1; i--) {
-          const stripped = lines[i]?.replace(/\x1b\[[0-9;]*m/g, "") || "";
-          if (stripped.length > 0 && /^─{3,}/.test(stripped)) {
-            bottomBorderIndex = i;
-            break;
+        const renderPowerlineEditor = (): string[] => {
+          if (!editorPerf.options.editorChrome) {
+            return editorPerf.options.enabled
+              ? editorPerf.measure("editor.render.base", () => originalRender(width))
+              : originalRender(width);
           }
-        }
 
-        const result: string[] = [];
-        result.push(" " + bc("─".repeat(width - 2)));
+          if (editorPerf.options.fastRender) {
+            const fastLines = editorPerf.options.enabled
+              ? editorPerf.measure("editor.render.fast-probe", () => renderFastPowerlineEditor(editor, width, {
+                  bashModeActive,
+                  completionsEnabled: bashModeSettings.completions,
+                }))
+              : renderFastPowerlineEditor(editor, width, {
+                  bashModeActive,
+                  completionsEnabled: bashModeSettings.completions,
+                });
+            if (fastLines) {
+              if (editorPerf.options.enabled) editorPerf.count("editor.render.fast-hit");
+              return fastLines;
+            }
+          }
 
-        for (let i = 1; i < bottomBorderIndex; i++) {
-          const prefix = i === 1 ? promptPrefix : contPrefix;
-          result.push(`${prefix}${lines[i] || ""}`);
-        }
+          if (width < 10) {
+            return editorPerf.options.enabled
+              ? editorPerf.measure("editor.render.base", () => originalRender(width))
+              : originalRender(width);
+          }
 
-        if (bottomBorderIndex === 1) {
-          result.push(`${promptPrefix}${" ".repeat(contentWidth)}`);
-        }
+          const bc = (s: string) => `${getFgAnsiCode("sep")}${s}${ansi.reset}`;
+          const promptGlyph = bashModeActive ? "$" : ">";
+          const promptColor = ansi.getFgAnsi(200, 200, 200);
+          const prompt = `${promptColor}${promptGlyph}${ansi.reset}`;
+          const promptPrefix = ` ${prompt} `;
+          const contPrefix = "   ";
+          const contentWidth = Math.max(1, width - 3);
+          const lines = editorPerf.options.enabled
+            ? editorPerf.measure("editor.render.base", () => originalRender(contentWidth))
+            : originalRender(contentWidth);
 
-        result.push(" " + bc("─".repeat(width - 2)));
+          if (lines.length === 0) return lines;
 
-        for (let i = bottomBorderIndex + 1; i < lines.length; i++) {
-          result.push(lines[i] || "");
-        }
+          let bottomBorderIndex = lines.length - 1;
+          for (let i = lines.length - 1; i >= 1; i--) {
+            const stripped = lines[i]?.replace(/\x1b\[[0-9;]*m/g, "") || "";
+            if (stripped.length > 0 && /^─{3,}/.test(stripped)) {
+              bottomBorderIndex = i;
+              break;
+            }
+          }
 
-        return result;
+          const result: string[] = [];
+          result.push(" " + bc("─".repeat(width - 2)));
+
+          for (let i = 1; i < bottomBorderIndex; i++) {
+            const prefix = i === 1 ? promptPrefix : contPrefix;
+            result.push(`${prefix}${lines[i] || ""}`);
+          }
+
+          if (bottomBorderIndex === 1) {
+            result.push(`${promptPrefix}${" ".repeat(contentWidth)}`);
+          }
+
+          result.push(" " + bc("─".repeat(width - 2)));
+
+          for (let i = bottomBorderIndex + 1; i < lines.length; i++) {
+            result.push(lines[i] || "");
+          }
+
+          return result;
+        };
+
+        return editorPerf.options.enabled
+          ? editorPerf.measure("editor.render.total", renderPowerlineEditor)
+          : renderPowerlineEditor();
       };
 
       return editor;

--- a/tests/bash-mode.test.ts
+++ b/tests/bash-mode.test.ts
@@ -945,12 +945,13 @@ test("bash editor hot path avoids full expansion and coalesces ghost work", asyn
       insertCharacter(character);
     });
 
-    editor.handleInput("a");
-    assert.equal(fastInserts, 1);
+    for (const character of ["a", "A", ".", "漢", "🙂"]) editor.handleInput(character);
+    assert.equal(editor.getText(), "aA.漢🙂");
+    assert.equal(fastInserts, 5);
     editor.onExtensionShortcut = (data) => data === "b";
     editor.handleInput("b");
-    assert.equal(editor.getText(), "a");
-    assert.equal(fastInserts, 1);
+    assert.equal(editor.getText(), "aA.漢🙂");
+    assert.equal(fastInserts, 5);
     editor.onExtensionShortcut = undefined;
     editor.render(80);
 
@@ -964,6 +965,94 @@ test("bash editor hot path avoids full expansion and coalesces ghost work", asyn
     assert.deepEqual(resolved, ["git"]);
     editor.clearGhostSuggestion();
 
+  } finally {
+    links.cleanup();
+  }
+});
+
+test("bash editor long ASCII backspace keeps undo without scanning the full line", async () => {
+  const links = ensureEditorModuleLinks();
+
+  try {
+    const { BashModeEditor } = await import("../bash-mode/editor.ts");
+    const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
+    const keybindings = KeybindingsManager.create();
+    const editor = new BashModeEditor(
+      { requestRender() {}, terminal: { columns: 80, rows: 24 } },
+      { borderColor: (text: string) => text },
+      keybindings,
+      {
+        keybindings,
+        isBashModeActive: () => false,
+        isShellRunning: () => false,
+        onExitBashMode() {},
+        onSubmitCommand() {},
+        onInterrupt() {},
+        onNotify() {},
+        getHistoryEntries: () => [],
+        resolveGhostSuggestion: async () => null,
+      },
+    );
+    const original = "x".repeat(5000);
+    editor.setText(original);
+    Reflect.get(editor, "undoStack").clear();
+    const segment = Reflect.get(editor, "segment").bind(editor);
+    Reflect.set(editor, "segment", () => {
+      throw new Error("long ASCII backspace must not segment the full line");
+    });
+
+    editor.handleInput("\x7f");
+    assert.equal(editor.getText(), original.slice(0, -1));
+
+    editor.handleInput("\x1b[122;9u");
+    assert.equal(editor.getText(), original);
+
+    Reflect.set(editor, "segment", segment);
+    editor.setText(`${"x".repeat(4998)}\u0600a`);
+    editor.handleInput("\x7f");
+    assert.equal(editor.getText(), "x".repeat(4998));
+  } finally {
+    links.cleanup();
+  }
+});
+
+test("bash editor long ASCII backspace preserves custom app bindings by input sequence", async () => {
+  const links = ensureEditorModuleLinks();
+
+  try {
+    const { BashModeEditor } = await import("../bash-mode/editor.ts");
+    const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
+    const keybindings = new KeybindingsManager({ "app.clear": "ctrl+h" });
+    const editor = new BashModeEditor(
+      { requestRender() {}, terminal: { columns: 80, rows: 24 } },
+      { borderColor: (text: string) => text },
+      keybindings,
+      {
+        keybindings,
+        isBashModeActive: () => false,
+        isShellRunning: () => false,
+        onExitBashMode() {},
+        onSubmitCommand() {},
+        onInterrupt() {},
+        onNotify() {},
+        getHistoryEntries: () => [],
+        resolveGhostSuggestion: async () => null,
+      },
+    );
+    let cleared = false;
+    editor.onAction("app.clear", () => {
+      cleared = true;
+    });
+    const original = "x".repeat(5000);
+    editor.setText(original);
+
+    editor.handleInput("\x7f");
+    assert.equal(editor.getText(), original.slice(0, -1));
+    assert.equal(cleared, false);
+
+    editor.handleInput("\x08");
+    assert.equal(cleared, true);
+    assert.equal(editor.getText(), original.slice(0, -1));
   } finally {
     links.cleanup();
   }
@@ -1000,6 +1089,12 @@ test("bash editor fast path preserves plain custom keybindings", async () => {
 
       editor.setText("x");
       editor.handleInput("a");
+      assert.equal(editor.getText(), "x");
+      assert.deepEqual(editor.getCursor(), { line: 0, col: 0 });
+
+      keybindings.setUserBindings({ "tui.editor.cursorLeft": "shift+a" });
+      Reflect.set(editor, "plainBoundInputs", null);
+      editor.handleInput("A");
       assert.equal(editor.getText(), "x");
       assert.deepEqual(editor.getCursor(), { line: 0, col: 0 });
     } finally {

--- a/tests/editor-performance.test.ts
+++ b/tests/editor-performance.test.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EditorPerfProfiler, readEditorPerfOptions } from "../editor-performance.ts";
+
+test("editor profiling and A/B switches are opt-in", () => {
+  assert.deepEqual(readEditorPerfOptions({}), {
+    enabled: false,
+    fastRender: true,
+    editorChrome: true,
+    widgets: true,
+    bashWidgets: true,
+    lastPrompt: true,
+  });
+
+  assert.deepEqual(readEditorPerfOptions({
+    POWERLINE_DEBUG_PERF: "1",
+    POWERLINE_PERF_FAST_RENDER: "0",
+    POWERLINE_PERF_EDITOR_CHROME: "0",
+    POWERLINE_PERF_WIDGETS: "0",
+    POWERLINE_PERF_BASH_WIDGETS: "0",
+    POWERLINE_PERF_LAST_PROMPT: "0",
+  }), {
+    enabled: true,
+    fastRender: false,
+    editorChrome: false,
+    widgets: false,
+    bashWidgets: false,
+    lastPrompt: false,
+  });
+});
+
+test("editor profiler reports timings, counts, and draft size", () => {
+  const profiler = new EditorPerfProfiler(readEditorPerfOptions({ POWERLINE_DEBUG_PERF: "1" }));
+
+  profiler.measure("input.total", () => 42);
+  profiler.count("editor.render.fast-hit");
+  profiler.observeDraft(["hello", "world"]);
+
+  const report = profiler.report();
+  assert.match(report, /inputs=1, editor-renders=0, renders\/input=0\.00, max-draft=11/);
+  assert.match(report, /editor\.render\.fast-hit: n=1/);
+  assert.match(report, /input\.total: n=1, avg=/);
+});


### PR DESCRIPTION
Improves the remaining measured editor hot path without removing the rounded Powerline editor.

Profiling showed that normal Powerline widgets and rendering add only microseconds, while Pi's full grapheme scan during Backspace took about 10.45 ms on a 200k-character line. For long single-line drafts at the end of the line, Powerline now uses a direct Backspace path only when the deleted character and its neighbor are printable ASCII and paste, jump, autocomplete, extension shortcut, and custom binding states are safe. Unicode grapheme boundaries and all other cases keep Pi's normal editor path.

This also extends the existing direct printable-input path to uppercase, punctuation, and Unicode while preserving configured bindings. Opt-in `POWERLINE_DEBUG_PERF=1` diagnostics add `/powerline-perf [reset]` and render A/B switches without changing normal sessions.

Validation:
- `npm test` (185 tests)
- `npm run typecheck`
- `npm pack --dry-run`
- `git diff HEAD^ HEAD --check`
- Direct Backspace/Ctrl+H custom-binding regression
- Local 200k-character Backspace-plus-undo benchmark: about 10.45 ms/call on `main`, 0.046 ms/call on this branch
