### PR TITLE
fix(git): 会话切换后失效分支与状态缓存

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Changed
 - **Powerline placement** — Clarified that the primary Powerline row can be shown above or below the editor. Thanks to [@smileBeda](https://github.com/smileBeda) for #188.
 
+### Fixed
+- **Git footer after session switch** — `session_start` for `fork`/`resume`/`new` (e.g. `/cd`, `/fork`, `/clone`, `/resume`, `/new`) now invalidates the cached git branch and status, so the footer reflects the new repo immediately instead of showing the previous repo's data until the TTL expires. Thanks to [@lengxf](https://github.com/lengxf) for #192.
+
 ## [0.16.0] - 2026-08-25
 
 ### Highlights

--- a/index.ts
+++ b/index.ts
@@ -1720,6 +1720,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     sessionStartTime = Date.now();
     currentCtx = ctx;
     customCompactionEnabled = detectCustomCompactionEnabled(ctx.cwd);
+    // A session switch (/cd, /fork, /clone, /resume, /new, switchSession) can
+    // land in a different repo. Drop git branch/status cache so the footer
+    // re-fetches for the new cwd instead of showing stale data until the TTL
+    // expires or the next file/git tool_result.
+    if (event.reason === "fork" || event.reason === "resume" || event.reason === "new") {
+      invalidateGitBranch();
+      invalidateGitStatus();
+    }
     lastUserPrompt = "";
     isStreaming = false;
     liveAssistantUsage = null;

--- a/tests/git-session-switch.test.ts
+++ b/tests/git-session-switch.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const indexSource = readFileSync(new URL("../index.ts", import.meta.url), "utf-8");
+
+// Guards the fix for stale git footer info after a session switch lands in a
+// different repo. `/cd` (switchSession -> reason "resume"), `/fork`, `/clone`
+// (`reason "fork"`), `/new` (`reason "new"`), and `/resume` (`reason "resume"`)
+// can all change cwd. The git segment caches branch/status at module scope with
+// a TTL, so without invalidation the footer keeps showing the previous repo's
+// data until the TTL expires or the next file/git tool_result fires.
+test("session_start invalidates git cache when switching into a potentially different repo", () => {
+  // The session_start handler must invalidate both branch and status caches.
+  assert.match(indexSource, /invalidateGitBranch\(\)/);
+  assert.match(indexSource, /invalidateGitStatus\(\)/);
+
+  // Invalidation must be gated on session-switch reasons, not startup/reload
+  // (startup would wrongly report the launch directory as a change).
+  assert.match(indexSource, /event\.reason === "fork" \|\| event\.reason === "resume" \|\| event\.reason === "new"/);
+});


### PR DESCRIPTION
## Problem

After a session switch that lands in a different repo — `/cd`, `/fork`, `/clone`, `/resume`, `/new`, or any `switchSession` — the Powerline git footer keeps showing the **previous repo's** branch and status until the cache TTL expires (or the next `write`/`edit`/`git` `tool_result` happens).

## Root cause

The git segment caches branch/status at module scope (`cachedBranch` / `cachedStatus`) with a TTL. The `session_start` handler updates `currentCtx` and `process.chdir()`, but **never calls `invalidateGitBranch()` / `invalidateGitStatus()`**.

`invalidateGitBranch()`'s own comment already says _"a branch/cwd change may mean a different repo"_, but the invalidation was only wired into `tool_result` / `user_bash` for git commands — not into the session-switch path.

Mapping (verified against pi's `agent-session-runtime.js`):

| Action | `session_start` reason |
|---|---|
| `/cd` (switchSession) | `resume` |
| `/fork`, `/clone` | `fork` |
| `/new` | `new` |
| `/resume` | `resume` |

## Fix

In the `session_start` handler, invalidate both git caches when `reason` is `fork` / `resume` / `new` (i.e. a real session switch — not `startup`/`reload`, which would wrongly report the launch directory as a change).

`startup` and `reload` are intentionally excluded:
- `startup` is the initial launch; reporting it as a cwd change would push the launch dir as a "change".
- `reload` keeps the same cwd.

## Verification

- `npm test` → 207 pass, 0 fail
- `npx tsc --noEmit` → clean
- `git diff --check` → clean

Manual: `/cd ~/other-repo` now updates the footer git segment immediately instead of after TTL.

## Checklist

- [x] Narrow change, only touches the `session_start` handler
- [x] Test added (`tests/git-session-switch.test.ts`) guarding the invalidation wiring
- [x] `CHANGELOG.md` updated under `[Unreleased] → Fixed`
