### PR TITLE
fix: keep compaction queue pending until compact ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Post-compaction queue delivery** — Keep prompts queued until `session_compact` confirms completion instead of blocking them when an intermediate `agent_settled` event fires. Closes #174.
+
 ## [0.15.0] - 2026-08-15
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -1911,10 +1911,6 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   });
 
   pi.on("agent_settled", async (_event, ctx) => {
-    if (powerlineCompacting) {
-      finishFailedCompaction(ctx, "Compaction did not complete");
-      return;
-    }
     if (deliverAfterRetrySettles) {
       deliverAfterRetrySettles = false;
       schedulePostCompactionDelivery(ctx);

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -158,6 +158,12 @@ test("post-compaction queue delivery does not read ctx.cwd from the delayed call
   assert.match(source, /finishPendingQueueDelivery\(getPromptHistoryText\(message\.content\), ctx\);/);
 });
 
+test("agent settlement does not fail a compaction that has not emitted session_compact", () => {
+  assert.doesNotMatch(source, /pi\.on\("agent_settled", async \(_event, ctx\) => \{\r?\n\s+if \(powerlineCompacting\)/);
+  assert.match(source, /pi\.on\("session_compact", async \(event, ctx\) => \{[\s\S]*?schedulePostCompactionDelivery\(ctx\);/);
+  assert.match(source, /onError: \(error: Error\) => \{\r?\n\s+finishFailedCompaction\(ctx, error\.message\);/);
+});
+
 test("editor-adjacent widgets cache queue and last-prompt work", () => {
   assert.match(source, /const QUEUE_SUMMARY_CACHE_TTL_MS = 250;/);
   assert.match(source, /queueSummaryCache = null;\r?\n\s+requestImmediateStatusRender/);


### PR DESCRIPTION
## Summary

Keeps post-compaction prompts queued until `session_compact` confirms that compaction finished. `agent_settled` no longer marks them blocked while compaction is still in flight, but real `ctx.compact()` errors still block the queued items.

Closes #174.

## Validation

- `node --experimental-strip-types --test tests/remaining-regressions.test.ts`
- `npm run typecheck`
- `git diff --check`