### PR TITLE
perf: speed up long-line cursor edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Editor cursor responsiveness** — Avoid full visual remaps or grapheme scans for safe plain-ASCII cursor movement and forward delete on long single-line drafts.
+
 ## [0.13.0] - 2026-08-12
 
 ### Changed

--- a/bash-mode/editor.ts
+++ b/bash-mode/editor.ts
@@ -31,7 +31,7 @@ const DEFAULT_EDITOR_BOUNDARY_SHORTCUTS: EditorBoundaryShortcuts = {
 };
 
 const GHOST_UPDATE_DEBOUNCE_MS = 50;
-const FAST_BACKSPACE_COLUMN_THRESHOLD = 1200;
+const FAST_ASCII_LINE_COLUMN_THRESHOLD = 1200;
 
 export function isPrintableInput(data: string): boolean {
   if (data.length === 1) {
@@ -118,6 +118,8 @@ export class BashModeEditor extends CustomEditor {
   private ghostToken = 0;
   private plainBoundInputs: Set<string> | null = null;
   private readonly backspaceBindingConflicts = new Map<string, boolean>();
+  private readonly forwardDeleteBindingConflicts = new Map<string, boolean>();
+  private readonly horizontalMoveBindingConflicts = new Map<string, boolean>();
 
   constructor(tui: any, theme: any, keybindings: KeybindingsManager, options: BashModeEditorOptions) {
     super(tui, theme, keybindings);
@@ -174,6 +176,8 @@ export class BashModeEditor extends CustomEditor {
   handleInput(data: string): void {
     if (BashModeEditor.prototype.tryFastPrintableInput.call(this, data)) return;
     if (BashModeEditor.prototype.tryFastAsciiBackspace.call(this, data)) return;
+    if (BashModeEditor.prototype.tryFastAsciiForwardDelete.call(this, data)) return;
+    if (BashModeEditor.prototype.tryFastAsciiHorizontalMove.call(this, data)) return;
 
     const droppedPathText = droppedPathTextFromInput(data);
     if (droppedPathText !== null) {
@@ -363,17 +367,24 @@ export class BashModeEditor extends CustomEditor {
     return true;
   }
 
-  private tryFastAsciiBackspace(data: string): boolean {
-    if (!this.keybindingsRef.matches(data, "tui.editor.deleteCharBackward")) return false;
-    let hasBindingConflict = this.backspaceBindingConflicts.get(data);
-    if (hasBindingConflict === undefined) {
-      hasBindingConflict = Object.entries(this.keybindingsRef.getEffectiveConfig()).some(([id, binding]) => {
-        if (id === "tui.editor.deleteCharBackward" || !binding) return false;
+  private hasBindingConflict(data: string, editorAction: string, cache: Map<string, boolean> | undefined): boolean {
+    const getEffectiveConfig = this.keybindingsRef.getEffectiveConfig;
+    if (!(cache instanceof Map) || typeof getEffectiveConfig !== "function") return true;
+
+    let hasConflict = cache.get(data);
+    if (hasConflict === undefined) {
+      hasConflict = Object.entries(getEffectiveConfig.call(this.keybindingsRef)).some(([id, binding]) => {
+        if (id === editorAction || !binding) return false;
         return (Array.isArray(binding) ? binding : [binding]).some((key) => matchesKey(data, key));
       });
-      this.backspaceBindingConflicts.set(data, hasBindingConflict);
+      cache.set(data, hasConflict);
     }
-    if (hasBindingConflict) return false;
+    return hasConflict;
+  }
+
+  private tryFastAsciiBackspace(data: string): boolean {
+    if (!this.keybindingsRef.matches(data, "tui.editor.deleteCharBackward")) return false;
+    if (BashModeEditor.prototype.hasBindingConflict.call(this, data, "tui.editor.deleteCharBackward", this.backspaceBindingConflicts)) return false;
     if (Reflect.get(this, "isInPaste") === true || Reflect.get(this, "jumpMode") !== null) return false;
     if (Reflect.get(this, "autocompleteState") !== null) return false;
 
@@ -384,13 +395,12 @@ export class BashModeEditor extends CustomEditor {
     if (!Array.isArray(lines) || lines.length !== 1 || cursorLine !== 0 || typeof cursorCol !== "number") return false;
 
     const line = lines[0];
-    if (typeof line !== "string" || cursorCol < FAST_BACKSPACE_COLUMN_THRESHOLD || cursorCol !== line.length) return false;
+    if (typeof line !== "string" || cursorCol < FAST_ASCII_LINE_COLUMN_THRESHOLD || cursorCol !== line.length) return false;
     const previousCode = line.charCodeAt(cursorCol - 2);
     const deletedCode = line.charCodeAt(cursorCol - 1);
     if (previousCode < 0x20 || previousCode > 0x7e || deletedCode < 0x20 || deletedCode > 0x7e) return false;
 
-    const pastes = Reflect.get(this as object, "pastes");
-    if (pastes instanceof Map && pastes.size) return false;
+    if (BashModeEditor.prototype.hasActivePastes.call(this)) return false;
 
     const nextLine = line.slice(0, -1);
     const isInSlashCommandContext = Reflect.get(this, "isInSlashCommandContext");
@@ -420,6 +430,106 @@ export class BashModeEditor extends CustomEditor {
       this.clearGhostSuggestion();
     }
     return true;
+  }
+
+  private tryFastAsciiForwardDelete(data: string): boolean {
+    if (!this.keybindingsRef.matches(data, "tui.editor.deleteCharForward")) return false;
+    if (BashModeEditor.prototype.hasBindingConflict.call(this, data, "tui.editor.deleteCharForward", this.forwardDeleteBindingConflicts)) return false;
+    if (Reflect.get(this, "isInPaste") === true || Reflect.get(this, "jumpMode") !== null) return false;
+    if (Reflect.get(this, "autocompleteState") !== null) return false;
+
+    const state = Reflect.get(this, "state");
+    const lines = state && typeof state === "object" ? Reflect.get(state, "lines") : null;
+    const cursorLine = state && typeof state === "object" ? Reflect.get(state, "cursorLine") : null;
+    const cursorCol = state && typeof state === "object" ? Reflect.get(state, "cursorCol") : null;
+    if (!Array.isArray(lines) || lines.length !== 1 || cursorLine !== 0 || typeof cursorCol !== "number") return false;
+
+    const line = lines[0];
+    if (typeof line !== "string" || cursorCol >= line.length || line.length < FAST_ASCII_LINE_COLUMN_THRESHOLD) return false;
+    if (!BashModeEditor.prototype.isPlainAsciiCursorMove.call(this, line, cursorCol)) return false;
+
+    if (BashModeEditor.prototype.hasActivePastes.call(this)) return false;
+
+    const nextBeforeCursor = line.slice(0, cursorCol);
+    const nextLine = nextBeforeCursor + line.slice(cursorCol + 1);
+    const isInSlashCommandContext = Reflect.get(this, "isInSlashCommandContext");
+    if (typeof isInSlashCommandContext === "function" && isInSlashCommandContext.call(this, nextBeforeCursor)) return false;
+    const autocompleteTriggerPattern = Reflect.get(this as object, "autocompleteTriggerPattern");
+    if (autocompleteTriggerPattern instanceof RegExp && autocompleteTriggerPattern.test(nextBeforeCursor)) return false;
+
+    const exitHistoryBrowsing = Reflect.get(this, "exitHistoryBrowsing");
+    const pushUndoSnapshot = Reflect.get(this, "pushUndoSnapshot");
+    if (typeof exitHistoryBrowsing !== "function" || typeof pushUndoSnapshot !== "function") return false;
+    if (this.onExtensionShortcut?.(data)) return true;
+
+    exitHistoryBrowsing.call(this);
+    pushUndoSnapshot.call(this);
+    Reflect.set(this, "lastAction", null);
+    lines[0] = nextLine;
+    this.onChange?.(nextLine);
+
+    resetShellHistoryBrowse(this);
+    if (this.isShellCompletionContext()) {
+      this.scheduleGhostUpdate();
+    } else {
+      this.clearGhostSuggestion();
+    }
+    return true;
+  }
+
+  private tryFastAsciiHorizontalMove(data: string): boolean {
+    const direction = this.keybindingsRef.matches(data, "tui.editor.cursorLeft")
+      ? -1
+      : this.keybindingsRef.matches(data, "tui.editor.cursorRight") ? 1 : 0;
+    if (direction === 0) return false;
+    if (BashModeEditor.prototype.hasBindingConflict.call(this, data, direction < 0 ? "tui.editor.cursorLeft" : "tui.editor.cursorRight", this.horizontalMoveBindingConflicts)) return false;
+    if (Reflect.get(this, "isInPaste") === true || Reflect.get(this, "jumpMode") !== null) return false;
+    if (Reflect.get(this, "autocompleteState") !== null) return false;
+    if (BashModeEditor.prototype.isShellCompletionContext.call(this)) return false;
+    if (BashModeEditor.prototype.hasActivePastes.call(this)) return false;
+
+    const state = Reflect.get(this, "state");
+    const lines = state && typeof state === "object" ? Reflect.get(state, "lines") : null;
+    const cursorLine = state && typeof state === "object" ? Reflect.get(state, "cursorLine") : null;
+    const cursorCol = state && typeof state === "object" ? Reflect.get(state, "cursorCol") : null;
+    if (!Array.isArray(lines) || lines.length !== 1 || cursorLine !== 0 || typeof cursorCol !== "number") return false;
+
+    const line = lines[0];
+    if (typeof line !== "string" || line.length < FAST_ASCII_LINE_COLUMN_THRESHOLD) return false;
+    if (direction < 0) {
+      if (cursorCol <= 0 || !BashModeEditor.prototype.isPlainAsciiCursorMove.call(this, line, cursorCol - 1)) return false;
+    } else if (cursorCol >= line.length || !BashModeEditor.prototype.isPlainAsciiCursorMove.call(this, line, cursorCol)) {
+      return false;
+    }
+
+    const setCursorCol = Reflect.get(this, "setCursorCol");
+    if (typeof setCursorCol !== "function") return false;
+    if (this.onExtensionShortcut?.(data)) return true;
+
+    Reflect.set(this, "lastAction", null);
+    setCursorCol.call(this, cursorCol + direction);
+    resetShellHistoryBrowse(this);
+    return true;
+  }
+
+  private hasActivePastes(): boolean {
+    const pastes = Reflect.get(this as object, "pastes");
+    return !(pastes instanceof Map) || pastes.size > 0;
+  }
+
+  private isPlainAsciiCursorMove(line: string, index: number): boolean {
+    return BashModeEditor.prototype.isPlainAsciiAt.call(this, line, index)
+      && BashModeEditor.prototype.isPlainAsciiOrEdge.call(this, line, index - 1)
+      && BashModeEditor.prototype.isPlainAsciiOrEdge.call(this, line, index + 1);
+  }
+
+  private isPlainAsciiOrEdge(line: string, index: number): boolean {
+    return index < 0 || index >= line.length || BashModeEditor.prototype.isPlainAsciiAt.call(this, line, index);
+  }
+
+  private isPlainAsciiAt(line: string, index: number): boolean {
+    const code = line.charCodeAt(index);
+    return code >= 0x20 && code <= 0x7e;
   }
 
   render(width: number): string[] {

--- a/tests/bash-mode.test.ts
+++ b/tests/bash-mode.test.ts
@@ -1058,6 +1058,298 @@ test("bash editor long ASCII backspace preserves custom app bindings by input se
   }
 });
 
+test("bash editor long ASCII forward delete keeps undo without scanning the full line", async () => {
+  const links = ensureEditorModuleLinks();
+
+  try {
+    const { BashModeEditor } = await import("../bash-mode/editor.ts");
+    const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
+    const keybindings = KeybindingsManager.create();
+    const editor = new BashModeEditor(
+      { requestRender() {}, terminal: { columns: 80, rows: 24 } },
+      { borderColor: (text: string) => text },
+      keybindings,
+      {
+        keybindings,
+        isBashModeActive: () => false,
+        isShellRunning: () => false,
+        onExitBashMode() {},
+        onSubmitCommand() {},
+        onInterrupt() {},
+        onNotify() {},
+        getHistoryEntries: () => [],
+        areCompletionsEnabled: () => false,
+        resolveGhostSuggestion: async () => null,
+      },
+    );
+    const original = "x".repeat(5000);
+    editor.setText(original);
+    Reflect.set(Reflect.get(editor, "state"), "cursorCol", 2500);
+    Reflect.get(editor, "undoStack").clear();
+    const segment = Reflect.get(editor, "segment").bind(editor);
+    Reflect.set(editor, "segment", () => {
+      throw new Error("long ASCII forward delete must not segment the full line");
+    });
+
+    editor.handleInput("\x1b[3~");
+    assert.equal(editor.getText(), `${"x".repeat(4999)}`);
+    assert.deepEqual(editor.getCursor(), { line: 0, col: 2500 });
+
+    editor.handleInput("\x1b[122;9u");
+    assert.equal(editor.getText(), original);
+    assert.deepEqual(editor.getCursor(), { line: 0, col: 2500 });
+
+    Reflect.set(editor, "segment", segment);
+    editor.setText(`${"x".repeat(2499)}\u0600a${"x".repeat(2500)}`);
+    Reflect.set(Reflect.get(editor, "state"), "cursorCol", 2499);
+    editor.handleInput("\x1b[3~");
+    assert.equal(editor.getText(), `${"x".repeat(2499)}${"x".repeat(2500)}`);
+  } finally {
+    links.cleanup();
+  }
+});
+
+test("bash editor long ASCII forward delete preserves custom app bindings by input sequence", async () => {
+  const links = ensureEditorModuleLinks();
+
+  try {
+    const { BashModeEditor } = await import("../bash-mode/editor.ts");
+    const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
+    const keybindings = new KeybindingsManager({ "app.clear": "ctrl+d" });
+    const editor = new BashModeEditor(
+      { requestRender() {}, terminal: { columns: 80, rows: 24 } },
+      { borderColor: (text: string) => text },
+      keybindings,
+      {
+        keybindings,
+        isBashModeActive: () => false,
+        isShellRunning: () => false,
+        onExitBashMode() {},
+        onSubmitCommand() {},
+        onInterrupt() {},
+        onNotify() {},
+        getHistoryEntries: () => [],
+        areCompletionsEnabled: () => false,
+        resolveGhostSuggestion: async () => null,
+      },
+    );
+    let cleared = false;
+    editor.onAction("app.clear", () => {
+      cleared = true;
+    });
+    editor.setText("x".repeat(5000));
+    Reflect.set(Reflect.get(editor, "state"), "cursorCol", 2500);
+
+    editor.handleInput("\x1b[3~");
+    assert.equal(editor.getText(), "x".repeat(4999));
+    assert.deepEqual(editor.getCursor(), { line: 0, col: 2500 });
+    assert.equal(cleared, false);
+
+    editor.handleInput("\x04");
+    assert.equal(cleared, true);
+    assert.equal(editor.getText(), "x".repeat(4999));
+  } finally {
+    links.cleanup();
+  }
+});
+
+test("bash editor long ASCII horizontal movement avoids visual remapping", async () => {
+  const links = ensureEditorModuleLinks();
+
+  try {
+    const { BashModeEditor } = await import("../bash-mode/editor.ts");
+    const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
+    const keybindings = KeybindingsManager.create();
+    const editor = new BashModeEditor(
+      { requestRender() {}, terminal: { columns: 80, rows: 24 } },
+      { borderColor: (text: string) => text },
+      keybindings,
+      {
+        keybindings,
+        isBashModeActive: () => false,
+        isShellRunning: () => false,
+        onExitBashMode() {},
+        onSubmitCommand() {},
+        onInterrupt() {},
+        onNotify() {},
+        getHistoryEntries: () => [],
+        areCompletionsEnabled: () => false,
+        resolveGhostSuggestion: async () => null,
+      },
+    );
+    editor.setText("x".repeat(5000));
+    Reflect.set(editor, "buildVisualLineMap", () => {
+      throw new Error("long ASCII horizontal movement must not rebuild visual lines");
+    });
+
+    editor.handleInput("\x1b[D");
+    assert.deepEqual(editor.getCursor(), { line: 0, col: 4999 });
+    editor.handleInput("\x1b[C");
+    assert.deepEqual(editor.getCursor(), { line: 0, col: 5000 });
+  } finally {
+    links.cleanup();
+  }
+});
+
+test("bash editor long ASCII horizontal movement preserves custom app bindings by input sequence", async () => {
+  const links = ensureEditorModuleLinks();
+
+  try {
+    const { BashModeEditor } = await import("../bash-mode/editor.ts");
+    const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
+    const keybindings = new KeybindingsManager({ "app.clear": "ctrl+b" });
+    const editor = new BashModeEditor(
+      { requestRender() {}, terminal: { columns: 80, rows: 24 } },
+      { borderColor: (text: string) => text },
+      keybindings,
+      {
+        keybindings,
+        isBashModeActive: () => false,
+        isShellRunning: () => false,
+        onExitBashMode() {},
+        onSubmitCommand() {},
+        onInterrupt() {},
+        onNotify() {},
+        getHistoryEntries: () => [],
+        areCompletionsEnabled: () => false,
+        resolveGhostSuggestion: async () => null,
+      },
+    );
+    let cleared = false;
+    editor.onAction("app.clear", () => {
+      cleared = true;
+    });
+    editor.setText("x".repeat(5000));
+
+    editor.handleInput("\x1b[D");
+    assert.deepEqual(editor.getCursor(), { line: 0, col: 4999 });
+    assert.equal(cleared, false);
+
+    editor.handleInput("\x02");
+    assert.equal(cleared, true);
+    assert.deepEqual(editor.getCursor(), { line: 0, col: 4999 });
+  } finally {
+    links.cleanup();
+  }
+});
+
+test("bash editor horizontal fast path resets shell history browsing", async () => {
+  const links = ensureEditorModuleLinks();
+
+  try {
+    const { BashModeEditor } = await import("../bash-mode/editor.ts");
+    const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
+    const keybindings = KeybindingsManager.create();
+    const historyCommand = "x".repeat(5000);
+    const editor = new BashModeEditor(
+      { requestRender() {}, terminal: { columns: 80, rows: 24 } },
+      { borderColor: (text: string) => text },
+      keybindings,
+      {
+        keybindings,
+        isBashModeActive: () => true,
+        isShellRunning: () => false,
+        onExitBashMode() {},
+        onSubmitCommand() {},
+        onInterrupt() {},
+        onNotify() {},
+        getHistoryEntries: (prefix: string) => prefix === "draft" ? [historyCommand] : [],
+        areCompletionsEnabled: () => false,
+        resolveGhostSuggestion: async () => null,
+      },
+    );
+    editor.setText("draft");
+    editor.handleInput("\x1b[A");
+    assert.equal(editor.getText(), historyCommand);
+
+    editor.handleInput("\x1b[D");
+    editor.handleInput("\x1b[B");
+
+    assert.equal(editor.getText(), historyCommand);
+    assert.deepEqual(editor.getCursor(), { line: 0, col: 4999 });
+    assert.equal(Reflect.get(editor, "shellHistoryIndex"), -1);
+  } finally {
+    links.cleanup();
+  }
+});
+
+test("bash editor horizontal fast path falls back with active paste markers", async () => {
+  const links = ensureEditorModuleLinks();
+
+  try {
+    const { BashModeEditor } = await import("../bash-mode/editor.ts");
+    const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
+    const keybindings = KeybindingsManager.create();
+    const editor = new BashModeEditor(
+      { requestRender() {}, terminal: { columns: 80, rows: 24 } },
+      { borderColor: (text: string) => text },
+      keybindings,
+      {
+        keybindings,
+        isBashModeActive: () => false,
+        isShellRunning: () => false,
+        onExitBashMode() {},
+        onSubmitCommand() {},
+        onInterrupt() {},
+        onNotify() {},
+        getHistoryEntries: () => [],
+        areCompletionsEnabled: () => false,
+        resolveGhostSuggestion: async () => null,
+      },
+    );
+    editor.setText("x".repeat(5000));
+    Reflect.get(editor, "pastes").set(1, "pasted text");
+    let visualMapCalls = 0;
+    const buildVisualLineMap = Reflect.get(editor, "buildVisualLineMap").bind(editor);
+    Reflect.set(editor, "buildVisualLineMap", (width: number) => {
+      visualMapCalls += 1;
+      return buildVisualLineMap(width);
+    });
+
+    editor.handleInput("\x1b[D");
+    assert.equal(visualMapCalls, 1);
+    assert.deepEqual(editor.getCursor(), { line: 0, col: 4999 });
+  } finally {
+    links.cleanup();
+  }
+});
+
+test("bash editor horizontal fast path falls back at mixed Unicode boundaries", async () => {
+  const links = ensureEditorModuleLinks();
+
+  try {
+    const { BashModeEditor } = await import("../bash-mode/editor.ts");
+    const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
+    const keybindings = KeybindingsManager.create();
+    const editor = new BashModeEditor(
+      { requestRender() {}, terminal: { columns: 80, rows: 24 } },
+      { borderColor: (text: string) => text },
+      keybindings,
+      {
+        keybindings,
+        isBashModeActive: () => false,
+        isShellRunning: () => false,
+        onExitBashMode() {},
+        onSubmitCommand() {},
+        onInterrupt() {},
+        onNotify() {},
+        getHistoryEntries: () => [],
+        areCompletionsEnabled: () => false,
+        resolveGhostSuggestion: async () => null,
+      },
+    );
+    const text = `${"x".repeat(4998)}\u0600a`;
+    editor.setText(text);
+    editor.handleInput("\x1b[D");
+    assert.deepEqual(editor.getCursor(), { line: 0, col: 4998 });
+
+    editor.handleInput("\x1b[C");
+    assert.deepEqual(editor.getCursor(), { line: 0, col: 5000 });
+  } finally {
+    links.cleanup();
+  }
+});
+
 test("bash editor fast path preserves plain custom keybindings", async () => {
   const links = ensureEditorModuleLinks();
 


### PR DESCRIPTION
## Summary

This keeps the v0.13.0 performance work going with measured, narrow editor hot-path wins.

It adds safe plain-ASCII fast paths for long single-line drafts:

- Left/Right cursor movement skips full visual remapping and grapheme segmentation when the cursor is inside a plain-ASCII boundary.
- Forward Delete removes one ASCII character without scanning the full line.
- Existing fallbacks remain for Unicode/wide text, multiline drafts, paste markers, jump mode, autocomplete, shell completions, slash-command autocomplete triggers, and custom binding conflicts.
- The horizontal fast path also resets bash shell-history browse state so Down does not restore the pre-history draft after a cursor move.

## Evidence

From `/tmp/pi-powerline-footer-lanes-20260812T1630Z/editor-perf-next`:

- `npm test` passed: 192 tests.
- `npm run typecheck` passed.
- `git diff --check` passed.
- `npm pack --dry-run --json` included the expected package files.
- Fresh review found one blocker in shell-history cleanup.
- Follow-up review after the fix: no findings.

Benchmarks on 200k-character ASCII drafts:

- Left arrow at end: about `0.003 ms/call`.
- Right arrow mid-line: about `0.002 ms/call`.
- Forward Delete mid-line: about `0.098 ms/call`.
- Backspace remains fast at about `0.059 ms/call`.

Review reports:

- `/Users/nicobailon/Documents/docs/pi-powerline-footer-backlog-20260811T2249Z/editor-next-fresh-review.md`
- `/Users/nicobailon/Documents/docs/pi-powerline-footer-backlog-20260811T2249Z/editor-next-followup-review.md`
