### PR TITLE
fix: prefer live thinking level selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Changed
 - **Powerline placement** — Clarified that the primary Powerline row can be shown above or below the editor. Thanks to [@smileBeda](https://github.com/smileBeda) for #188.
 
+### Fixed
+- **Live thinking-level display** — Prefer the authoritative thinking-level selection event over a stale session-start context so the footer updates from `think:off` to the selected level. Thanks to [@csp256](https://github.com/csp256) for #196.
+
 ## [0.16.0] - 2026-08-25
 
 ### Highlights

--- a/index.ts
+++ b/index.ts
@@ -28,6 +28,7 @@ import { getAgentPath } from "./paths.ts";
 import { collectHiddenExtensionStatusKeys, getNotificationExtensionStatuses, mergeSegmentOptions, mergeSegmentsWithCustomItems, nextPowerlineSettingWithOptions, nextPowerlineSettingWithPreset, parsePowerlineConfig } from "./powerline-config.ts";
 import { getSeparator } from "./separators.ts";
 import { renderSegment } from "./segments.ts";
+import { resolveThinkingLevelSelection } from "./thinking-level.ts";
 import { getGitStatus, invalidateGitStatus, invalidateGitBranch, subscribeGitUpdates } from "./git-status.ts";
 import { SessionBranchCache, SessionTokenStatsCache } from "./token-stats.ts";
 import { ansi, getFgAnsiCode } from "./colors.ts";
@@ -1846,7 +1847,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   pi.on("thinking_level_select", async (event, ctx) => {
     currentCtx = ctx;
-    currentThinkingLevel = getThinkingLevelFn?.() ?? (typeof event.level === "string" ? event.level : null);
+    currentThinkingLevel = resolveThinkingLevelSelection(event.level, getThinkingLevelFn?.());
     requestImmediateStatusRender({ deferDuringTyping: false });
   });
 

--- a/tests/thinking-level.test.ts
+++ b/tests/thinking-level.test.ts
@@ -1,0 +1,13 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveThinkingLevelSelection } from "../thinking-level.ts";
+
+test("thinking-level selection prefers the live event over stale context", () => {
+  assert.equal(resolveThinkingLevelSelection("medium", "off"), "medium");
+  assert.equal(resolveThinkingLevelSelection("high", "low"), "high");
+});
+
+test("thinking-level selection falls back to context when the event has no level", () => {
+  assert.equal(resolveThinkingLevelSelection(undefined, "low"), "low");
+  assert.equal(resolveThinkingLevelSelection(undefined, undefined), null);
+});

--- a/thinking-level.ts
+++ b/thinking-level.ts
@@ -1,0 +1,6 @@
+export function resolveThinkingLevelSelection(
+  eventLevel: unknown,
+  contextLevel: string | null | undefined,
+): string | null {
+  return typeof eventLevel === "string" ? eventLevel : contextLevel ?? null;
+}


### PR DESCRIPTION
## Summary

Fix the thinking segment staying at `think:off` after the user selects another level.

The `thinking_level_select` event is the authoritative live value, but the handler previously consulted a session-start context getter first. A stale non-null value such as `off` therefore masked `event.level`. This change resolves the event value first and retains the captured context only as a fallback.

A small pure resolver keeps the precedence explicit and provides regression coverage for a live `medium` selection overriding stale `off` context.

## Validation

- `npm test` — 208 passed
- `npm run typecheck`
- `git diff --check`

Fixes #196
