### PR TITLE
feat: configure compact prompt handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Compact prompt mode** — Added `powerline.queue.compactPromptMode: "native"` so `/compact <text>` can pass `<text>` through to Pi as custom compaction instructions instead of using Powerline's post-compaction queue shorthand.
+
 ### Changed
 - **Powerline placement** — Clarified that the primary Powerline row can be shown above or below the editor. Thanks to [@smileBeda](https://github.com/smileBeda) for #188.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- **Compact prompt mode** — Added `powerline.queue.compactPromptMode: "native"` so `/compact <text>` can pass `<text>` through to Pi as custom compaction instructions instead of using Powerline's post-compaction queue shorthand.
+- **Compact prompt mode** — Added `powerline.queue.compactPromptMode: "native"` so `/compact <text>` can pass `<text>` through to Pi as custom compaction instructions instead of using Powerline's post-compaction queue shorthand. Thanks to [@joshuajbrunner](https://github.com/joshuajbrunner) for #191.
 
 ### Changed
 - **Powerline placement** — Clarified that the primary Powerline row can be shown above or below the editor. Thanks to [@smileBeda](https://github.com/smileBeda) for #188.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Use `/cd <path>` to continue the current conversation from another working direc
 
 Powerline Queue commands:
 
-- `/compact <text>` — compact now and queue `<text>` as the next prompt after successful compaction
+- `/compact <text>` — compact now and queue `<text>` as the next prompt after successful compaction by default
 - `/queue` — open the queued-prompt picker
 - `/queue alias <name> [path]` — save a project alias, defaulting to the current cwd when `path` is omitted
 - `/queue send [id]` / `/queue retry [id]` — deliver a queued prompt now
@@ -61,6 +61,20 @@ Powerline Queue commands:
 - `/queue target <id> @name|global|current` — retarget a queued prompt
 
 Queued data is stored under the Pi agent directory in `powerline-footer/inbox.jsonl` and `powerline-footer/projects.json`. `inbox.jsonl` is a stable read surface for orchestrators and helper agents; each line is a queue item with `id`, `text`, `createdAt`, `updatedAt`, `source`, `target`, `intent`, `status`, and optional `error`. Writes should still go through Powerline commands or the store so locking and atomic writes are preserved.
+
+Set `powerline.queue.compactPromptMode` to `"native"` if you want `/compact <text>` to pass `<text>` through to Pi as custom compaction instructions instead of using Powerline's post-compaction queue shorthand:
+
+```json
+{
+  "powerline": {
+    "queue": {
+      "compactPromptMode": "native"
+    }
+  }
+}
+```
+
+The default mode is `"queue"`, which preserves the existing compact-and-queue behavior.
 
 - `/powerline placement below` — move the primary powerline row below the editor
 - `/powerline placement above` — restore the default placement

--- a/index.ts
+++ b/index.ts
@@ -85,6 +85,7 @@ let config: PowerlineConfig = {
   invalidPlacement: null,
   welcome: true,
   stashSharpSShortcut: false,
+  queue: { compactPromptMode: "queue" },
   workingVibes: {},
 };
 
@@ -3085,7 +3086,9 @@ export default function powerlineFooter(pi: ExtensionAPI) {
         const isFollowUpSubmit = keybindings.matches(data, "app.message.followUp");
         if (!powerlineCompacting && !bashModeActive && isSubmit && typeof ctx.compact === "function") {
           const editorText = editor.getExpandedText().trim();
-          const compactQueuedPrompt = parseCompactQueuedPrompt(editorText);
+          const compactQueuedPrompt = config.queue.compactPromptMode === "queue"
+            ? parseCompactQueuedPrompt(editorText)
+            : null;
           if (editorText === "/compact" || compactQueuedPrompt) {
             editor.addToHistory?.(editorText);
             editor.setText("");

--- a/powerline-config.ts
+++ b/powerline-config.ts
@@ -3,6 +3,8 @@ import { normalizeCostCurrency } from "./currency-rates.ts";
 import { BUILTIN_STATUS_LINE_SEGMENT_IDS } from "./types.ts";
 import type { ColorValue, CustomItemPosition, CustomStatusItem, PowerlinePlacement, PresetDef, StatusLineLayout, StatusLinePreset, StatusLineSegmentId, StatusLineSegmentOptions, StatusLineSeparatorStyle } from "./types.ts";
 
+export type CompactPromptMode = "queue" | "native";
+
 export interface PowerlineConfig {
   preset: StatusLinePreset;
   customItems: CustomStatusItem[];
@@ -16,6 +18,7 @@ export interface PowerlineConfig {
   invalidPlacement: string | null;
   welcome: boolean;
   stashSharpSShortcut: boolean;
+  queue: { compactPromptMode: CompactPromptMode };
   workingVibes: { color?: ColorValue | "rainbow" };
 }
 
@@ -210,6 +213,13 @@ function normalizeLayout(
     : { layout: null, invalidLayoutSegments };
 }
 
+function normalizeQueueOptions(raw: unknown): PowerlineConfig["queue"] {
+  if (!isRecord(raw)) return { compactPromptMode: "queue" };
+  return {
+    compactPromptMode: raw.compactPromptMode === "native" ? "native" : "queue",
+  };
+}
+
 function normalizeSegmentOptions(raw: Record<string, unknown>): StatusLineSegmentOptions {
   const options: StatusLineSegmentOptions = {};
 
@@ -307,6 +317,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     invalidPlacement: null,
     welcome: true,
     stashSharpSShortcut: false,
+    queue: { compactPromptMode: "queue" },
     workingVibes: {},
   };
 
@@ -333,6 +344,7 @@ export function parsePowerlineConfig(value: unknown, presets: readonly StatusLin
     invalidPlacement,
     welcome: value.welcome !== false,
     stashSharpSShortcut: value.stashSharpSShortcut === true,
+    queue: normalizeQueueOptions(value.queue),
     workingVibes: isRecord(value.workingVibes) && typeof value.workingVibes.color === "string" && value.workingVibes.color.trim()
       ? { color: value.workingVibes.color.trim() as ColorValue | "rainbow" }
       : {},

--- a/tests/custom-items.test.ts
+++ b/tests/custom-items.test.ts
@@ -36,6 +36,7 @@ test("parsePowerlineConfig supports object config with custom items", () => {
   assert.equal(config.invalidPlacement, null);
   assert.equal(config.welcome, true);
   assert.equal(config.stashSharpSShortcut, false);
+  assert.deepEqual(config.queue, { compactPromptMode: "queue" });
 });
 
 test("parsePowerlineConfig accepts self-colored custom items", () => {
@@ -168,8 +169,23 @@ test("parsePowerlineConfig validates primary powerline placement", () => {
   assert.equal(invalid.invalidPlacement, "sideways");
 });
 
+test("parsePowerlineConfig supports queue compact prompt mode", () => {
+  const defaultConfig = parsePowerlineConfig({}, ["default", "compact"]);
+  const native = parsePowerlineConfig(
+    { queue: { compactPromptMode: "native" } },
+    ["default", "compact"],
+  );
+  const invalid = parsePowerlineConfig(
+    { queue: { compactPromptMode: "passthrough" } },
+    ["default", "compact"],
+  );
+  const shorthand = parsePowerlineConfig("compact", ["default", "compact"]);
 
-
+  assert.deepEqual(defaultConfig.queue, { compactPromptMode: "queue" });
+  assert.deepEqual(native.queue, { compactPromptMode: "native" });
+  assert.deepEqual(invalid.queue, { compactPromptMode: "queue" });
+  assert.deepEqual(shorthand.queue, { compactPromptMode: "queue" });
+});
 
 test("parsePowerlineConfig supports welcome and legacy sharp-S settings", () => {
   const config = parsePowerlineConfig(


### PR DESCRIPTION
## Summary

Adds `powerline.queue.compactPromptMode` so users can choose how Powerline handles `/compact <text>`.

By default, behavior remains unchanged:

```json
{
  "powerline": {
    "queue": {
      "compactPromptMode": "queue"
    }
  }
}
```

In `"queue"` mode, `/compact <text>` compacts now and queues `<text>` as the next prompt after successful compaction.

Users can opt into native Pi compaction instructions with:

```json
{
  "powerline": {
    "queue": {
      "compactPromptMode": "native"
    }
  }
}
```

In `"native"` mode, Powerline no longer intercepts `/compact <text>` as a queued prompt, allowing Pi to receive `<text>` as custom compaction instructions.

## Why

Powerline currently intercepts `/compact <text>` before Pi’s native command handling sees it. That prevents users from passing custom compaction instructions when Powerline is enabled.

This keeps the existing compact-and-queue shorthand as the default while giving users an opt-in way to restore native `/compact <instructions>` behavior.

## Changes

- Adds `CompactPromptMode` and `powerline.queue.compactPromptMode` config parsing.
- Defaults invalid/missing values to `"queue"` for compatibility.
- Gates `/compact <text>` queue interception on `compactPromptMode === "queue"`.
- Documents the new setting in the README.
- Adds changelog entry and config parser coverage.

## Validation

- `npm run typecheck`
- `npm test`
