### PR TITLE
fix: lazy load stash project history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - **Quote previous messages** — Added `/reply` to insert a previous user or assistant message as a Markdown quote. An optional `powerlineShortcuts.reply` shortcut is disabled by default and loads the picker only when used.
 - **Self-colored custom items** — Added `customItems[].selfColorize` so extension statuses can keep embedded ANSI colors, including multiple colors within one item, without being wrapped by the configured custom-item color. Thanks to [@elecnix](https://github.com/elecnix) for #176.
 
+### Changed
+- **Editor stash restore** — Stashed editor text now stays stashed after agent runs and restores only after an explicit `Alt+S` or stash-history action. Closes #183.
+- **Stash history loading** — Recent project prompts now load only when that source is selected, and the project scan is bounded to newest session file tails. Closes #184.
+
 ### Fixed
 - **Windows git polling** — Hide spawned git child-process consoles so detached Windows hosts do not flash a visible window on each footer poll or bash completion. Thanks to [@xing-shuyin](https://github.com/xing-shuyin) for #180.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Customizes the default [pi](https://github.com/badlogic/pi-mono) editor with a p
 
 ## Features
 
-**Editor stash** — Press `Alt+S` to save your editor content and clear the editor, type a quick prompt, and your stashed text auto-restores when the agent finishes. Toggles between stash, pop, and update-existing-stash. A `stash` indicator appears in the powerline bar while text is stashed.
+**Editor stash** — Press `Alt+S` to save your editor content and clear the editor, type a quick prompt, then press `Alt+S` again with an empty editor to restore the stash. Toggles between stash, pop, and update-existing-stash. A `stash` indicator appears in the powerline bar while text is stashed.
 
 **Powerline Queue** — Messages typed during compaction are held by Powerline and delivered after successful compaction instead of disappearing into Pi's native queue. `/queue` provides a file-backed queue for aliases, retries, clears, and manual delivery. Active queued and blocked counts appear in the `queue` segment only when there is something to show.
 
@@ -275,7 +275,7 @@ Use `Alt+S` / `Option+S` as a quick stash toggle while drafting. It keeps one ac
 | Has text | Has stash | Update stash with current text, clear editor |
 | Empty | Empty | Show "Nothing to stash" |
 
-Auto-restore after an agent run only happens when the editor is still empty. If you typed meanwhile, the stash is preserved.
+Stashes are restored only by explicit user action. Agent runs do not restore stashed text automatically.
 
 The `stash` indicator appears in the powerline bar (on presets with `extension_statuses`). Active stash is still session-local and resets on session switch / disable, but stash history is persisted to the agent dir at `powerline-footer/stash-history.json` so it survives restarts. By default the agent dir is `~/.pi/agent`; set `PI_CODING_AGENT_DIR` to move global powerline settings, stash history, sessions, vibes, skills, commands, and extension discovery with Pi.
 
@@ -289,7 +289,7 @@ Open prompt history with either:
 Prompt history now has two sources:
 
 - stashed prompts — up to 12 recent stashed prompts (newest first)
-- recent project prompts — up to 50 recent user-submitted prompts pulled from pi sessions in the current project folder
+- recent project prompts — up to 50 recent user-submitted prompts pulled on demand from newest pi sessions in the current project folder
 
 Selecting a stashed or project prompt-history entry inserts it into the editor. If the editor already has text, you can choose `Replace`, `Append`, or `Cancel`.
 

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { CURSOR_MARKER, isKeyRelease, type AutocompleteProvider, type SelectItem, SelectList, truncateToWidth, TUI_KEYBINDINGS, visibleWidth } from "@earendil-works/pi-tui";
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 
 import type { ColorScheme, SegmentContext, StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "./types.ts";
@@ -113,6 +113,9 @@ type PowerlineShortcutAction =
   | { kind: "bashMode" };
 const STASH_HISTORY_LIMIT = 12;
 const PROJECT_PROMPT_HISTORY_LIMIT = 50;
+const PROJECT_PROMPT_HISTORY_FILE_LIMIT = 50;
+const PROJECT_PROMPT_HISTORY_MAX_BYTES = 3 * 1024 * 1024;
+const PROJECT_PROMPT_HISTORY_FILE_MAX_BYTES = 64 * 1024;
 const STASH_PREVIEW_WIDTH = 72;
 const DEFAULT_SHORTCUTS: PowerlineShortcuts = {
   stashHistory: "ctrl+alt+h",
@@ -414,19 +417,56 @@ function getPromptHistoryText(content: unknown): string {
   return parts.join("\n").replace(/\s+/g, " ").trim();
 }
 
+function readFileTail(filePath: string, size: number, maxBytes: number): string {
+  const bytesToRead = Math.min(size, maxBytes);
+  if (bytesToRead === 0) {
+    return "";
+  }
+
+  const fd = openSync(filePath, "r");
+  try {
+    const buffer = Buffer.allocUnsafe(bytesToRead);
+    const bytesRead = readSync(fd, buffer, 0, bytesToRead, size - bytesToRead);
+    const text = buffer.toString("utf8", 0, bytesRead);
+    if (size <= bytesToRead) {
+      return text;
+    }
+
+    const firstNewline = text.indexOf("\n");
+    return firstNewline === -1 ? "" : text.slice(firstNewline + 1);
+  } finally {
+    closeSync(fd);
+  }
+}
+
 function readRecentProjectPrompts(cwd: string, limit: number): string[] {
   const sessionsPath = getProjectSessionsPath(cwd);
   if (!existsSync(sessionsPath)) {
     return [];
   }
 
-  const promptEntries: { text: string; timestamp: number }[] = [];
-  const fileNames = readdirSync(sessionsPath)
-    .filter((fileName) => fileName.endsWith(".jsonl"));
+  const files = readdirSync(sessionsPath)
+    .filter((fileName) => fileName.endsWith(".jsonl"))
+    .map((fileName) => {
+      const filePath = join(sessionsPath, fileName);
+      const stats = statSync(filePath);
+      return { fileName, filePath, mtimeMs: stats.mtimeMs, size: stats.size };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs || b.fileName.localeCompare(a.fileName))
+    .slice(0, PROJECT_PROMPT_HISTORY_FILE_LIMIT);
 
-  for (const fileName of fileNames) {
-    const filePath = join(sessionsPath, fileName);
-    const lines = readFileSync(filePath, "utf-8").split("\n");
+  const prompts: string[] = [];
+  const seen = new Set<string>();
+  let remainingBytes = PROJECT_PROMPT_HISTORY_MAX_BYTES;
+
+  for (const file of files) {
+    if (remainingBytes <= 0) {
+      break;
+    }
+
+    const bytesToRead = Math.min(file.size, PROJECT_PROMPT_HISTORY_FILE_MAX_BYTES, remainingBytes);
+    remainingBytes -= bytesToRead;
+    const lines = readFileTail(file.filePath, file.size, bytesToRead).split("\n");
 
     for (let i = lines.length - 1; i >= 0; i--) {
       const line = lines[i];
@@ -439,7 +479,7 @@ function readRecentProjectPrompts(cwd: string, limit: number): string[] {
         entry = JSON.parse(line);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`Failed to parse session file ${filePath}: ${message}`, { cause: error });
+        throw new Error(`Failed to parse session file ${file.filePath}: ${message}`, { cause: error });
       }
 
       if (!isRecord(entry) || entry.type !== "message" || !isRecord(entry.message) || entry.message.role !== "user") {
@@ -451,29 +491,15 @@ function readRecentProjectPrompts(cwd: string, limit: number): string[] {
         continue;
       }
 
-      const timestamp = typeof entry.message.timestamp === "number"
-        ? entry.message.timestamp
-        : typeof entry.timestamp === "string"
-          ? Date.parse(entry.timestamp)
-          : 0;
+      if (seen.has(text)) {
+        continue;
+      }
 
-      promptEntries.push({ text, timestamp: Number.isFinite(timestamp) ? timestamp : 0 });
-    }
-  }
-
-  promptEntries.sort((a, b) => b.timestamp - a.timestamp);
-
-  const prompts: string[] = [];
-  const seen = new Set<string>();
-  for (const entry of promptEntries) {
-    if (seen.has(entry.text)) {
-      continue;
-    }
-
-    seen.add(entry.text);
-    prompts.push(entry.text);
-    if (prompts.length >= limit) {
-      return prompts;
+      seen.add(text);
+      prompts.push(text);
+      if (prompts.length >= limit) {
+        return prompts;
+      }
     }
   }
 
@@ -2036,33 +2062,23 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   async function selectPromptHistorySource(
     ctx: any,
     stashCount: number,
-    projectPromptCount: number,
   ): Promise<"stash" | "project" | null> {
+    if (stashCount === 0) {
+      return "project";
+    }
+
     const items: SelectItem[] = [];
 
-    if (stashCount > 0) {
-      items.push({
-        value: "stash",
-        label: "Stashed prompts",
-        description: `${stashCount} saved`,
-      });
-    }
-
-    if (projectPromptCount > 0) {
-      items.push({
-        value: "project",
-        label: "Recent project prompts",
-        description: `${projectPromptCount} recent`,
-      });
-    }
-
-    if (items.length === 0) {
-      return null;
-    }
-
-    if (items.length === 1) {
-      return items[0]?.value === "project" ? "project" : "stash";
-    }
+    items.push({
+      value: "stash",
+      label: "Stashed prompts",
+      description: `${stashCount} saved`,
+    });
+    items.push({
+      value: "project",
+      label: "Recent project prompts",
+      description: "load on demand",
+    });
 
     const selected = await showSelectOverlay(
       ctx, "Prompt history", "↑↓ navigate • enter open • esc cancel",
@@ -2197,36 +2213,37 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   }
 
   async function openStashHistory(ctx: any): Promise<void> {
-    let projectPrompts: string[] = [];
-
-    try {
-      projectPrompts = readRecentProjectPrompts(ctx.cwd, PROJECT_PROMPT_HISTORY_LIMIT);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      ctx.ui.notify(`Failed to load project prompts: ${message}`, "warning");
-    }
-
-    if (stashedPromptHistory.length === 0 && projectPrompts.length === 0) {
-      ctx.ui.notify("No prompt history yet", "info");
-      return;
-    }
-
-    const source = await selectPromptHistorySource(ctx, stashedPromptHistory.length, projectPrompts.length);
+    const source = await selectPromptHistorySource(ctx, stashedPromptHistory.length);
     if (!source) {
       return;
     }
 
-    const selected = source === "project"
-      ? await selectProjectPromptFromHistory(ctx, projectPrompts)
-      : await selectStashedPromptFromHistory(ctx);
-    if (!selected) return;
+    if (source === "project") {
+      let projectPrompts: string[] = [];
+      try {
+        projectPrompts = readRecentProjectPrompts(ctx.cwd, PROJECT_PROMPT_HISTORY_LIMIT);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        ctx.ui.notify(`Failed to load project prompts: ${message}`, "warning");
+        return;
+      }
 
-    if (source === "stash") {
-      await handleSelectedStashHistoryEntry(ctx, selected);
+      if (projectPrompts.length === 0) {
+        ctx.ui.notify(stashedPromptHistory.length === 0 ? "No prompt history yet" : "No recent project prompts", "info");
+        return;
+      }
+
+      const selected = await selectProjectPromptFromHistory(ctx, projectPrompts);
+      if (!selected) return;
+
+      await insertSelectedPromptHistoryEntry(ctx, selected);
       return;
     }
 
-    await insertSelectedPromptHistoryEntry(ctx, selected);
+    const selected = await selectStashedPromptFromHistory(ctx);
+    if (!selected) return;
+
+    await handleSelectedStashHistoryEntry(ctx, selected);
   }
 
   pi.on("agent_end", async (_event, ctx) => {
@@ -2247,16 +2264,6 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     try {
       if (hasUI) {
         onVibeAgentEnd(ctx.ui.setWorkingMessage); // working-vibes internal state + reset message
-        if (stashedEditorText !== null) {
-          if (ctx.ui.getEditorText().trim() === "") {
-            ctx.ui.setEditorText(stashedEditorText);
-            stashedEditorText = null;
-            ctx.ui.setStatus("stash", undefined);
-            ctx.ui.notify("Stash restored", "info");
-          } else {
-            ctx.ui.notify("Stash preserved — clear editor then Alt+S to restore", "info");
-          }
-        }
       }
     } catch (error) {
       if (!isStaleExtensionContextError(error)) throw error;

--- a/tests/stash-shortcut.test.ts
+++ b/tests/stash-shortcut.test.ts
@@ -1,9 +1,141 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { matchesStashShortcutInput } from "../shortcuts.ts";
 
 const source = readFileSync(new URL("../index.ts", import.meta.url), "utf-8");
+
+function projectSessionsPath(agentDir: string, cwd: string): string {
+  const projectKey = cwd
+    .replace(/^[/\\]+|[/\\]+$/g, "")
+    .replace(/[/\\]+/g, "-");
+  return join(agentDir, "sessions", `--${projectKey}--`);
+}
+
+function writeAgentSettings(agentDir: string): void {
+  mkdirSync(agentDir, { recursive: true });
+  writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ powerline: { welcome: false } }));
+}
+
+function writeStashHistory(agentDir: string, history: string[]): void {
+  mkdirSync(join(agentDir, "powerline-footer"), { recursive: true });
+  writeFileSync(join(agentDir, "powerline-footer", "stash-history.json"), JSON.stringify({ version: 1, history }));
+}
+
+function sessionLine(text: string, timestamp: number): string {
+  return JSON.stringify({
+    type: "message",
+    message: { role: "user", content: text, timestamp },
+    timestamp: new Date(timestamp).toISOString(),
+  });
+}
+
+async function loadPowerline(agentDir: string) {
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+  const moduleUrl = new URL("../index.ts", import.meta.url);
+  const mod = await import(`${moduleUrl.href}?stashTest=${Date.now()}-${Math.random()}`);
+  return {
+    extension: mod.default as (pi: any) => void,
+    restoreEnv: () => {
+      if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+      else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    },
+  };
+}
+
+function fakeTheme() {
+  return {
+    fg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  };
+}
+
+function createFakePi() {
+  const handlers = new Map<string, (event: any, ctx: any) => Promise<void>>();
+  const commands = new Map<string, { handler: (args: string, ctx: any) => Promise<void> }>();
+  return {
+    handlers,
+    commands,
+    pi: {
+      on(name: string, handler: (event: any, ctx: any) => Promise<void>) {
+        handlers.set(name, handler);
+      },
+      registerCommand(name: string, command: { handler: (args: string, ctx: any) => Promise<void> }) {
+        commands.set(name, command);
+      },
+      sendUserMessage() {},
+    },
+  };
+}
+
+function createCtx(options: { cwd: string; text?: string; customInputs?: string[][] } = { cwd: process.cwd() }) {
+  let text = options.text ?? "";
+  let terminalInput: ((data: string) => unknown) | null = null;
+  const setEditorTextCalls: string[] = [];
+  const notifications: { message: string; level?: string }[] = [];
+  const statuses: Array<[string, string | undefined]> = [];
+  const customTitles: string[] = [];
+  const customInputs = [...(options.customInputs ?? [])];
+
+  const ctx = {
+    cwd: options.cwd,
+    hasUI: true,
+    model: { name: "test", provider: "test" },
+    modelRegistry: {},
+    ui: {
+      getEditorText: () => text,
+      setEditorText: (next: string) => {
+        setEditorTextCalls.push(next);
+        text = next;
+      },
+      setStatus: (key: string, value: string | undefined) => statuses.push([key, value]),
+      notify: (message: string, level?: string) => notifications.push({ message, level }),
+      setWorkingMessage() {},
+      onTerminalInput: (handler: (data: string) => unknown) => {
+        terminalInput = handler;
+        return () => { terminalInput = null; };
+      },
+      custom: async (factory: any) => new Promise((resolve) => {
+        const done = (result: unknown) => resolve(result);
+        const component = factory({ requestRender() {} }, fakeTheme(), {}, done);
+        const rendered = component.render(80).join("\n");
+        const title = rendered.includes("Stashed prompts") && rendered.includes("Recent project prompts")
+          ? "Prompt history"
+          : rendered.includes("Stash history")
+            ? "Stash history"
+            : rendered.includes("Recent project prompts")
+              ? "Recent project prompts"
+              : "unknown";
+        customTitles.push(title);
+        for (const input of customInputs.shift() ?? ["\r"]) {
+          component.handleInput(input);
+        }
+      }),
+      select: async () => "Insert",
+      setWidget() {},
+      setFooter() {},
+      setHeader() {},
+      setEditorComponent() {},
+      getEditorComponent: () => undefined,
+    },
+  };
+
+  return {
+    ctx,
+    get text() { return text; },
+    setEditorTextCalls,
+    notifications,
+    statuses,
+    customTitles,
+    sendTerminalInput: (data: string) => {
+      assert.ok(terminalInput, "expected terminal input handler to be installed");
+      return terminalInput(data);
+    },
+  };
+}
 
 test("stash shortcut matches Alt+S encodings without consuming literal sharp-S by default", () => {
   assert.equal(matchesStashShortcutInput("ß"), false);
@@ -34,4 +166,96 @@ test("stash shortcut stays in terminal/editor fallback routing", () => {
   assert.match(source, /matchesConfiguredShortcut\(data, resolvedShortcuts\.stashHistory\)/);
   assert.doesNotMatch(source, /data === "\\x1b\\b"/);
   assert.doesNotMatch(source, /data === "\\x1b\\x7f"/);
+});
+
+test("agent_end leaves an active stash untouched until explicit restore", async () => {
+  const agentDir = mkdtempSync(join(tmpdir(), "powerline-stash-agent-end-"));
+  const cwd = mkdtempSync(join(tmpdir(), "powerline-stash-cwd-"));
+  writeAgentSettings(agentDir);
+  const { extension, restoreEnv } = await loadPowerline(agentDir);
+
+  try {
+    const fake = createFakePi();
+    extension(fake.pi);
+    const runtime = createCtx({ cwd, text: "draft to keep" });
+    await fake.handlers.get("session_start")?.({ reason: "resume" }, runtime.ctx);
+
+    runtime.sendTerminalInput("\x1bs");
+    assert.equal(runtime.text, "");
+    assert.deepEqual(runtime.statuses.at(-1), ["stash", "stash"]);
+
+    runtime.setEditorTextCalls.length = 0;
+    await fake.handlers.get("agent_end")?.({}, runtime.ctx);
+    assert.deepEqual(runtime.setEditorTextCalls, []);
+    assert.equal(runtime.text, "");
+    assert.deepEqual(runtime.statuses.at(-1), ["stash", "stash"]);
+    assert.equal(runtime.notifications.some((entry) => entry.message === "Stash restored"), false);
+
+    runtime.sendTerminalInput("\x1bs");
+    assert.equal(runtime.text, "draft to keep");
+    assert.deepEqual(runtime.statuses.at(-1), ["stash", undefined]);
+    assert.equal(runtime.notifications.some((entry) => entry.message === "Stash restored"), true);
+  } finally {
+    restoreEnv();
+  }
+});
+
+test("stash history can open stashed prompts without reading project JSONL", async () => {
+  const agentDir = mkdtempSync(join(tmpdir(), "powerline-stash-history-fast-"));
+  const cwd = "/tmp/powerline-stash-history-cwd";
+  writeAgentSettings(agentDir);
+  writeStashHistory(agentDir, ["saved stash"]);
+  const sessionsPath = projectSessionsPath(agentDir, cwd);
+  mkdirSync(sessionsPath, { recursive: true });
+  writeFileSync(join(sessionsPath, "broken.jsonl"), '{"type":"message","message":{"role":"user",');
+  const { extension, restoreEnv } = await loadPowerline(agentDir);
+
+  try {
+    const fake = createFakePi();
+    extension(fake.pi);
+    const runtime = createCtx({ cwd, customInputs: [["\r"], ["\r"]] });
+    await fake.commands.get("stash-history")?.handler("", runtime.ctx);
+
+    assert.deepEqual(runtime.customTitles, ["Prompt history", "Stash history"]);
+    assert.equal(runtime.text, "saved stash");
+    assert.equal(runtime.notifications.some((entry) => entry.level === "warning"), false);
+  } finally {
+    restoreEnv();
+  }
+});
+
+test("stash history loads project prompts on demand from bounded newest files", async () => {
+  const agentDir = mkdtempSync(join(tmpdir(), "powerline-project-history-"));
+  const cwd = "/tmp/powerline-project-history-cwd";
+  writeAgentSettings(agentDir);
+  writeStashHistory(agentDir, ["saved stash"]);
+  const sessionsPath = projectSessionsPath(agentDir, cwd);
+  mkdirSync(sessionsPath, { recursive: true });
+
+  const now = Date.now();
+  for (let i = 0; i < 50; i += 1) {
+    const filePath = join(sessionsPath, `recent-${String(i).padStart(2, "0")}.jsonl`);
+    writeFileSync(filePath, `${sessionLine(`project prompt ${i}`, now - i)}\n`);
+    const mtime = new Date(now - i * 1000);
+    utimesSync(filePath, mtime, mtime);
+  }
+  const oldBrokenPath = join(sessionsPath, "old-broken.jsonl");
+  writeFileSync(oldBrokenPath, '{"type":"message","message":{"role":"user",');
+  const oldTime = new Date(now - 100_000);
+  utimesSync(oldBrokenPath, oldTime, oldTime);
+
+  const { extension, restoreEnv } = await loadPowerline(agentDir);
+
+  try {
+    const fake = createFakePi();
+    extension(fake.pi);
+    const runtime = createCtx({ cwd, customInputs: [["\x1b[B", "\r"], ["\r"]] });
+    await fake.commands.get("stash-history")?.handler("", runtime.ctx);
+
+    assert.deepEqual(runtime.customTitles, ["Prompt history", "Recent project prompts"]);
+    assert.equal(runtime.text, "project prompt 0");
+    assert.equal(runtime.notifications.some((entry) => entry.level === "warning"), false);
+  } finally {
+    restoreEnv();
+  }
 });


### PR DESCRIPTION
## Summary

Stop automatically restoring stashed editor text after agent runs. Stashes now return only after explicit user action.

Load recent project prompts only when the project source is selected, and bound the project scan to newest session file tails.

Closes #183.
Closes #184.

## Validation

- `node --experimental-strip-types --test tests/stash-shortcut.test.ts`
- `npm run typecheck`
- `git diff --check`
- Fresh read-only review: No issues found

## Performance

The stash-source path no longer lists, stats, reads, or parses project session JSONL files before the first source choice. Project prompt loading has file, per-file byte, total byte, and prompt-count bounds.