### PR TITLE
docs: clarify current powerline layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **Powerline placement** — Clarified that the primary Powerline row can be shown above or below the editor. Thanks to [@smileBeda](https://github.com/smileBeda) for #188.
+
 ## [0.16.0] - 2026-08-25
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Customizes the default [pi](https://github.com/badlogic/pi-mono) editor with a p
 
 **Welcome overlay** — Branded splash screen shown as centered overlay on startup. Shows gradient logo, model info, keyboard tips, loaded AGENTS.md/extensions/skills/templates counts, an approximate initial system-prompt token count, and recent sessions. Auto-dismisses after 30 seconds or on any key press. Set `powerline.welcome` to `false` to disable it while keeping the footer enabled.
 
-**Rounded box design** — Status renders directly in the editor's top border, not as a separate footer.
+**Powerline placement** — The primary Powerline row can be shown above or below the editor.
 
 **Native Pi layout** — Pi owns fixed input, feed scrolling, selection, and terminal behavior; this extension supplies powerline widgets and the custom bash/stash/editor integrations.
 


### PR DESCRIPTION
Closes #188.

This removes the stale README claim that the status row renders inside the editor top border. The current layout uses Powerline rows above or below the editor, so the docs now say that directly.

Validation:
- git diff --check
- Fresh read-only review found no issues
