### PR TITLE
refactor: clean editor hot-path narrowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - **Editor typing responsiveness** — Avoid expanding paste markers or joining full drafts in editor hot paths, debounce bash ghost completion, run git completion lookups asynchronously, cache queue/prompt render work, use a bounded fast render path for large editor drafts, and avoid full grapheme scans when deleting plain ASCII from long lines. Opt-in profiling and render A/B flags now identify remaining editor costs without affecting normal sessions.
+- **Editor hot-path cleanup** — Simplified type narrowing in the fast Backspace path without changing behavior.
 - **Bash completions are opt-in** — Disable Powerline bash ghost suggestions and one-off `!command` predictions by default. Set `bashMode.completions` to `true` to re-enable them.
 - **GitHub Actions runtime** — Updated checkout and Node setup actions to their Node 24 runtime versions.
 

--- a/bash-mode/editor.ts
+++ b/bash-mode/editor.ts
@@ -343,7 +343,7 @@ export class BashModeEditor extends CustomEditor {
         for (const key of Array.isArray(binding) ? binding : [binding]) {
           if (isPrintableInput(key)) this.plainBoundInputs.add(key);
           if (key === "space") this.plainBoundInputs.add(" ");
-          if (/^shift\+[a-z]$/.test(key)) this.plainBoundInputs.add(key.at(-1)!.toUpperCase());
+          if (/^shift\+[a-z]$/.test(key)) this.plainBoundInputs.add(key.slice(-1).toUpperCase());
         }
       }
     }
@@ -389,15 +389,14 @@ export class BashModeEditor extends CustomEditor {
     const deletedCode = line.charCodeAt(cursorCol - 1);
     if (previousCode < 0x20 || previousCode > 0x7e || deletedCode < 0x20 || deletedCode > 0x7e) return false;
 
-    const pastes = Reflect.get(this, "pastes") as Map<number, string> | undefined;
-    if (pastes?.size) return false;
+    const pastes = Reflect.get(this as object, "pastes");
+    if (pastes instanceof Map && pastes.size) return false;
 
     const nextLine = line.slice(0, -1);
-    const nextBeforeCursor = nextLine;
     const isInSlashCommandContext = Reflect.get(this, "isInSlashCommandContext");
-    if (typeof isInSlashCommandContext === "function" && isInSlashCommandContext.call(this, nextBeforeCursor)) return false;
-    const autocompleteTriggerPattern = Reflect.get(this, "autocompleteTriggerPattern") as RegExp | undefined;
-    if (autocompleteTriggerPattern?.test(nextBeforeCursor)) return false;
+    if (typeof isInSlashCommandContext === "function" && isInSlashCommandContext.call(this, nextLine)) return false;
+    const autocompleteTriggerPattern = Reflect.get(this as object, "autocompleteTriggerPattern");
+    if (autocompleteTriggerPattern instanceof RegExp && autocompleteTriggerPattern.test(nextLine)) return false;
 
     const exitHistoryBrowsing = Reflect.get(this, "exitHistoryBrowsing");
     const pushUndoSnapshot = Reflect.get(this, "pushUndoSnapshot");


### PR DESCRIPTION
Cleans up the editor hot path after the performance work.

This keeps behavior unchanged while removing a no-op alias, replacing a non-null assertion with direct string slicing, and narrowing reflected private editor state with `instanceof` checks instead of casts.

Validation:
- `npm run typecheck`
- `npm test -- tests/bash-mode.test.ts`
- `git diff --check`
- Fresh review: no findings
