### PR TITLE
feat: support self-colored custom items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Self-colored custom items** — Added `customItems[].selfColorize` so extension statuses can keep embedded ANSI colors, including multiple colors within one item, without being wrapped by the configured custom-item color. Thanks to [@elecnix](https://github.com/elecnix) for #176.
+
 ## [0.15.1] - 2026-08-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ You can promote any extension status key into its own dedicated powerline item. 
 - `position` (optional): `left`, `right`, or `secondary` (default `right`)
 - `prefix` (optional): text shown before the live status value
 - `color` (optional): any Pi theme color (`warning`, `accent`, etc.) or hex (`#RRGGBB`)
+- `selfColorize` (optional): trust ANSI colors already embedded in the status value and do not apply `color` (default `false`)
 - `hideWhenMissing` (optional): hide item when no status is present (default `true`)
 - `excludeFromExtensionStatuses` (optional): omit this key from the aggregate `extension_statuses` segment (default `true`)
 

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -101,6 +101,7 @@ function normalizeCustomStatusItem(raw: unknown, idOverride?: string): CustomSta
     statusKey,
     position: normalizeCustomItemPosition(raw.position),
     color: normalizeCustomColor(raw.color),
+    selfColorize: raw.selfColorize === true,
     prefix: normalizeCustomPrefix(raw.prefix),
     hideWhenMissing: raw.hideWhenMissing !== false,
     excludeFromExtensionStatuses: raw.excludeFromExtensionStatuses !== false,
@@ -430,12 +431,14 @@ export function getNotificationExtensionStatuses(
   return notifications;
 }
 
-export function normalizeExtensionStatusValue(value: string): string | null {
+export function normalizeExtensionStatusValue(value: string, preserveAnsi = false): string | null {
   if (!value || visibleWidth(value) <= 0) {
     return null;
   }
 
-  const stripped = value.replace(/(\x1b\[[0-9;]*m|\s|·|[|])+$/, "");
+  const stripped = preserveAnsi
+    ? value.replace(/(\s|·|[|])+$/, "")
+    : value.replace(/(\x1b\[[0-9;]*m|\s|·|[|])+$/, "");
   return visibleWidth(stripped) > 0 ? stripped : null;
 }
 

--- a/segments.ts
+++ b/segments.ts
@@ -537,7 +537,7 @@ function renderCustomSegment(id: `custom:${string}`, ctx: SegmentContext): Rende
   if (!custom) return { content: "", visible: false };
 
   const rawStatus = ctx.extensionStatuses.get(custom.statusKey);
-  const normalizedStatus = rawStatus ? normalizeExtensionStatusValue(rawStatus) : null;
+  const normalizedStatus = rawStatus ? normalizeExtensionStatusValue(rawStatus, custom.selfColorize) : null;
   if (!normalizedStatus) {
     return custom.hideWhenMissing ? { content: "", visible: false } : { content: custom.prefix ?? custom.id, visible: true };
   }
@@ -546,7 +546,7 @@ function renderCustomSegment(id: `custom:${string}`, ctx: SegmentContext): Rende
   if (custom.prefix) {
     content = `${custom.prefix}${SEP_DOT}${content}`;
   }
-  if (custom.color) {
+  if (custom.color && !custom.selfColorize) {
     content = applyColor(ctx.theme, custom.color, content);
   }
 

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -26,6 +26,7 @@ test("parsePowerlineConfig supports object config with custom items", () => {
   assert.equal(config.customItems[0].statusKey, "ci-status");
   assert.equal(config.customItems[1].statusKey, "review");
   assert.equal(config.customItems[1].hideWhenMissing, false);
+  assert.equal(config.customItems[0].selfColorize, false);
   assert.deepEqual(config.disabledSegments, []);
   assert.deepEqual(config.invalidDisabledSegments, []);
   assert.equal(config.layout, null);
@@ -35,6 +36,21 @@ test("parsePowerlineConfig supports object config with custom items", () => {
   assert.equal(config.invalidPlacement, null);
   assert.equal(config.welcome, true);
   assert.equal(config.stashSharpSShortcut, false);
+});
+
+test("parsePowerlineConfig accepts self-colored custom items", () => {
+  const config = parsePowerlineConfig({ customItems: [{ id: "usage", color: "warning", selfColorize: true }] }, ["default"]);
+
+  assert.deepEqual(config.customItems, [{
+    id: "usage",
+    statusKey: "usage",
+    position: "right",
+    color: "warning",
+    selfColorize: true,
+    prefix: undefined,
+    hideWhenMissing: true,
+    excludeFromExtensionStatuses: true,
+  }]);
 });
 
 test("parsePowerlineConfig supports disabled segments", () => {

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -73,6 +73,29 @@ test("model segment can show provider-qualified ids", () => {
   assert.equal(stripAnsi(alreadyQualified.content), "openai/gpt-4.1");
 });
 
+test("self-colored custom items preserve ANSI resets and skip configured color", () => {
+  const status = "\x1b[32m50%\x1b[0m";
+  const rendered = renderSegment("custom:usage", createSegmentContext({
+    extensionStatuses: new Map([["usage", status]]),
+    customItemsById: new Map([[
+      "usage",
+      {
+        id: "usage",
+        statusKey: "usage",
+        position: "right",
+        color: "warning",
+        selfColorize: true,
+        hideWhenMissing: true,
+        excludeFromExtensionStatuses: true,
+      },
+    ]]),
+    theme: { fg: (color, text) => `<${color}>${text}</${color}>` },
+  }));
+
+  assert.equal(rendered.content, status);
+  assert.equal(rendered.visible, true);
+});
+
 test("cost segment supports subscription display modes and converted currencies", () => {
   __setCurrencyRatesForTest({ CNY: 7.2 });
 

--- a/types.ts
+++ b/types.ts
@@ -117,6 +117,7 @@ export interface CustomStatusItem {
   statusKey: string;
   position: CustomItemPosition;
   color?: ColorValue;
+  selfColorize: boolean;
   prefix?: string;
   hideWhenMissing: boolean;
   excludeFromExtensionStatuses: boolean;


### PR DESCRIPTION
## Summary

Adds `customItems[].selfColorize` so a promoted extension status can keep its own ANSI colors without being wrapped by the configured custom-item color.

This preserves trailing ANSI reset codes for the opt-in self-colored path, while keeping the existing normalization and coloring behavior for normal custom items.

Closes #176.

## Validation

- `node --experimental-strip-types --test tests/custom-items.test.ts tests/remaining-regressions.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`

Thanks to [@elecnix](https://github.com/elecnix) for #176.
