### PR TITLE
fix: detect Nerd Fonts via TERM when TERM_PROGRAM is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **Powerline placement** — Clarified that the primary Powerline row can be shown above or below the editor. Thanks to [@smileBeda](https://github.com/smileBeda) for #188.
 
 ### Fixed
+- **Terminal-name heuristic** — Fall back to `TERM` only when `TERM_PROGRAM` is unset when inferring Nerd Font support. Thanks to [@a5ehren](https://github.com/a5ehren) for #192/#195.
 - **Live thinking-level display** — Prefer the authoritative thinking-level selection event over a stale session-start context so the footer updates from `think:off` to the selected level. Thanks to [@csp256](https://github.com/csp256) for #196.
 
 ## [0.16.0] - 2026-08-25

--- a/icons.ts
+++ b/icons.ts
@@ -171,8 +171,10 @@ export function hasNerdFonts(): boolean {
   // Check for Ghostty (survives into tmux via GHOSTTY_RESOURCES_DIR)
   if (process.env.GHOSTTY_RESOURCES_DIR) return true;
   
-  // Check common terminals known to support Nerd Fonts (case-insensitive)
-  const term = (process.env.TERM_PROGRAM || "").toLowerCase();
+  // Check common terminals known to support Nerd Fonts (case-insensitive).
+  // TERM_PROGRAM is not set by all terminals (e.g. kitty sets TERM=xterm-kitty
+  // instead), so check TERM as well.
+  const term = `${process.env.TERM || ""} ${process.env.TERM_PROGRAM || ""}`.toLowerCase();
   const nerdTerms = ["iterm", "wezterm", "kitty", "ghostty", "alacritty"];
   return nerdTerms.some(t => term.includes(t));
 }

--- a/icons.ts
+++ b/icons.ts
@@ -162,7 +162,7 @@ export const ASCII_SEPARATORS: SeparatorChars = {
   dot: ".",
 };
 
-// Detect Nerd Font support (check TERM or specific env var)
+// Infer Nerd Font support from environment overrides and terminal-name heuristics.
 export function hasNerdFonts(): boolean {
   // User can set this env var to force Nerd Fonts
   if (process.env.POWERLINE_NERD_FONTS === "1") return true;
@@ -171,10 +171,9 @@ export function hasNerdFonts(): boolean {
   // Check for Ghostty (survives into tmux via GHOSTTY_RESOURCES_DIR)
   if (process.env.GHOSTTY_RESOURCES_DIR) return true;
   
-  // Check common terminals known to support Nerd Fonts (case-insensitive).
-  // TERM_PROGRAM is not set by all terminals (e.g. kitty sets TERM=xterm-kitty
-  // instead), so check TERM as well.
-  const term = `${process.env.TERM || ""} ${process.env.TERM_PROGRAM || ""}`.toLowerCase();
+  // Use TERM only when TERM_PROGRAM is unset (e.g. kitty uses TERM=xterm-kitty).
+  // Terminal names are a heuristic, not detection of the configured font.
+  const term = (process.env.TERM_PROGRAM ?? process.env.TERM ?? "").toLowerCase();
   const nerdTerms = ["iterm", "wezterm", "kitty", "ghostty", "alacritty"];
   return nerdTerms.some(t => term.includes(t));
 }

--- a/tests/icons.test.ts
+++ b/tests/icons.test.ts
@@ -1,0 +1,23 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { hasNerdFonts } from "../icons.ts";
+
+test("hasNerdFonts detects kitty via TERM when TERM_PROGRAM is unset", () => {
+  const saved = { ...process.env };
+  try {
+    delete process.env.TERM_PROGRAM;
+    delete process.env.POWERLINE_NERD_FONTS;
+    delete process.env.GHOSTTY_RESOURCES_DIR;
+
+    process.env.TERM = "xterm-kitty";
+    assert.equal(hasNerdFonts(), true, "kitty TERM=xterm-kitty should be detected");
+
+    process.env.TERM = "xterm-256color";
+    assert.equal(hasNerdFonts(), false, "plain xterm should not be detected");
+  } finally {
+    for (const key of ["TERM", "TERM_PROGRAM", "POWERLINE_NERD_FONTS", "GHOSTTY_RESOURCES_DIR"]) {
+      if (key in saved) process.env[key] = saved[key];
+      else delete process.env[key];
+    }
+  }
+});

--- a/tests/icons.test.ts
+++ b/tests/icons.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { hasNerdFonts } from "../icons.ts";
 
-test("hasNerdFonts detects kitty via TERM when TERM_PROGRAM is unset", () => {
+test("hasNerdFonts uses TERM only when TERM_PROGRAM is unset and preserves overrides", () => {
   const saved = { ...process.env };
   try {
     delete process.env.TERM_PROGRAM;
@@ -14,6 +14,28 @@ test("hasNerdFonts detects kitty via TERM when TERM_PROGRAM is unset", () => {
 
     process.env.TERM = "xterm-256color";
     assert.equal(hasNerdFonts(), false, "plain xterm should not be detected");
+
+    process.env.TERM = "xterm-kitty";
+    process.env.TERM_PROGRAM = "vscode";
+    assert.equal(hasNerdFonts(), false, "TERM must not override a present TERM_PROGRAM");
+
+    process.env.TERM_PROGRAM = "";
+    assert.equal(hasNerdFonts(), false, "empty TERM_PROGRAM must not fall back to TERM");
+
+    process.env.TERM = "xterm-256color";
+    process.env.TERM_PROGRAM = "WezTerm";
+    assert.equal(hasNerdFonts(), true, "recognized TERM_PROGRAM remains case-insensitive");
+
+    process.env.TERM_PROGRAM = "vscode";
+    process.env.POWERLINE_NERD_FONTS = "1";
+    assert.equal(hasNerdFonts(), true, "explicit enable overrides the terminal heuristic");
+
+    delete process.env.POWERLINE_NERD_FONTS;
+    process.env.GHOSTTY_RESOURCES_DIR = "/ghostty";
+    assert.equal(hasNerdFonts(), true, "Ghostty marker overrides the terminal heuristic");
+
+    process.env.POWERLINE_NERD_FONTS = "0";
+    assert.equal(hasNerdFonts(), false, "explicit disable overrides Ghostty");
   } finally {
     for (const key of ["TERM", "TERM_PROGRAM", "POWERLINE_NERD_FONTS", "GHOSTTY_RESOURCES_DIR"]) {
       if (key in saved) process.env[key] = saved[key];


### PR DESCRIPTION
## Summary
Use `TERM` as a fallback in the existing terminal-name heuristic only when `TERM_PROGRAM` is unset. This covers kitty reporting `TERM=xterm-kitty`; present or empty `TERM_PROGRAM` values keep precedence. Explicit Nerd Font overrides and the Ghostty marker retain their priority.

This is a terminal-name heuristic, not configured-font discovery or a guarantee for every Linux terminal.

Thanks to [@a5ehren](https://github.com/a5ehren) for the contribution and report. Original authorship and Unreleased changelog credit are preserved.

## Validation
- Focused fallback, precedence, and override tests passed.
- Typecheck passed with locked Pi 0.84.1 dependencies.
- Fresh review found no issues on `1d7169befd1852b7dd58ea6483570abf76037edf`.
- Full cross-platform suite is required on the published head before merge.

Closes #195.
