### PR TITLE
feat: add working vibe color support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Working vibe colors** — Added `powerline.workingVibes.color` for Pi theme colors, hex colors, or `rainbow`. Thanks to [@jummyliu](https://github.com/jummyliu) for #170.
+
 ### Changed
 - **Pi 0.84 compatibility** — Widened Pi package peer dependency ranges to `>=0.81.0 <0.85.0` and refreshed dev dependencies against `@earendil-works/*` 0.84.1, so `pi-powerline-footer` can install alongside extensions that require Pi 0.84.x packages. Thanks to [@brunoessmann](https://github.com/brunoessmann) for #168.
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ In the agent settings file:
 ```json
 {
   "workingVibe": "star trek",                              // Theme phrase
+  "powerline": { "workingVibes": { "color": "rainbow" } }, // Optional: Pi theme color, hex, or "rainbow"
   "workingVibeMode": "generate",                           // "generate" (on-demand) or "file" (pre-generated)
   "workingVibeModel": "openai-codex/gpt-5.4-mini",         // Optional: model to use (default)
   "workingVibeFallback": "Working",                        // Optional: fallback message
@@ -359,6 +360,8 @@ In the agent settings file:
   "workingVibeMaxLength": 65                         // Optional: max message length (default 65)
 }
 ```
+
+Set `powerline.workingVibes.color` to a Pi theme color such as `accent` or `warning`, a hex color such as `#89d281`, or `rainbow` to style each working-vibe message. Omit it to keep Pi's default muted message color.
 
 ### Modes
 

--- a/index.ts
+++ b/index.ts
@@ -62,6 +62,8 @@ import {
   getVibeFileCount,
   generateVibesBatch,
   parseVibeGenerateArgs,
+  setVibeWorkingMessageTheme,
+  setVibeWorkingMessageColor,
 } from "./working-vibes.ts";
 import { PowerlineQueueStore, currentQueueContext, formatQueueDeliveryText, parseCompactQueuedPrompt } from "./queue/store.ts";
 import type { PowerlineQueueItem, QueueContext, QueueIntent, QueueSummary, QueueTarget } from "./queue/types.ts";
@@ -83,6 +85,7 @@ let config: PowerlineConfig = {
   invalidPlacement: null,
   welcome: true,
   stashSharpSShortcut: false,
+  workingVibes: {},
 };
 
 const CUSTOM_COMPACTION_STATUS_KEY = "compact-policy";
@@ -1714,6 +1717,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
     // Initialize vibe manager (needs modelRegistry from ctx)
     initVibeManager(ctx);
+    setVibeWorkingMessageColor(config.workingVibes.color);
 
     if (enabled && ctx.hasUI) {
       setupCustomEditor(ctx);
@@ -2631,6 +2635,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   });
 
   function buildSegmentContext(ctx: any, theme: Theme): SegmentContext {
+    setVibeWorkingMessageTheme(theme);
     const presetDef = getPreset(config.preset);
     const colors: ColorScheme = presetDef.colors ?? getDefaultColors();
 

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -16,6 +16,7 @@ export interface PowerlineConfig {
   invalidPlacement: string | null;
   welcome: boolean;
   stashSharpSShortcut: boolean;
+  workingVibes: { color?: ColorValue | "rainbow" };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -305,6 +306,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     invalidPlacement: null,
     welcome: true,
     stashSharpSShortcut: false,
+    workingVibes: {},
   };
 
   const directPreset = normalizePreset(value, presets);
@@ -330,6 +332,9 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     invalidPlacement,
     welcome: value.welcome !== false,
     stashSharpSShortcut: value.stashSharpSShortcut === true,
+    workingVibes: isRecord(value.workingVibes) && typeof value.workingVibes.color === "string" && value.workingVibes.color.trim()
+      ? { color: value.workingVibes.color.trim() as ColorValue | "rainbow" }
+      : {},
   };
 }
 

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -176,6 +176,7 @@ test("parsePowerlineConfig extracts supported segment options", () => {
       git: { showBranch: false, showStaged: false, showUnstaged: true, showUntracked: false, polling: "branch", hostIcon: true },
       time: { format: "12h", showSeconds: true },
       cost: { subscriptionDisplay: "both", currency: "cny" },
+      workingVibes: { color: "rainbow" },
     },
     ["default", "compact"],
   );
@@ -191,7 +192,16 @@ test("parsePowerlineConfig extracts supported segment options", () => {
     time: { format: "12h", showSeconds: true },
     cost: { subscriptionDisplay: "both", currency: "CNY" },
   });
+  assert.deepEqual(config.workingVibes, { color: "rainbow" });
   assert.deepEqual(invalidCurrency.segmentOptions, { cost: {} });
+});
+
+test("parsePowerlineConfig accepts working-vibe theme colors and hex colors", () => {
+  const semantic = parsePowerlineConfig({ workingVibes: { color: "warning" } }, ["default"]);
+  const hex = parsePowerlineConfig({ workingVibes: { color: "#89d281" } }, ["default"]);
+
+  assert.deepEqual(semantic.workingVibes, { color: "warning" });
+  assert.deepEqual(hex.workingVibes, { color: "#89d281" });
 });
 
 test("mergeSegmentOptions lets user config override preset segment defaults", () => {

--- a/tests/working-vibes.test.ts
+++ b/tests/working-vibes.test.ts
@@ -4,7 +4,8 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync }
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { parseVibeGenerateArgs } from "../working-vibes.ts";
+import { initVibeManager, onVibeAgentEnd, onVibeAgentStart, onVibeBeforeAgentStart, parseVibeGenerateArgs, setVibeMode, setVibeTheme, setVibeWorkingMessageColor, setVibeWorkingMessageTheme } from "../working-vibes.ts";
+import { rainbow } from "../theme.ts";
 
 const FAUX_PROVIDER_PATH = new URL("../node_modules/@earendil-works/pi-ai/dist/providers/faux.js", import.meta.url).href;
 
@@ -60,6 +61,53 @@ test("parseVibeGenerateArgs supports multi-word themes", () => {
   assert.deepEqual(parseVibeGenerateArgs(["star", "trek", "abc"]), { theme: "star trek abc", count: 100 });
   assert.deepEqual(parseVibeGenerateArgs(["lord", "of", "rings", "999"]), { theme: "lord of rings", count: 500 });
   assert.equal(parseVibeGenerateArgs([]), null);
+});
+
+
+test("working-vibe color styles semantic, hex, and rainbow messages", () => {
+  const home = mkdtempSync(join(tmpdir(), "powerline-vibes-home-"));
+  const previousHome = process.env.HOME;
+  process.env.HOME = home;
+
+  try {
+    initVibeManager({ modelRegistry: { find() { return undefined; } } } as any);
+    setVibeWorkingMessageTheme({
+      fg(color, text) {
+        return `<${color}>${text}</${color}>`;
+      },
+    });
+    setVibeTheme("star trek");
+    setVibeMode("file");
+    onVibeAgentStart();
+
+    const semantic: Array<string | undefined> = [];
+    setVibeWorkingMessageColor("warning");
+    onVibeBeforeAgentStart("fix a bug", (message) => semantic.push(message));
+    assert.equal(semantic[0], "<warning>Channeling star trek...</warning>");
+
+    const hex: Array<string | undefined> = [];
+    setVibeWorkingMessageColor("#89d281");
+    onVibeBeforeAgentStart("fix a bug", (message) => hex.push(message));
+    assert.equal(hex[0], "\x1b[38;2;137;210;129mChanneling star trek...\x1b[0m");
+
+    const rainbowUpdates: Array<string | undefined> = [];
+    setVibeWorkingMessageColor("rainbow");
+    onVibeBeforeAgentStart("fix a bug", (message) => rainbowUpdates.push(message));
+    assert.equal(rainbowUpdates[0], rainbow("Channeling star trek..."));
+
+    const defaultUpdates: Array<string | undefined> = [];
+    setVibeWorkingMessageColor(undefined);
+    onVibeBeforeAgentStart("fix a bug", (message) => defaultUpdates.push(message));
+    assert.equal(defaultUpdates[0], "Channeling star trek...");
+    onVibeAgentEnd(() => {});
+  } finally {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    rmSync(home, { recursive: true, force: true });
+  }
 });
 
 test("generateVibesBatch includes a system prompt so faux providers can return text", async () => {

--- a/working-vibes.ts
+++ b/working-vibes.ts
@@ -7,6 +7,8 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { getAgentPath } from "./paths.ts";
+import { applyColor, rainbow } from "./theme.ts";
+import type { ColorValue, ThemeLike } from "./types.ts";
 
 type VibeMode = "generate" | "file";
 
@@ -82,6 +84,8 @@ let extensionCtx: ExtensionContext | null = null;
 let currentGeneration: AbortController | null = null;
 let isStreaming = false;
 let lastVibeTime = 0;
+let workingMessageTheme: ThemeLike | null = null;
+let workingMessageColor: ColorValue | "rainbow" | undefined;
 
 // File-based mode state
 let vibeCache: string[] = [];        // Cached vibes from file
@@ -180,6 +184,7 @@ function loadConfig(): VibeConfig {
     typeof settings.workingVibeMaxLength === "number" && Number.isFinite(settings.workingVibeMaxLength)
       ? Math.max(4, Math.floor(settings.workingVibeMaxLength))
       : 65;
+
 
   return {
     theme,
@@ -438,8 +443,19 @@ function trackRecentVibe(vibe: string): void {
   recentVibes = [vibe, ...recentVibes.filter(v => v !== vibe)].slice(0, MAX_RECENT_VIBES);
 }
 
+function setStyledWorkingMessage(setWorkingMessage: (msg?: string) => void, message?: string): void {
+  if (!message || !workingMessageColor || !workingMessageTheme) {
+    setWorkingMessage(message);
+    return;
+  }
+
+  setWorkingMessage(workingMessageColor === "rainbow"
+    ? rainbow(message)
+    : applyColor(workingMessageTheme, workingMessageColor, message));
+}
+
 function updateVibeFromFile(setWorkingMessage: (msg?: string) => void): void {
-  setWorkingMessage(getNextVibeFromFile());
+  setStyledWorkingMessage(setWorkingMessage, getNextVibeFromFile());
 }
 
 async function generateAndUpdate(
@@ -475,7 +491,7 @@ async function generateAndUpdate(
     // Only update if still streaming and THIS generation wasn't aborted
     if (isStreaming && !controller.signal.aborted) {
       trackRecentVibe(vibe);
-      setWorkingMessage(vibe);
+      setStyledWorkingMessage(setWorkingMessage, vibe);
     }
   } catch (error) {
     // AbortError is expected on timeout/cancel - don't log as error
@@ -491,6 +507,14 @@ async function generateAndUpdate(
 // ═══════════════════════════════════════════════════════════════════════════
 // Exported Functions (called from index.ts)
 // ═══════════════════════════════════════════════════════════════════════════
+
+export function setVibeWorkingMessageTheme(theme: ThemeLike): void {
+  workingMessageTheme = theme;
+}
+
+export function setVibeWorkingMessageColor(color: ColorValue | "rainbow" | undefined): void {
+  workingMessageColor = color;
+}
 
 export function initVibeManager(ctx: ExtensionContext): void {
   extensionCtx = ctx;
@@ -525,7 +549,7 @@ export function onVibeBeforeAgentStart(
   
   // Queue themed placeholder BEFORE agent_start creates the loader
   // This sets pendingWorkingMessage which is applied when loader is created
-  setWorkingMessage(`Channeling ${config.theme}...`);
+  setStyledWorkingMessage(setWorkingMessage, `Channeling ${config.theme}...`);
   
   // Mark vibe generation time for rate limiting
   lastVibeTime = Date.now();


### PR DESCRIPTION
## Summary

Adds `powerline.workingVibes.color` so working-vibe messages can use a Pi theme color, a hex color, or `rainbow`.

The default remains unchanged when the option is omitted. This also documents the setting and credits the original request: Thanks to [@jummyliu](https://github.com/jummyliu) for #170.

Closes #170.

## Validation

- `git diff --check origin/main...HEAD`
- `node --experimental-strip-types --test tests/working-vibes.test.ts tests/custom-items.test.ts` (28 tests)
- `npm run typecheck`
- Fresh exact-head review: no issues found
