### PR TITLE
fix: hide git child consoles on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - **Quote previous messages** — Added `/reply` to insert a previous user or assistant message as a Markdown quote. An optional `powerlineShortcuts.reply` shortcut is disabled by default and loads the picker only when used.
 - **Self-colored custom items** — Added `customItems[].selfColorize` so extension statuses can keep embedded ANSI colors, including multiple colors within one item, without being wrapped by the configured custom-item color. Thanks to [@elecnix](https://github.com/elecnix) for #176.
 
+### Fixed
+- **Windows git polling** — Hide spawned git child-process consoles so detached Windows hosts do not flash a visible window on each footer poll or bash completion. Thanks to [@xing-shuyin](https://github.com/xing-shuyin) for #180.
+
 ## [0.15.1] - 2026-08-19
 
 ### Fixed

--- a/bash-mode/completion.ts
+++ b/bash-mode/completion.ts
@@ -211,7 +211,7 @@ function getPathSuggestions(token: string, cwd: string): ExtendedCompletionItem[
 function runGit(args: string[], cwd: string, signal: AbortSignal): Promise<string[]> {
   return new Promise((resolve) => {
     try {
-      execFile("git", args, { cwd, encoding: "utf8", signal }, (error, stdout) => {
+      execFile("git", args, { cwd, encoding: "utf8", signal, windowsHide: true }, (error, stdout) => {
         if (error || !stdout) {
           resolve([]);
           return;

--- a/git-status.ts
+++ b/git-status.ts
@@ -102,6 +102,7 @@ function runGit(args: string[], timeoutMs = 200): Promise<string | null> {
     const proc = spawn("git", args, {
       stdio: ["ignore", "pipe", "pipe"],
       env: readOnlyGitEnv(),
+      windowsHide: true,
     });
 
     let stdout = "";

--- a/tests/git-optional-locks.test.ts
+++ b/tests/git-optional-locks.test.ts
@@ -7,6 +7,8 @@ import { join } from "node:path";
 import { readOnlyGitEnv } from "../git-status.ts";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const gitStatusSource = readFileSync(new URL("../git-status.ts", import.meta.url), "utf-8");
+const completionSource = readFileSync(new URL("../bash-mode/completion.ts", import.meta.url), "utf-8");
 
 // Background fetches spawn git with up to 500ms timeouts; give them room.
 const FETCH_SETTLE_MS = 1200;
@@ -19,6 +21,20 @@ test("read-only git commands opt out of git's optional index lock", () => {
 
 test("readOnlyGitEnv overrides an inherited GIT_OPTIONAL_LOCKS=1", () => {
   assert.equal(readOnlyGitEnv({ GIT_OPTIONAL_LOCKS: "1" }).GIT_OPTIONAL_LOCKS, "0");
+});
+
+test("footer git polling hides Windows child consoles while preserving read-only env", () => {
+  assert.match(
+    gitStatusSource,
+    /spawn\("git", args, \{\s*stdio: \["ignore", "pipe", "pipe"\],\s*env: readOnlyGitEnv\(\),\s*windowsHide: true,\s*\}\)/s,
+  );
+});
+
+test("bash git completions hide Windows child consoles", () => {
+  assert.match(
+    completionSource,
+    /execFile\("git", args, \{ cwd, encoding: "utf8", signal, windowsHide: true \}/,
+  );
 });
 
 // Guards the regression end to end, via a `git` shim on PATH: the footer polls


### PR DESCRIPTION
## Summary

Hide Powerline git child processes on Windows so detached hosts do not flash console windows during footer polling or bash git completions.

Closes #180.

## Validation

- `node --experimental-strip-types --test tests/git-optional-locks.test.ts tests/bash-mode.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh read-only review: No issues found

## Credit

Thanks to [@xing-shuyin](https://github.com/xing-shuyin) for #180.