### PR TITLE
feat: add lazy quote reply command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **Quote previous messages** — Added `/reply` to insert a previous user or assistant message as a Markdown quote. An optional `powerlineShortcuts.reply` shortcut is disabled by default and loads the picker only when used.
 - **Self-colored custom items** — Added `customItems[].selfColorize` so extension statuses can keep embedded ANSI colors, including multiple colors within one item, without being wrapped by the configured custom-item color. Thanks to [@elecnix](https://github.com/elecnix) for #176.
 
 ## [0.15.1] - 2026-08-19

--- a/README.md
+++ b/README.md
@@ -301,6 +301,24 @@ Selecting a stashed or project prompt-history entry inserts it into the editor. 
 - `cmd+shift+up` — move the editor cursor to the start of the first line
 - `cmd+shift+down` — move the editor cursor to the end of the last line
 
+### Quoting previous messages
+
+Run `/reply` to choose a previous user or assistant message and insert it as a Markdown quote while keeping the current draft. You can also pass a unique entry id prefix, for example `/reply abc123`.
+
+The shortcut is opt-in and disabled by default. Enable it in the agent settings file with `powerlineShortcuts.reply`, for example:
+
+```json
+{
+  "powerlineShortcuts": {
+    "reply": "ctrl+shift+r"
+  }
+}
+```
+
+Set `reply` to `null` to disable it. Quotes are loaded only when the command or configured shortcut is used.
+
+If you already installed the standalone `pi-quote-reply` extension, remove or disable it before using Powerline's integrated `/reply`. Pi suffixes duplicate extension commands as `/reply:1` and `/reply:2`, so keeping both installed prevents plain `/reply` from dispatching reliably.
+
 Copy/cut actions do not modify stash state or stash history. Dragging files, folders, images, or screenshots from Finder into the custom editor inserts their path strings. Pi owns chat scrolling, selection, and fixed input behavior natively.
 
 ### Shortcut configuration
@@ -314,13 +332,14 @@ You can override shortcut keys in the agent settings file:
     "copyEditor": "ctrl+alt+c",
     "cutEditor": "ctrl+alt+x",
     "queueOpen": "ctrl+alt+q",
+    "reply": null,
     "editorStart": "cmd+shift+up",
     "editorEnd": "cmd+shift+down"
   }
 }
 ```
 
-After changing bindings, run `/reload`. Invalid bindings, reserved key conflicts like `Alt+S`, or duplicate conflicts fall back to safe defaults. Set a binding to `null` or `""` to disable that action. `cmd` and `command` are accepted aliases for Pi's `super` modifier for the documented Command navigation keys.
+After changing bindings, run `/reload`. Invalid bindings fall back to safe defaults. Reserved key conflicts like `Alt+S` or duplicate conflicts fall back to that action's default when it is free, otherwise they disable the action. Set a binding to `null` or `""` to disable that action. `cmd` and `command` are accepted aliases for Pi's `super` modifier for the documented Command navigation keys.
 
 ### Editor autocomplete composition
 

--- a/index.ts
+++ b/index.ts
@@ -98,6 +98,7 @@ export interface PowerlineShortcuts {
   copyEditor: ShortcutBinding;
   cutEditor: ShortcutBinding;
   queueOpen: ShortcutBinding;
+  reply: ShortcutBinding;
   editorStart: ShortcutBinding;
   editorEnd: ShortcutBinding;
 }
@@ -108,6 +109,7 @@ type PowerlineShortcutAction =
   | { kind: "copyEditor" }
   | { kind: "cutEditor" }
   | { kind: "queueOpen" }
+  | { kind: "reply" }
   | { kind: "bashMode" };
 const STASH_HISTORY_LIMIT = 12;
 const PROJECT_PROMPT_HISTORY_LIMIT = 50;
@@ -117,6 +119,7 @@ const DEFAULT_SHORTCUTS: PowerlineShortcuts = {
   copyEditor: "ctrl+alt+c",
   cutEditor: "ctrl+alt+x",
   queueOpen: "ctrl+alt+q",
+  reply: null,
   editorStart: "super+shift+up",
   editorEnd: "super+shift+down",
 };
@@ -126,7 +129,7 @@ const DEFAULT_BASH_MODE_SETTINGS = {
   transcriptMaxLines: 2000,
   transcriptMaxBytes: 512 * 1024,
 } as const satisfies BashModeSettings;
-const SHORTCUT_KEYS: PowerlineShortcutKey[] = ["stashHistory", "copyEditor", "cutEditor", "queueOpen", "editorStart", "editorEnd"];
+const SHORTCUT_KEYS: PowerlineShortcutKey[] = ["stashHistory", "copyEditor", "cutEditor", "queueOpen", "reply", "editorStart", "editorEnd"];
 const APP_RESERVED_SHORTCUTS = [
   "escape",
   "ctrl+c",
@@ -724,15 +727,15 @@ function findShortcutReplacement(key: PowerlineShortcutKey, used: Set<string>): 
   if (preferred && !used.has(shortcutUsageKey(preferred))) {
     return preferred;
   }
-
-  for (const shortcutKey of SHORTCUT_KEYS) {
-    const candidate = DEFAULT_SHORTCUTS[shortcutKey];
-    if (candidate && !used.has(shortcutUsageKey(candidate))) {
-      return candidate;
-    }
-  }
-
   return null;
+}
+
+function shortcutBelongsToOtherDefault(key: PowerlineShortcutKey, shortcut: string): boolean {
+  const usageKey = shortcutUsageKey(shortcut);
+  return SHORTCUT_KEYS.some((shortcutKey) => {
+    const defaultShortcut = DEFAULT_SHORTCUTS[shortcutKey];
+    return shortcutKey !== key && defaultShortcut !== null && shortcutUsageKey(defaultShortcut) === usageKey;
+  });
 }
 
 function bashToggleShortcutReservation(settings: Record<string, unknown>): ShortcutBinding {
@@ -776,7 +779,7 @@ export function resolveShortcutConfig(settings: Record<string, unknown>): Powerl
 
     const configuredUsageKey = shortcutUsageKey(configured);
 
-    if (!used.has(configuredUsageKey)) {
+    if (!used.has(configuredUsageKey) && !shortcutBelongsToOtherDefault(key, configured)) {
       used.add(configuredUsageKey);
       continue;
     }
@@ -784,6 +787,7 @@ export function resolveShortcutConfig(settings: Record<string, unknown>): Powerl
     const replacement = findShortcutReplacement(key, used);
     if (!replacement) {
       console.debug(`[powerline-footer] Shortcut conflict for ${key}: "${configured}" is already in use`);
+      resolved[key] = null;
       continue;
     }
 
@@ -2124,6 +2128,9 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     if (matchesConfiguredShortcut(data, resolvedShortcuts.queueOpen)) {
       return { kind: "queueOpen" };
     }
+    if (resolvedShortcuts.reply && matchesConfiguredShortcut(data, resolvedShortcuts.reply)) {
+      return { kind: "reply" };
+    }
     if (matchesConfiguredShortcut(data, bashModeSettings.toggleShortcut)) {
       return { kind: "bashMode" };
     }
@@ -2151,6 +2158,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
     if (action.kind === "queueOpen") {
       void openQueuePicker(ctx);
+      return;
+    }
+
+    if (action.kind === "reply") {
+      void import("./quote-reply.ts").then(({ reply }) => reply("", ctx));
       return;
     }
 
@@ -2259,6 +2271,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   });
 
   registerCdCommand(pi, () => currentCtx?.cwd ?? process.cwd());
+
+  pi.registerCommand("reply", {
+    description: "Quote a previous user or assistant message into the editor",
+    handler: async (args, ctx) => {
+      const { reply } = await import("./quote-reply.ts");
+      await reply(args, ctx);
+    },
+  });
 
   pi.registerCommand("queue", {
     description: "Manage Powerline queued prompts and project aliases",

--- a/quote-reply.ts
+++ b/quote-reply.ts
@@ -1,0 +1,282 @@
+import type { ExtensionContext, SessionEntry, Theme } from "@earendil-works/pi-coding-agent";
+import { decodeKittyPrintable, fuzzyFilter, Key, matchesKey, truncateToWidth, visibleWidth, type Component, type OverlayHandle } from "@earendil-works/pi-tui";
+
+type QuoteRole = "assistant" | "user";
+
+interface QuoteCandidate {
+  id: string;
+  role: QuoteRole;
+  text: string;
+  timestampMs: number;
+  searchText: string;
+}
+
+const MAX_QUOTE_CHARS = 6_000;
+const MAX_EXCERPT_CHARS = 220;
+const MAX_VISIBLE_ITEMS = 8;
+const MAX_RPC_OPTIONS = 80;
+const MAX_CANDIDATES = 200;
+const MAX_SEARCH_TEXT_CHARS = 1_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function contentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .flatMap((block) => (isRecord(block) && block.type === "text" && typeof block.text === "string" ? [block.text] : []))
+    .join("\n\n");
+}
+
+function timestampMs(entry: SessionEntry, fallback: unknown): number {
+  if (typeof fallback === "number" && Number.isFinite(fallback)) return fallback;
+  const parsed = Date.parse(entry.timestamp);
+  return Number.isNaN(parsed) ? Date.now() : parsed;
+}
+
+function buildCandidate(entry: SessionEntry): QuoteCandidate | undefined {
+  if (entry.type !== "message") return undefined;
+  const { message } = entry;
+  if (message.role !== "assistant" && message.role !== "user") return undefined;
+
+  const id = entry.id.trim();
+  if (!id) throw new Error("Session entry id must not be empty.");
+
+  const text = contentText(message.content).trim();
+  if (!text) return undefined;
+
+  const role = message.role;
+  return {
+    id,
+    role,
+    text,
+    timestampMs: timestampMs(entry, message.timestamp),
+    searchText: `${id} ${role} ${text}`.slice(0, MAX_SEARCH_TEXT_CHARS).toLowerCase(),
+  };
+}
+
+function collectCandidates(ctx: ExtensionContext): QuoteCandidate[] {
+  const candidates: QuoteCandidate[] = [];
+  const branch = ctx.sessionManager.getBranch();
+  for (let index = branch.length - 1; index >= 0 && candidates.length < MAX_CANDIDATES; index--) {
+    const candidate = buildCandidate(branch[index]);
+    if (candidate) candidates.push(candidate);
+  }
+  return candidates;
+}
+
+function sameLocalDate(date: Date, other: Date): boolean {
+  return date.getFullYear() === other.getFullYear() && date.getMonth() === other.getMonth() && date.getDate() === other.getDate();
+}
+
+function formatTimestamp(timestamp: number): string {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const time = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return sameLocalDate(date, now) ? time : `${date.toLocaleDateString()} ${time}`;
+}
+
+function excerpt(text: string, maxChars = MAX_EXCERPT_CHARS): string {
+  const compact = text.replace(/\s+/g, " ").trim();
+  if (compact.length <= maxChars) return compact;
+  return `${compact.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+function formatQuote(candidate: QuoteCandidate): string {
+  const truncated = candidate.text.length > MAX_QUOTE_CHARS;
+  const quoteText = truncated ? candidate.text.slice(0, MAX_QUOTE_CHARS).trimEnd() : candidate.text;
+  const lines = [
+    `Quoted previous ${candidate.role} message ${candidate.id} for reference only:`,
+    "",
+    quoteText.split(/\r?\n/).map((line) => (line ? `> ${line}` : ">")).join("\n"),
+  ];
+  if (truncated) lines.push("", `> [Quote truncated from ${candidate.text.length.toLocaleString()} characters.]`);
+  lines.push("", "My reply:", "");
+  return lines.join("\n");
+}
+
+function insertQuote(ctx: ExtensionContext, candidate: QuoteCandidate): void {
+  ctx.ui.setEditorText(`${formatQuote(candidate)}${ctx.ui.getEditorText()}`);
+  ctx.ui.notify(`Inserted quote from ${candidate.role} message ${candidate.id}.`, "info");
+}
+
+function printableInput(data: string): string | undefined {
+  const kittyPrintable = decodeKittyPrintable(data);
+  if (kittyPrintable !== undefined) return kittyPrintable;
+  if (!data) return undefined;
+  return [...data].some((char) => {
+    const code = char.charCodeAt(0);
+    return code < 32 || code === 0x7f || (code >= 0x80 && code <= 0x9f);
+  }) ? undefined : data;
+}
+
+function filterCandidates(candidates: QuoteCandidate[], query: string): QuoteCandidate[] {
+  const trimmed = query.trim();
+  return trimmed ? fuzzyFilter(candidates, trimmed, (candidate) => candidate.searchText) : candidates;
+}
+
+class QuotePicker implements Component {
+  private query = "";
+  private selectedIndex = 0;
+  private readonly candidates: QuoteCandidate[];
+  private readonly theme: Theme;
+  private readonly onSelect: (candidate: QuoteCandidate) => void;
+  private readonly onCancel: () => void;
+
+  constructor(candidates: QuoteCandidate[], theme: Theme, onSelect: (candidate: QuoteCandidate) => void, onCancel: () => void) {
+    this.candidates = candidates;
+    this.theme = theme;
+    this.onSelect = onSelect;
+    this.onCancel = onCancel;
+  }
+
+  render(width: number): string[] {
+    const innerWidth = Math.max(0, width - 2);
+    const filtered = filterCandidates(this.candidates, this.query);
+    this.selectedIndex = filtered.length === 0 ? 0 : Math.min(this.selectedIndex, filtered.length - 1);
+    const lines = [this.topBorder(innerWidth, " Reply "), this.emptyRow(innerWidth), this.row(innerWidth, this.searchLine()), this.emptyRow(innerWidth), this.divider(innerWidth)];
+
+    if (filtered.length === 0) {
+      lines.push(this.emptyRow(innerWidth), this.row(innerWidth, this.theme.fg("warning", this.theme.italic("No matching messages"))), this.emptyRow(innerWidth));
+    } else {
+      lines.push(this.emptyRow(innerWidth));
+      const start = Math.max(0, Math.min(this.selectedIndex - Math.floor(MAX_VISIBLE_ITEMS / 2), filtered.length - MAX_VISIBLE_ITEMS));
+      for (const [offset, candidate] of filtered.slice(start, start + MAX_VISIBLE_ITEMS).entries()) {
+        lines.push(this.row(innerWidth, this.renderCandidate(innerWidth, candidate, start + offset === this.selectedIndex)));
+      }
+      lines.push(this.emptyRow(innerWidth));
+      if (filtered.length > MAX_VISIBLE_ITEMS) lines.push(this.row(innerWidth, this.scrollIndicator(filtered.length)), this.emptyRow(innerWidth));
+    }
+
+    lines.push(this.divider(innerWidth), this.emptyRow(innerWidth), this.row(innerWidth, this.help()), this.bottomBorder(innerWidth));
+    return lines;
+  }
+
+  handleInput(data: string): void {
+    const filtered = filterCandidates(this.candidates, this.query);
+    if (matchesKey(data, Key.up)) {
+      this.selectedIndex = filtered.length === 0 ? 0 : (this.selectedIndex - 1 + filtered.length) % filtered.length;
+      return;
+    }
+    if (matchesKey(data, Key.down)) {
+      this.selectedIndex = filtered.length === 0 ? 0 : (this.selectedIndex + 1) % filtered.length;
+      return;
+    }
+    if (matchesKey(data, Key.enter)) {
+      const selected = filtered[this.selectedIndex];
+      if (selected) this.onSelect(selected);
+      return;
+    }
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+      this.onCancel();
+      return;
+    }
+    if (matchesKey(data, Key.backspace)) {
+      this.query = Array.from(this.query).slice(0, -1).join("");
+      this.selectedIndex = 0;
+      return;
+    }
+    if (matchesKey(data, Key.ctrl("u"))) {
+      this.query = "";
+      this.selectedIndex = 0;
+      return;
+    }
+    const printable = printableInput(data);
+    if (printable) {
+      this.query += printable;
+      this.selectedIndex = 0;
+    }
+  }
+
+  invalidate(): void {}
+
+  private searchLine(): string {
+    const cursor = this.theme.fg("accent", "│");
+    const icon = this.theme.fg("dim", "◎");
+    const query = this.query ? `${this.query}${cursor}` : `${cursor}${this.theme.fg("dim", this.theme.italic("type to filter messages..."))}`;
+    return `${icon}  ${query}`;
+  }
+
+  private renderCandidate(innerWidth: number, candidate: QuoteCandidate, selected: boolean): string {
+    const prefix = selected ? this.theme.fg("accent", "▸") : this.theme.fg("borderMuted", "·");
+    const role = this.theme.fg(candidate.role === "assistant" ? "accent" : "success", candidate.role);
+    const meta = this.theme.fg("dim", `${candidate.id}  ${formatTimestamp(candidate.timestampMs)}`);
+    const head = `${prefix} ${selected ? this.theme.bold(role) : role} ${meta}`;
+    const maxExcerptWidth = Math.max(0, innerWidth - visibleWidth(head) - 8);
+    const preview = maxExcerptWidth > 18 ? this.theme.fg("muted", excerpt(candidate.text, maxExcerptWidth)) : "";
+    const separator = preview ? `  ${this.theme.fg("borderMuted", "—")}  ` : "";
+    return selected ? this.theme.fg("accent", `${head}${separator}${preview}`) : `${head}${separator}${preview}`;
+  }
+
+  private scrollIndicator(total: number): string {
+    const filled = Math.max(1, Math.round(((this.selectedIndex + 1) / total) * 10));
+    const dots = Array.from({ length: 10 }, (_, index) => index < filled ? "●" : "○").map((dot, index) => index < filled ? this.theme.fg("accent", dot) : this.theme.fg("dim", dot)).join(" ");
+    return `${dots}  ${this.theme.fg("dim", `${this.selectedIndex + 1}/${total}`)}`;
+  }
+
+  private topBorder(innerWidth: number, title: string): string {
+    const borderLength = Math.max(0, innerWidth - visibleWidth(title));
+    const left = Math.floor(borderLength / 2);
+    return this.border(`╭${"─".repeat(left)}`) + this.theme.fg("dim", title) + this.border(`${"─".repeat(borderLength - left)}╮`);
+  }
+
+  private divider(innerWidth: number): string { return this.border(`├${"─".repeat(innerWidth)}┤`); }
+  private bottomBorder(innerWidth: number): string { return this.border(`╰${"─".repeat(innerWidth)}╯`); }
+  private emptyRow(innerWidth: number): string { return this.border("│") + " ".repeat(innerWidth) + this.border("│"); }
+  private row(innerWidth: number, content: string): string { return this.border("│") + truncateToWidth(` ${content}`, innerWidth, "…", true) + this.border("│"); }
+  private border(text: string): string { return this.theme.fg("borderMuted", text); }
+  private help(): string { return this.theme.fg("dim", `${this.theme.italic("↑↓")} navigate  ${this.theme.italic("enter")} quote  ${this.theme.italic("esc")} cancel  ${this.theme.italic("⌫")} edit`); }
+}
+
+async function pickCandidate(ctx: ExtensionContext, candidates: QuoteCandidate[]): Promise<QuoteCandidate | undefined> {
+  if (ctx.mode !== "tui") {
+    const options = candidates.slice(0, MAX_RPC_OPTIONS).map((candidate) => `${candidate.id} ${candidate.role}: ${excerpt(candidate.text)}`);
+    const selected = await ctx.ui.select("Reply to previous message", options);
+    if (!selected) return undefined;
+    const [id] = selected.split(" ");
+    return id ? candidates.find((candidate) => candidate.id === id) : undefined;
+  }
+
+  let overlayHandle: OverlayHandle | undefined;
+  let finished = false;
+  return ctx.ui.custom<QuoteCandidate | undefined>((tui, theme, _keybindings, done) => {
+    const finish = (candidate: QuoteCandidate | undefined) => {
+      if (finished) return;
+      finished = true;
+      done(candidate);
+      overlayHandle?.hide();
+      tui.requestRender(true);
+    };
+    const picker = new QuotePicker(candidates, theme, finish, () => finish(undefined));
+    return {
+      render: (width: number) => picker.render(width),
+      handleInput: (data: string) => { picker.handleInput(data); if (!finished) tui.requestRender(); },
+      invalidate: () => picker.invalidate(),
+    };
+  }, { overlay: true, overlayOptions: { width: "85%", minWidth: 72, maxHeight: "80%" }, onHandle: (handle) => { overlayHandle = handle; } });
+}
+
+export async function reply(args: string, ctx: ExtensionContext): Promise<void> {
+  const candidates = collectCandidates(ctx);
+  if (candidates.length === 0) {
+    ctx.ui.notify("No user or assistant messages are available to quote.", "warning");
+    return;
+  }
+
+  const query = args.trim().replace(/^#/, "").toLowerCase();
+  if (query) {
+    const matches = candidates.filter((candidate) => candidate.id.toLowerCase().startsWith(query));
+    const candidate = matches[0];
+    if (matches.length === 1 && candidate) {
+      insertQuote(ctx, candidate);
+      return;
+    }
+    ctx.ui.notify(matches.length > 1 ? `Message id "${query}" matches ${matches.length} messages. Type more of the id.` : `No quotable message matches id "${query}".`, "warning");
+    return;
+  }
+
+  const candidate = await pickCandidate(ctx, candidates);
+  if (candidate) insertQuote(ctx, candidate);
+}

--- a/tests/jump-shortcuts.test.ts
+++ b/tests/jump-shortcuts.test.ts
@@ -9,6 +9,7 @@ test("surviving editor shortcuts resolve without app-owned chat scrolling", () =
   assert.equal(resolved.stashHistory, "ctrl+alt+h");
   assert.equal(resolved.copyEditor, "ctrl+alt+c");
   assert.equal(resolved.cutEditor, "ctrl+alt+x");
+  assert.equal(resolved.reply, null);
   assert.equal(resolved.editorStart, "super+shift+up");
   assert.equal(resolved.editorEnd, "super+shift+down");
   assert.equal(Object.keys(resolved).some((key) => key.startsWith("scroll")), false);
@@ -34,6 +35,32 @@ test("editor boundary shortcuts remain configurable", () => {
 
   assert.equal(resolved.editorStart, "ctrl+shift+u");
   assert.equal(resolved.editorEnd, "ctrl+shift+d");
+});
+
+test("reply shortcut is opt-in and configurable", () => {
+  assert.equal(resolveShortcutConfig({ powerlineShortcuts: { reply: null } }).reply, null);
+  assert.equal(resolveShortcutConfig({ powerlineShortcuts: { reply: "ctrl+shift+r" } }).reply, "ctrl+shift+r");
+});
+
+test("conflicting reply shortcut disables reply instead of borrowing another action", () => {
+  const reserved = resolveShortcutConfig({ powerlineShortcuts: { reply: "ctrl+r" } });
+  assert.equal(reserved.reply, null);
+  assert.equal(reserved.editorStart, "super+shift+up");
+  assert.equal(reserved.editorEnd, "super+shift+down");
+
+  const duplicate = resolveShortcutConfig({ powerlineShortcuts: { reply: "ctrl+alt+h" } });
+  assert.equal(duplicate.reply, null);
+  assert.equal(duplicate.stashHistory, "ctrl+alt+h");
+
+  const editorStartDefault = resolveShortcutConfig({ powerlineShortcuts: { reply: "super+shift+up" } });
+  assert.equal(editorStartDefault.reply, null);
+  assert.equal(editorStartDefault.editorStart, "super+shift+up");
+  assert.equal(editorStartDefault.editorEnd, "super+shift+down");
+
+  const editorEndDefault = resolveShortcutConfig({ powerlineShortcuts: { reply: "super+shift+down" } });
+  assert.equal(editorEndDefault.reply, null);
+  assert.equal(editorEndDefault.editorStart, "super+shift+up");
+  assert.equal(editorEndDefault.editorEnd, "super+shift+down");
 });
 
 test("bash completions are opt-in", () => {

--- a/tests/quote-reply.test.ts
+++ b/tests/quote-reply.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { reply } from "../quote-reply.ts";
+
+function contextFor(entries: unknown[], editorText = "draft") {
+  let text = editorText;
+  const notifications: string[] = [];
+  return {
+    context: {
+      mode: "rpc",
+      sessionManager: { getBranch: () => entries },
+      ui: {
+        getEditorText: () => text,
+        setEditorText: (next: string) => { text = next; },
+        notify: (message: string) => { notifications.push(message); },
+        select: async () => undefined,
+      },
+    } as any,
+    get text() { return text; },
+    notifications,
+  };
+}
+
+test("reply quotes a matching message and preserves the current draft", async () => {
+  const harness = contextFor([
+    { type: "message", id: "old", timestamp: "2026-08-23T00:00:00.000Z", message: { role: "toolResult", content: [{ type: "text", text: "ignore" }] } },
+    { type: "message", id: "abc123", timestamp: "2026-08-23T00:01:00.000Z", message: { role: "user", content: [{ type: "text", text: "Please inspect this." }] } },
+  ]);
+
+  await reply("abc", harness.context);
+
+  assert.equal(harness.text, "Quoted previous user message abc123 for reference only:\n\n> Please inspect this.\n\nMy reply:\ndraft");
+  assert.deepEqual(harness.notifications, ["Inserted quote from user message abc123."]);
+});


### PR DESCRIPTION
## Summary

Adds `/reply` to quote a previous user or assistant message into the editor while preserving the current draft.

The shortcut stays opt-in through `powerlineShortcuts.reply`, which defaults to `null`. The quote picker module is lazy-loaded only when `/reply` runs or the configured shortcut is pressed, so the footer render path has no quote-reply work.

Closes #181.

## Validation

- `node --experimental-strip-types --test tests/quote-reply.test.ts tests/jump-shortcuts.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- `npm pack --dry-run --json`
