### PR TITLE
test: type reply and stash test doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - **Editor stash restore** — Stashed editor text now stays stashed after agent runs and restores only after an explicit `Alt+S` or stash-history action. Closes #183.
 - **Stash history loading** — Recent project prompts now load only when that source is selected, and the project scan is bounded to newest session file tails. Closes #184.
+- **Reply internals** — Narrowed `/reply` to the session and UI members it uses, and kept the new reply/stash test doubles type-checked against those contracts.
 
 ### Fixed
 - **Windows git polling** — Hide spawned git child-process consoles so detached Windows hosts do not flash a visible window on each footer poll or bash completion. Thanks to [@xing-shuyin](https://github.com/xing-shuyin) for #180.

--- a/quote-reply.ts
+++ b/quote-reply.ts
@@ -2,6 +2,13 @@ import type { ExtensionContext, SessionEntry, Theme } from "@earendil-works/pi-c
 import { decodeKittyPrintable, fuzzyFilter, Key, matchesKey, truncateToWidth, visibleWidth, type Component, type OverlayHandle } from "@earendil-works/pi-tui";
 
 type QuoteRole = "assistant" | "user";
+type QuoteReplyUi = Pick<ExtensionContext["ui"], "getEditorText" | "notify" | "select" | "setEditorText"> & Partial<Pick<ExtensionContext["ui"], "custom">>;
+
+interface QuoteReplyContext {
+  mode: ExtensionContext["mode"];
+  sessionManager: Pick<ExtensionContext["sessionManager"], "getBranch">;
+  ui: QuoteReplyUi;
+}
 
 interface QuoteCandidate {
   id: string;
@@ -57,7 +64,7 @@ function buildCandidate(entry: SessionEntry): QuoteCandidate | undefined {
   };
 }
 
-function collectCandidates(ctx: ExtensionContext): QuoteCandidate[] {
+function collectCandidates(ctx: QuoteReplyContext): QuoteCandidate[] {
   const candidates: QuoteCandidate[] = [];
   const branch = ctx.sessionManager.getBranch();
   for (let index = branch.length - 1; index >= 0 && candidates.length < MAX_CANDIDATES; index--) {
@@ -97,7 +104,7 @@ function formatQuote(candidate: QuoteCandidate): string {
   return lines.join("\n");
 }
 
-function insertQuote(ctx: ExtensionContext, candidate: QuoteCandidate): void {
+function insertQuote(ctx: QuoteReplyContext, candidate: QuoteCandidate): void {
   ctx.ui.setEditorText(`${formatQuote(candidate)}${ctx.ui.getEditorText()}`);
   ctx.ui.notify(`Inserted quote from ${candidate.role} message ${candidate.id}.`, "info");
 }
@@ -230,8 +237,8 @@ class QuotePicker implements Component {
   private help(): string { return this.theme.fg("dim", `${this.theme.italic("↑↓")} navigate  ${this.theme.italic("enter")} quote  ${this.theme.italic("esc")} cancel  ${this.theme.italic("⌫")} edit`); }
 }
 
-async function pickCandidate(ctx: ExtensionContext, candidates: QuoteCandidate[]): Promise<QuoteCandidate | undefined> {
-  if (ctx.mode !== "tui") {
+async function pickCandidate(ctx: QuoteReplyContext, candidates: QuoteCandidate[]): Promise<QuoteCandidate | undefined> {
+  if (ctx.mode !== "tui" || !ctx.ui.custom) {
     const options = candidates.slice(0, MAX_RPC_OPTIONS).map((candidate) => `${candidate.id} ${candidate.role}: ${excerpt(candidate.text)}`);
     const selected = await ctx.ui.select("Reply to previous message", options);
     if (!selected) return undefined;
@@ -258,7 +265,7 @@ async function pickCandidate(ctx: ExtensionContext, candidates: QuoteCandidate[]
   }, { overlay: true, overlayOptions: { width: "85%", minWidth: 72, maxHeight: "80%" }, onHandle: (handle) => { overlayHandle = handle; } });
 }
 
-export async function reply(args: string, ctx: ExtensionContext): Promise<void> {
+export async function reply(args: string, ctx: QuoteReplyContext): Promise<void> {
   const candidates = collectCandidates(ctx);
   if (candidates.length === 0) {
     ctx.ui.notify("No user or assistant messages are available to quote.", "warning");

--- a/tests/quote-reply.test.ts
+++ b/tests/quote-reply.test.ts
@@ -1,8 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
 import { reply } from "../quote-reply.ts";
 
-function contextFor(entries: unknown[], editorText = "draft") {
+function contextFor(entries: SessionEntry[], editorText = "draft") {
   let text = editorText;
   const notifications: string[] = [];
   return {
@@ -15,7 +16,7 @@ function contextFor(entries: unknown[], editorText = "draft") {
         notify: (message: string) => { notifications.push(message); },
         select: async () => undefined,
       },
-    } as any,
+    },
     get text() { return text; },
     notifications,
   };
@@ -23,7 +24,7 @@ function contextFor(entries: unknown[], editorText = "draft") {
 
 test("reply quotes a matching message and preserves the current draft", async () => {
   const harness = contextFor([
-    { type: "message", id: "old", timestamp: "2026-08-23T00:00:00.000Z", message: { role: "toolResult", content: [{ type: "text", text: "ignore" }] } },
+    { type: "message", id: "old", timestamp: "2026-08-23T00:00:00.000Z", message: { role: "tool", content: [{ type: "text", text: "ignore" }] } },
     { type: "message", id: "abc123", timestamp: "2026-08-23T00:01:00.000Z", message: { role: "user", content: [{ type: "text", text: "Please inspect this." }] } },
   ]);
 

--- a/tests/stash-shortcut.test.ts
+++ b/tests/stash-shortcut.test.ts
@@ -32,13 +32,53 @@ function sessionLine(text: string, timestamp: number): string {
   });
 }
 
+type FakeTheme = ReturnType<typeof fakeTheme>;
+interface FakeComponent {
+  render(width: number): string[];
+  handleInput(data: string): void;
+}
+type CustomFactory = (
+  tui: { requestRender(): void },
+  theme: FakeTheme,
+  keybindings: Record<string, never>,
+  done: (result: unknown) => void,
+) => FakeComponent;
+interface FakeCtx {
+  cwd: string;
+  hasUI: boolean;
+  model: { name: string; provider: string };
+  modelRegistry: Record<string, never>;
+  ui: {
+    getEditorText(): string;
+    setEditorText(next: string): void;
+    setStatus(key: string, value: string | undefined): void;
+    notify(message: string, level?: string): void;
+    setWorkingMessage(): void;
+    onTerminalInput(handler: (data: string) => unknown): () => void;
+    custom(factory: CustomFactory): Promise<unknown>;
+    select(): Promise<string>;
+    setWidget(): void;
+    setFooter(): void;
+    setHeader(): void;
+    setEditorComponent(): void;
+    getEditorComponent(): undefined;
+  };
+}
+type TestHandler = (event: unknown, ctx: FakeCtx) => Promise<void> | void;
+type TestCommand = { handler: (args: string, ctx: FakeCtx) => Promise<void> | void };
+interface TestPi {
+  on(name: string, handler: TestHandler): void;
+  registerCommand(name: string, command: TestCommand): void;
+  sendUserMessage(): void;
+}
+
 async function loadPowerline(agentDir: string) {
   const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
   process.env.PI_CODING_AGENT_DIR = agentDir;
   const moduleUrl = new URL("../index.ts", import.meta.url);
   const mod = await import(`${moduleUrl.href}?stashTest=${Date.now()}-${Math.random()}`);
   return {
-    extension: mod.default as (pi: any) => void,
+    extension: mod.default as (pi: TestPi) => void,
     restoreEnv: () => {
       if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
       else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
@@ -54,16 +94,16 @@ function fakeTheme() {
 }
 
 function createFakePi() {
-  const handlers = new Map<string, (event: any, ctx: any) => Promise<void>>();
-  const commands = new Map<string, { handler: (args: string, ctx: any) => Promise<void> }>();
+  const handlers = new Map<string, TestHandler>();
+  const commands = new Map<string, TestCommand>();
   return {
     handlers,
     commands,
     pi: {
-      on(name: string, handler: (event: any, ctx: any) => Promise<void>) {
+      on(name: string, handler: TestHandler) {
         handlers.set(name, handler);
       },
-      registerCommand(name: string, command: { handler: (args: string, ctx: any) => Promise<void> }) {
+      registerCommand(name: string, command: TestCommand) {
         commands.set(name, command);
       },
       sendUserMessage() {},
@@ -80,7 +120,7 @@ function createCtx(options: { cwd: string; text?: string; customInputs?: string[
   const customTitles: string[] = [];
   const customInputs = [...(options.customInputs ?? [])];
 
-  const ctx = {
+  const ctx: FakeCtx = {
     cwd: options.cwd,
     hasUI: true,
     model: { name: "test", provider: "test" },
@@ -98,7 +138,7 @@ function createCtx(options: { cwd: string; text?: string; customInputs?: string[
         terminalInput = handler;
         return () => { terminalInput = null; };
       },
-      custom: async (factory: any) => new Promise((resolve) => {
+      custom: async (factory: CustomFactory) => new Promise((resolve) => {
         const done = (result: unknown) => resolve(result);
         const component = factory({ requestRender() {} }, fakeTheme(), {}, done);
         const rendered = component.render(80).join("\n");


### PR DESCRIPTION
## Summary

Narrow `/reply` to the session and UI members it uses, then update the new reply and stash-history test doubles so they type-check without broad `as any` escapes.

## Validation

- `node --experimental-strip-types --test tests/quote-reply.test.ts tests/stash-shortcut.test.ts`
- `npm run typecheck`
- `git diff --check`
- fresh follow-up review: No issues found