### PR TITLE
perf: discover welcome sessions asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Compact prompt mode** — Added `powerline.queue.compactPromptMode: "native"` so `/compact <text>` can pass `<text>` through to Pi as custom compaction instructions instead of using Powerline's post-compaction queue shorthand. Thanks to [@joshuajbrunner](https://github.com/joshuajbrunner) for #191.
 
 ### Changed
+- **Welcome startup** — Discover recent sessions asynchronously with bounded header reads, cancelling pending discovery when welcome is dismissed or the session changes. Fixes #199.
 - **Powerline placement** — Clarified that the primary Powerline row can be shown above or below the editor. Thanks to [@smileBeda](https://github.com/smileBeda) for #188.
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -1189,7 +1189,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   let stashShortcutInputUnsubscribe: (() => void) | null = null;
   let dismissWelcomeOverlay: (() => void) | null = null;
   let welcomeHeaderActive = false;
-  let welcomeOverlayShouldDismiss = false;
+  let welcomeRequest: AbortController | null = null;
+  let welcomeTimer: ReturnType<typeof setTimeout> | null = null;
   let lastUserPrompt = "";
   let showLastPrompt = true;
   let lastPromptRenderCache: {
@@ -1715,6 +1716,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   // Track session start
   pi.on("session_start", async (event, ctx) => {
+    dismissWelcome(currentCtx ?? ctx);
     shellSession?.dispose();
     shellSession = null;
     sessionGeneration++;
@@ -1768,10 +1770,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
   pi.on("session_shutdown", async (_event, ctx) => {
     sessionGeneration++;
-    dismissWelcomeOverlay?.();
-    dismissWelcomeOverlay = null;
-    welcomeHeaderActive = false;
-    welcomeOverlayShouldDismiss = false;
+    dismissWelcome(ctx);
     statusRenderScheduler.cancel();
     restoreFooterStatusRepaintHook?.();
     restoreFooterStatusRepaintHook = null;
@@ -1986,12 +1985,13 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   }
 
   function dismissWelcome(ctx: any) {
+    welcomeRequest?.abort();
+    welcomeRequest = null;
+    if (welcomeTimer) clearTimeout(welcomeTimer);
+    welcomeTimer = null;
     if (dismissWelcomeOverlay) {
       dismissWelcomeOverlay();
       dismissWelcomeOverlay = null;
-    } else {
-      // The startup overlay mounts after a delay; dismiss it immediately if it appears later.
-      welcomeOverlayShouldDismiss = true;
     }
     if (welcomeHeaderActive) {
       welcomeHeaderActive = false;
@@ -2000,7 +2000,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   }
 
   function dismissWelcomeForInput(ctx: any) {
-    if (!dismissWelcomeOverlay && welcomeOverlayShouldDismiss && !welcomeHeaderActive) return;
+    if (!welcomeRequest && !dismissWelcomeOverlay && !welcomeHeaderActive) return;
     dismissWelcome(ctx);
   }
 
@@ -2401,10 +2401,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           shellSession = null;
           bashTranscript.clear();
           bashModeActive = false;
-          dismissWelcomeOverlay?.();
-          dismissWelcomeOverlay = null;
-          welcomeHeaderActive = false;
-          welcomeOverlayShouldDismiss = false;
+          dismissWelcome(ctx);
           getPromptHistoryState().savedPromptHistory = [];
           stashedEditorText = null;
                 ctx.ui.setStatus("stash", undefined);
@@ -3265,117 +3262,132 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     installPowerlineWidgets(ctx);
   }
 
-  function setupWelcomeHeader(ctx: any) {
-    const modelName = ctx.model?.name || ctx.model?.id || "No model";
-    const providerName = ctx.model?.provider || "Unknown";
-    const loadedCounts = discoverLoadedCounts();
-    const recentSessions = getRecentSessions(3);
-    const initialContextTokens = estimateInitialContextTokens(ctx);
+  function beginWelcomeRequest(ctx: any): AbortController {
+    dismissWelcome(ctx);
+    welcomeRequest = new AbortController();
+    return welcomeRequest;
+  }
 
-    const header = new WelcomeHeader(modelName, providerName, recentSessions, loadedCounts, initialContextTokens);
-    welcomeHeaderActive = true;
-
-    ctx.ui.setHeader(() => {
-      return {
-        render(width: number): string[] {
-          return header.render(width);
-        },
-        invalidate() {
-          header.invalidate();
-        },
-      };
+  function canShowWelcome(ctx: any, request: AbortController, generation: number): boolean {
+    if (request !== welcomeRequest || request.signal.aborted || generation !== sessionGeneration
+      || !enabled || !config.welcome || !ctx.hasUI || isStreaming
+      || ctx.ui.getEditorText()) return false;
+    const sessionEvents = ctx.sessionManager?.getBranch?.() ?? [];
+    return !sessionEvents.some((entry: unknown) => {
+      if (!isRecord(entry)) return false;
+      if (entry.type === "tool_call" || entry.type === "tool_result") return true;
+      return entry.type === "message" && isRecord(entry.message) && entry.message.role === "assistant";
     });
   }
 
+  function setupWelcomeHeader(ctx: any) {
+    const request = beginWelcomeRequest(ctx);
+    const generation = sessionGeneration;
+    // Keep optional archive discovery off the session_start completion path.
+    welcomeTimer = setTimeout(async () => {
+      welcomeTimer = null;
+      try {
+        if (!canShowWelcome(ctx, request, generation)) return;
+        const recentSessions = await getRecentSessions(3, request.signal);
+        if (!canShowWelcome(ctx, request, generation)) return;
+        const modelName = ctx.model?.name || ctx.model?.id || "No model";
+        const providerName = ctx.model?.provider || "Unknown";
+        const loadedCounts = discoverLoadedCounts();
+        const initialContextTokens = estimateInitialContextTokens(ctx);
+
+        const header = new WelcomeHeader(modelName, providerName, recentSessions, loadedCounts, initialContextTokens);
+        welcomeHeaderActive = true;
+        ctx.ui.setHeader(() => header);
+      } catch (error: unknown) {
+        if (!request.signal.aborted || error !== request.signal.reason) {
+          console.debug("[powerline-footer] Welcome header failed:", error);
+        }
+      }
+    }, 0);
+  }
+
   function setupWelcomeOverlay(ctx: any) {
+    const request = beginWelcomeRequest(ctx);
     const modelName = ctx.model?.name || ctx.model?.id || "No model";
     const providerName = ctx.model?.provider || "Unknown";
-    const loadedCounts = discoverLoadedCounts();
-    const recentSessions = getRecentSessions(3);
 
     const overlaySessionGeneration = sessionGeneration;
 
     // Small delay to let pi-mono finish initialization
-    setTimeout(() => {
-      if (!enabled || welcomeOverlayShouldDismiss || isStreaming || overlaySessionGeneration !== sessionGeneration) {
-        welcomeOverlayShouldDismiss = false;
-        return;
-      }
+    welcomeTimer = setTimeout(async () => {
+      welcomeTimer = null;
+      try {
+        if (!canShowWelcome(ctx, request, overlaySessionGeneration)) return;
+        const recentSessions = await getRecentSessions(3, request.signal);
+        if (!canShowWelcome(ctx, request, overlaySessionGeneration)) return;
+        const loadedCounts = discoverLoadedCounts();
+        const initialContextTokens = estimateInitialContextTokens(ctx);
 
-      const sessionEvents = ctx.sessionManager?.getBranch?.() ?? [];
-      const hasActivity = sessionEvents.some((entry: unknown) => {
-        if (!isRecord(entry)) return false;
-        if (entry.type === "tool_call" || entry.type === "tool_result") return true;
-        return entry.type === "message" && isRecord(entry.message) && entry.message.role === "assistant";
-      });
-      if (hasActivity) {
-        return;
-      }
+        void ctx.ui.custom(
+          (tui: any, _theme: any, _keybindings: any, done: (result: void) => void) => {
+            if (!canShowWelcome(ctx, request, overlaySessionGeneration)) {
+              done();
+              return { render: () => [], invalidate() {} };
+            }
+            const welcome = new WelcomeComponent(
+              modelName,
+              providerName,
+              recentSessions,
+              loadedCounts,
+              initialContextTokens,
+            );
 
-      const initialContextTokens = estimateInitialContextTokens(ctx);
+            let countdown = 30;
+            let dismissed = false;
+            let interval: ReturnType<typeof setInterval> | null = null;
 
-      ctx.ui.custom(
-        (tui: any, _theme: any, _keybindings: any, done: (result: void) => void) => {
-          const welcome = new WelcomeComponent(
-            modelName,
-            providerName,
-            recentSessions,
-            loadedCounts,
-            initialContextTokens,
-          );
-
-          let countdown = 30;
-          let dismissed = false;
-          let interval: ReturnType<typeof setInterval> | null = null;
-
-          const dismiss = () => {
-            if (dismissed) return;
-            dismissed = true;
-            if (interval) clearInterval(interval);
-            dismissWelcomeOverlay = null;
-            done();
-          };
-
-          interval = setInterval(() => {
-            if (dismissed) return;
-            countdown--;
-            welcome.setCountdown(countdown);
-            tui.requestRender();
-            if (countdown <= 0) dismiss();
-          }, 1000);
-
-          dismissWelcomeOverlay = dismiss;
-
-          if (welcomeOverlayShouldDismiss) {
-            welcomeOverlayShouldDismiss = false;
-            dismiss();
-          }
-
-          return {
-            focused: false,
-            wantsKeyRelease: true,
-            invalidate: () => welcome.invalidate(),
-            render: (width: number) => welcome.render(width),
-            handleInput: (data: string) => {
-              dismiss();
-              if (!isKeyRelease(data)) currentEditor?.handleInput(data);
-            },
-            dispose: () => {
+            const dismiss = () => {
+              if (dismissed) return;
               dismissed = true;
               if (interval) clearInterval(interval);
-            },
-          };
-        },
-        {
-          overlay: true,
-          overlayOptions: () => ({
-            verticalAlign: "center",
-            horizontalAlign: "center",
-          }),
-        },
-      ).catch((error: unknown) => {
-        console.debug("[powerline-footer] Welcome overlay failed:", error);
-      });
+              request.abort();
+              if (welcomeRequest === request) welcomeRequest = null;
+              dismissWelcomeOverlay = null;
+              done();
+            };
+
+            interval = setInterval(() => {
+              if (dismissed) return;
+              countdown--;
+              welcome.setCountdown(countdown);
+              tui.requestRender();
+              if (countdown <= 0) dismiss();
+            }, 1000);
+
+            dismissWelcomeOverlay = dismiss;
+
+            return {
+              focused: false,
+              wantsKeyRelease: true,
+              invalidate: () => welcome.invalidate(),
+              render: (width: number) => welcome.render(width),
+              handleInput: (data: string) => {
+                dismiss();
+                if (!isKeyRelease(data)) currentEditor?.handleInput(data);
+              },
+              dispose: dismiss,
+            };
+          },
+          {
+            overlay: true,
+            overlayOptions: () => ({
+              verticalAlign: "center",
+              horizontalAlign: "center",
+            }),
+          },
+        ).catch((error: unknown) => {
+          console.debug("[powerline-footer] Welcome overlay failed:", error);
+        });
+      } catch (error: unknown) {
+        if (!request.signal.aborted || error !== request.signal.reason) {
+          console.debug("[powerline-footer] Welcome overlay failed:", error);
+        }
+      }
     }, 100);
   }
 }

--- a/tests/welcome.test.ts
+++ b/tests/welcome.test.ts
@@ -252,8 +252,8 @@ test("getRecentSessions follows nested directory links without looping", async (
   });
 });
 
-type WelcomeView = { render(width: number): string[]; handleInput?(data: string): void; dispose?(): void };
-type WelcomeEditor = { getText(): string; setText(text: string): void; handleInput(data: string): void };
+type WelcomeView = { render(width: number): string[]; handleInput?(data: string): void };
+type WelcomeEditor = { getText(): string; handleInput(data: string): void };
 
 async function welcomeHarness(t: test.TestContext, home: string, quietStartup: boolean) {
   const agentDir = join(home, ".pi", "agent");
@@ -264,42 +264,32 @@ async function welcomeHarness(t: test.TestContext, home: string, quietStartup: b
   const { default: extension } = await import("../index.ts");
   const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
   const timeouts = new Map<object, () => unknown>();
-  const intervals = new Map<object, () => unknown>();
   t.mock.method(globalThis, "setTimeout", (callback: () => unknown) => {
     const handle = {};
     timeouts.set(handle, callback);
     return handle;
   });
   t.mock.method(globalThis, "clearTimeout", (handle: object) => timeouts.delete(handle));
-  t.mock.method(globalThis, "setInterval", (callback: () => unknown) => {
-    const handle = {};
-    intervals.set(handle, callback);
-    return handle;
-  });
-  t.mock.method(globalThis, "clearInterval", (handle: object) => intervals.delete(handle));
   const tui = { requestRender() {}, terminal: { columns: 96, rows: 30 } };
   let editor: WelcomeEditor;
-  let header: WelcomeView | undefined;
-  let overlay: WelcomeView | undefined;
+  let view: WelcomeView | undefined;
   let installations = 0;
-  const branch: unknown[] = [];
   const ctx = {
     cwd: home, hasUI: true, model: { name: "Test model", provider: "test" }, modelRegistry: {},
-    sessionManager: { getBranch: () => branch, getSessionId: () => "welcome-test" },
+    sessionManager: { getBranch: () => [], getSessionId: () => "welcome-test" },
     ui: {
       getEditorText: () => editor?.getText() ?? "",
-      setEditorText: (text: string) => editor.setText(text),
       setEditorComponent(factory?: (tui: object, theme: object, keys: object) => WelcomeEditor) {
         if (factory) editor = factory(tui, {}, KeybindingsManager.create());
       },
       getEditorComponent: () => undefined,
       setHeader(factory?: () => WelcomeView) {
-        header = factory?.();
-        if (header) installations++;
+        view = factory?.();
+        if (view) installations++;
       },
       custom(factory: (tui: object, theme: object, keys: object, done: () => void) => WelcomeView) {
         return new Promise<void>((resolve) => {
-          overlay = factory(tui, {}, {}, () => { overlay = undefined; resolve(); });
+          view = factory(tui, {}, {}, () => { view = undefined; resolve(); });
           installations++;
         });
       },
@@ -309,32 +299,29 @@ async function welcomeHarness(t: test.TestContext, home: string, quietStartup: b
   };
   type Handler = (event: { reason?: string }, context: typeof ctx) => unknown;
   const handlers = new Map<string, Handler>();
-  const commands = new Map<string, { handler(args: string, context: typeof ctx): unknown }>();
   const pi = {
     on: (name: string, handler: Handler) => handlers.set(name, handler),
-    registerCommand: (name: string, command: { handler(args: string, context: typeof ctx): unknown }) => commands.set(name, command),
+    registerCommand() {},
     sendUserMessage() {},
   };
   (extension as unknown as (api: typeof pi) => void)(pi);
   return {
-    ctx, branch,
-    get header() { return header; }, get overlay() { return overlay; },
+    ctx,
+    get view() { return view; },
     get installations() { return installations; },
     type: (text: string) => editor.handleInput(text),
     event: async (name: string, reason?: string) => { await handlers.get(name)?.({ reason }, ctx); },
-    disable: async () => { await commands.get("powerline")?.handler("", ctx); },
     runStartupWork: () => {
       const callbacks = [...timeouts.values()];
       timeouts.clear();
       return Promise.all(callbacks.map((callback) => callback()));
     },
-    tickCountdown: () => { for (const callback of [...intervals.values()]) callback(); },
   };
 }
 
-test("pending welcome discovery rechecks cancellation and activity before installing UI", async (t) => {
+test("pending welcome discovery is cancelled by typing or nonblocking shutdown", async (t) => {
   for (const quiet of [true, false]) {
-    for (const action of ["typing", "disable", "replacement", "shutdown", "activity"] as const) {
+    for (const action of ["typing", "shutdown"] as const) {
       await t.test(`${quiet ? "header" : "overlay"}: ${action}`, async (t) => {
         await withTemporaryHome(async (home) => {
           const harness = await welcomeHarness(t, home, quiet);
@@ -358,12 +345,6 @@ test("pending welcome discovery rechecks cancellation and activity before instal
               harness.type("x");
               harness.type("\x7f"); // Empty again: cancellation, not draft text, must prevent resurrection.
               assert.equal(harness.ctx.ui.getEditorText(), "");
-            } else if (action === "disable") {
-              await harness.disable();
-            } else if (action === "replacement") {
-              await harness.event("session_start", "reload");
-            } else if (action === "activity") {
-              harness.branch.push({ type: "message", message: { role: "assistant" } });
             } else {
               // Shutdown must finish even while the filesystem operation remains blocked.
               await harness.event("session_shutdown");
@@ -384,7 +365,7 @@ test("pending welcome discovery rechecks cancellation and activity before instal
   }
 });
 
-test("welcome lifecycle installs eligible UI, preserves overlay forwarding and countdown", async (t) => {
+test("eligible welcome installs and dismisses without losing input", async (t) => {
   for (const quiet of [true, false]) {
     await t.test(quiet ? "header" : "overlay", async (t) => {
       await withTemporaryHome(async (home) => {
@@ -392,28 +373,17 @@ test("welcome lifecycle installs eligible UI, preserves overlay forwarding and c
         try {
           await harness.event("session_start", "startup");
           await harness.runStartupWork();
-          const view = quiet ? harness.header : harness.overlay;
+          const view = harness.view;
           assert.ok(view);
           assert.match(view.render(96).join("\n"), /Test model/);
           if (!quiet) {
-            harness.tickCountdown();
-            assert.match(view.render(96).join("\n"), /29s/);
             view.handleInput?.("x");
-            assert.equal(harness.overlay, undefined);
             assert.equal(harness.ctx.ui.getEditorText(), "x");
           } else {
             harness.type("x");
-            assert.equal(harness.header, undefined);
           }
+          assert.equal(harness.view, undefined);
           assert.equal(harness.installations, 1);
-          if (!quiet) {
-            harness.ctx.ui.setEditorText("");
-            await harness.event("session_start", "startup");
-            await harness.runStartupWork();
-            assert.ok(harness.overlay);
-            for (let second = 0; second < 30; second++) harness.tickCountdown();
-            assert.equal(harness.overlay, undefined);
-          }
         } finally {
           await harness.event("session_shutdown");
           t.mock.restoreAll();

--- a/tests/welcome.test.ts
+++ b/tests/welcome.test.ts
@@ -1,11 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
+import fsPromises from "node:fs/promises";
+import { syncBuiltinESMExports } from "node:module";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { discoverLoadedCounts, getRecentSessions, WelcomeHeader } from "../welcome.ts";
-
-const indexSource = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
 
 test("discoverLoadedCounts ignores dangling skill symlinks", () => {
   const root = mkdtempSync(join(tmpdir(), "powerline-welcome-"));
@@ -51,7 +52,7 @@ test("discoverLoadedCounts ignores dangling skill symlinks", () => {
   }
 });
 
-function withTemporaryHome(run: (home: string) => void): void {
+async function withTemporaryHome(run: (home: string) => void | Promise<void>): Promise<void> {
   const home = mkdtempSync(join(tmpdir(), "powerline-welcome-home-"));
   const originalHome = process.env.HOME;
   const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
@@ -59,7 +60,7 @@ function withTemporaryHome(run: (home: string) => void): void {
   try {
     process.env.HOME = home;
     delete process.env.PI_CODING_AGENT_DIR;
-    run(home);
+    await run(home);
   } finally {
     if (originalHome === undefined) {
       delete process.env.HOME;
@@ -93,32 +94,20 @@ test("welcome renders the initial system prompt token estimate", () => {
   for (const output of withoutEstimate) {
     assert.doesNotMatch(output, /initial prompt tokens/);
   }
-  assert.match(indexSource, /new WelcomeHeader\(modelName, providerName, recentSessions, loadedCounts, initialContextTokens\)/);
-
-  const overlayStart = indexSource.indexOf("function setupWelcomeOverlay");
-  const delayStart = indexSource.indexOf("setTimeout(() => {", overlayStart);
-  const activityGuardStart = indexSource.indexOf("if (hasActivity) {", delayStart);
-  const estimateStart = indexSource.indexOf("const initialContextTokens = estimateInitialContextTokens(ctx);", overlayStart);
-  const componentStart = indexSource.indexOf("new WelcomeComponent(", overlayStart);
-  assert.ok(overlayStart >= 0);
-  assert.ok(delayStart > overlayStart);
-  assert.ok(activityGuardStart > delayStart);
-  assert.ok(estimateStart > activityGuardStart);
-  assert.ok(componentStart > estimateStart);
 });
 
-test("getRecentSessions prefers cwd basename from session header", () => {
-  withTemporaryHome((home) => {
+test("getRecentSessions prefers cwd basename from session header", async () => {
+  await withTemporaryHome(async (home) => {
     const sessionsDir = join(home, ".pi", "agent", "sessions", "--Users-nico-dev-encoded-name--");
     mkdirSync(sessionsDir, { recursive: true });
     writeFileSync(join(sessionsDir, "session.jsonl"), JSON.stringify({ cwd: "/Users/nico/dev/my-dashed-project" }) + "\n");
 
-    assert.equal(getRecentSessions(1)[0]?.name, "my-dashed-project");
+    assert.equal((await getRecentSessions(1))[0]?.name, "my-dashed-project");
   });
 });
 
-test("getRecentSessions falls back to encoded directory when header cwd is unusable", () => {
-  withTemporaryHome((home) => {
+test("getRecentSessions falls back to encoded directory when header cwd is unusable", async () => {
+  await withTemporaryHome(async (home) => {
     const root = join(home, ".pi", "agent", "sessions");
     const cases = [
       ["invalid-json", "not-json\n"],
@@ -132,14 +121,14 @@ test("getRecentSessions falls back to encoded directory when header cwd is unusa
       writeFileSync(join(sessionsDir, "session.jsonl"), content);
     }
 
-    const names = getRecentSessions(10).map((session) => session.name);
+    const names = (await getRecentSessions(10)).map((session) => session.name);
     assert.ok(names.includes("json"));
     assert.ok(names.includes("cwd"));
   });
 });
 
-test("welcome discovery respects PI_CODING_AGENT_DIR for agent-global files", () => {
-  withTemporaryHome((home) => {
+test("welcome discovery respects PI_CODING_AGENT_DIR for agent-global files", async () => {
+  await withTemporaryHome((home) => {
     const root = mkdtempSync(join(tmpdir(), "powerline-welcome-agent-dir-"));
     const project = join(root, "project");
     const agentDir = join(root, "agent-dir");
@@ -173,36 +162,8 @@ test("welcome discovery respects PI_CODING_AGENT_DIR for agent-global files", ()
   });
 });
 
-test("welcome input dismissal is synchronous", () => {
-  const dismissForInputStart = indexSource.indexOf("function dismissWelcomeForInput");
-  const directDismissStart = indexSource.indexOf("dismissWelcome(ctx);", dismissForInputStart);
-  const inputHandlerStart = indexSource.indexOf("const handlePowerlineEditorInput = (data: string) => {");
-  const inputDismissStart = indexSource.indexOf("dismissWelcomeForInput(ctx);", inputHandlerStart);
-  const printableStart = indexSource.indexOf("if (isPrintableInput(data))", inputHandlerStart);
-
-  assert.ok(dismissForInputStart >= 0);
-  assert.ok(directDismissStart > dismissForInputStart);
-  assert.ok(inputDismissStart > inputHandlerStart);
-  assert.ok(printableStart > inputDismissStart);
-  assert.equal(indexSource.includes("welcomeDismissScheduler"), false);
-});
-
-test("welcome overlay forwards the dismissing keypress to the editor", () => {
-  const overlayStart = indexSource.indexOf("function setupWelcomeOverlay");
-  const handleInputStart = indexSource.indexOf("handleInput: (data: string) => {", overlayStart);
-  const wantsKeyReleaseStart = indexSource.indexOf("wantsKeyRelease: true,", overlayStart);
-  const dismissStart = indexSource.indexOf("dismiss();", handleInputStart);
-  const forwardStart = indexSource.indexOf("if (!isKeyRelease(data)) currentEditor?.handleInput(data);", handleInputStart);
-
-  assert.ok(overlayStart >= 0);
-  assert.ok(wantsKeyReleaseStart > overlayStart);
-  assert.ok(handleInputStart > wantsKeyReleaseStart);
-  assert.ok(dismissStart > handleInputStart);
-  assert.ok(forwardStart > dismissStart);
-});
-
-test("getRecentSessions reads custom agent sessions and existing legacy sessions", () => {
-  withTemporaryHome((home) => {
+test("getRecentSessions reads custom agent sessions and existing legacy sessions", async () => {
+  await withTemporaryHome(async (home) => {
     const root = mkdtempSync(join(tmpdir(), "powerline-welcome-sessions-"));
     const agentDir = join(root, "agent-dir");
 
@@ -215,11 +176,249 @@ test("getRecentSessions reads custom agent sessions and existing legacy sessions
       writeFileSync(join(customSessionDir, "session.jsonl"), JSON.stringify({ cwd: "/tmp/custom-project" }) + "\n");
       writeFileSync(join(legacySessionDir, "session.jsonl"), JSON.stringify({ cwd: "/tmp/legacy-project" }) + "\n");
 
-      const names = getRecentSessions(10).map((session) => session.name);
+      const names = (await getRecentSessions(10)).map((session) => session.name);
       assert.ok(names.includes("custom-project"));
       assert.ok(names.includes("legacy-project"));
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
   });
+});
+
+test("getRecentSessions selects newest distinct projects across a large nested archive", async () => {
+  await withTemporaryHome(async (home) => {
+    const root = join(home, ".pi", "agent", "sessions");
+    const nested = join(root, "--encoded--", "artifacts", "nested");
+    mkdirSync(nested, { recursive: true });
+    const now = Date.now();
+    for (let i = 0; i < 1000; i++) {
+      const file = join(nested, `${i}.jsonl`);
+      writeFileSync(file, JSON.stringify({ cwd: "/projects/older" }) + "\n");
+      utimesSync(file, (now - 86_400_000) / 1000, (now - 86_400_000) / 1000);
+    }
+    const recent = [
+      ["a.jsonl", JSON.stringify({ cwd: "/projects/my-dashed-project" }), 60_000],
+      ["b.jsonl", JSON.stringify({ cwd: "/other/my-dashed-project" }), 120_000],
+      ["c.jsonl", "not-json", 180_000],
+      ["d.jsonl", JSON.stringify({ cwd: "/projects/third" }), 240_000],
+    ] as const;
+    for (const [name, header, age] of recent) {
+      const file = join(nested, name);
+      writeFileSync(file, header + "\n" + "ignored body".repeat(1000));
+      utimesSync(file, (now - age) / 1000, (now - age) / 1000);
+    }
+
+    assert.deepEqual(await getRecentSessions(), [
+      { name: "my-dashed-project", timeAgo: "1m ago" },
+      { name: "nested", timeAgo: "3m ago" },
+      { name: "third", timeAgo: "4m ago" },
+    ]);
+  });
+});
+
+test("getRecentSessions rejects pre-aborted and in-flight discovery without partial results", async () => {
+  await withTemporaryHome(async (home) => {
+    const root = join(home, ".pi", "agent", "sessions");
+    mkdirSync(root, { recursive: true });
+    for (let i = 0; i < 100; i++) {
+      writeFileSync(join(root, `${i}.jsonl`), JSON.stringify({ cwd: `/projects/${i}` }) + "\n");
+    }
+    const controller = new AbortController();
+    controller.abort();
+    await assert.rejects(getRecentSessions(3, controller.signal), { name: "AbortError" });
+
+    const running = new AbortController();
+    const result = getRecentSessions(3, running.signal);
+    const rejected = assert.rejects(result, { name: "AbortError" });
+    await setImmediate();
+    running.abort();
+    await rejected;
+    // Cleanup immediately after completion also exercises closed handles on Windows.
+    rmSync(root, { recursive: true });
+    assert.deepEqual(await getRecentSessions(), []);
+  });
+});
+
+test("getRecentSessions follows nested directory links without looping", async () => {
+  await withTemporaryHome(async (home) => {
+    const root = join(home, ".pi", "agent", "sessions");
+    const archive = join(home, "archive");
+    mkdirSync(root, { recursive: true });
+    mkdirSync(archive);
+    writeFileSync(join(archive, "session.jsonl"), JSON.stringify({ cwd: "/projects/linked" }) + "\n");
+    symlinkSync(archive, join(root, "linked"), process.platform === "win32" ? "junction" : "dir");
+    symlinkSync(root, join(archive, "cycle"), process.platform === "win32" ? "junction" : "dir");
+    assert.deepEqual(await getRecentSessions(), [{ name: "linked", timeAgo: "just now" }]);
+  });
+});
+
+type WelcomeView = { render(width: number): string[]; handleInput?(data: string): void; dispose?(): void };
+type WelcomeEditor = { getText(): string; setText(text: string): void; handleInput(data: string): void };
+
+async function welcomeHarness(t: test.TestContext, home: string, quietStartup: boolean) {
+  const agentDir = join(home, ".pi", "agent");
+  mkdirSync(agentDir, { recursive: true });
+  writeFileSync(join(agentDir, "settings.json"), JSON.stringify({
+    quietStartup, powerline: { welcome: true }, bashMode: { completions: false },
+  }));
+  const { default: extension } = await import("../index.ts");
+  const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
+  const timeouts = new Map<object, () => unknown>();
+  const intervals = new Map<object, () => unknown>();
+  t.mock.method(globalThis, "setTimeout", (callback: () => unknown) => {
+    const handle = {};
+    timeouts.set(handle, callback);
+    return handle;
+  });
+  t.mock.method(globalThis, "clearTimeout", (handle: object) => timeouts.delete(handle));
+  t.mock.method(globalThis, "setInterval", (callback: () => unknown) => {
+    const handle = {};
+    intervals.set(handle, callback);
+    return handle;
+  });
+  t.mock.method(globalThis, "clearInterval", (handle: object) => intervals.delete(handle));
+  const tui = { requestRender() {}, terminal: { columns: 96, rows: 30 } };
+  let editor: WelcomeEditor;
+  let header: WelcomeView | undefined;
+  let overlay: WelcomeView | undefined;
+  let installations = 0;
+  const branch: unknown[] = [];
+  const ctx = {
+    cwd: home, hasUI: true, model: { name: "Test model", provider: "test" }, modelRegistry: {},
+    sessionManager: { getBranch: () => branch, getSessionId: () => "welcome-test" },
+    ui: {
+      getEditorText: () => editor?.getText() ?? "",
+      setEditorText: (text: string) => editor.setText(text),
+      setEditorComponent(factory?: (tui: object, theme: object, keys: object) => WelcomeEditor) {
+        if (factory) editor = factory(tui, {}, KeybindingsManager.create());
+      },
+      getEditorComponent: () => undefined,
+      setHeader(factory?: () => WelcomeView) {
+        header = factory?.();
+        if (header) installations++;
+      },
+      custom(factory: (tui: object, theme: object, keys: object, done: () => void) => WelcomeView) {
+        return new Promise<void>((resolve) => {
+          overlay = factory(tui, {}, {}, () => { overlay = undefined; resolve(); });
+          installations++;
+        });
+      },
+      setStatus() {}, setWidget() {}, setFooter() {}, setWorkingMessage() {}, notify() {},
+      onTerminalInput: () => () => {},
+    },
+  };
+  type Handler = (event: { reason?: string }, context: typeof ctx) => unknown;
+  const handlers = new Map<string, Handler>();
+  const commands = new Map<string, { handler(args: string, context: typeof ctx): unknown }>();
+  const pi = {
+    on: (name: string, handler: Handler) => handlers.set(name, handler),
+    registerCommand: (name: string, command: { handler(args: string, context: typeof ctx): unknown }) => commands.set(name, command),
+    sendUserMessage() {},
+  };
+  (extension as unknown as (api: typeof pi) => void)(pi);
+  return {
+    ctx, branch,
+    get header() { return header; }, get overlay() { return overlay; },
+    get installations() { return installations; },
+    type: (text: string) => editor.handleInput(text),
+    event: async (name: string, reason?: string) => { await handlers.get(name)?.({ reason }, ctx); },
+    disable: async () => { await commands.get("powerline")?.handler("", ctx); },
+    runStartupWork: () => {
+      const callbacks = [...timeouts.values()];
+      timeouts.clear();
+      return Promise.all(callbacks.map((callback) => callback()));
+    },
+    tickCountdown: () => { for (const callback of [...intervals.values()]) callback(); },
+  };
+}
+
+test("pending welcome discovery rechecks cancellation and activity before installing UI", async (t) => {
+  for (const quiet of [true, false]) {
+    for (const action of ["typing", "disable", "replacement", "shutdown", "activity"] as const) {
+      await t.test(`${quiet ? "header" : "overlay"}: ${action}`, async (t) => {
+        await withTemporaryHome(async (home) => {
+          const harness = await welcomeHarness(t, home, quiet);
+          const entered = Promise.withResolvers<void>();
+          const release = Promise.withResolvers<void>();
+          const realpath = fsPromises.realpath;
+          t.mock.method(fsPromises, "realpath", async (path: string) => {
+            if (path === join(home, ".pi", "agent", "sessions")) {
+              entered.resolve();
+              await release.promise;
+            }
+            return realpath(path);
+          });
+          syncBuiltinESMExports();
+          let operation: Promise<unknown> | undefined;
+          try {
+            await harness.event("session_start", "startup");
+            operation = harness.runStartupWork();
+            await entered.promise;
+            if (action === "typing") {
+              harness.type("x");
+              harness.type("\x7f"); // Empty again: cancellation, not draft text, must prevent resurrection.
+              assert.equal(harness.ctx.ui.getEditorText(), "");
+            } else if (action === "disable") {
+              await harness.disable();
+            } else if (action === "replacement") {
+              await harness.event("session_start", "reload");
+            } else if (action === "activity") {
+              harness.branch.push({ type: "message", message: { role: "assistant" } });
+            } else {
+              // Shutdown must finish even while the filesystem operation remains blocked.
+              await harness.event("session_shutdown");
+            }
+            release.resolve();
+            await operation;
+            assert.equal(harness.installations, 0);
+          } finally {
+            release.resolve();
+            await operation;
+            await harness.event("session_shutdown");
+            t.mock.restoreAll();
+            syncBuiltinESMExports();
+          }
+        });
+      });
+    }
+  }
+});
+
+test("welcome lifecycle installs eligible UI, preserves overlay forwarding and countdown", async (t) => {
+  for (const quiet of [true, false]) {
+    await t.test(quiet ? "header" : "overlay", async (t) => {
+      await withTemporaryHome(async (home) => {
+        const harness = await welcomeHarness(t, home, quiet);
+        try {
+          await harness.event("session_start", "startup");
+          await harness.runStartupWork();
+          const view = quiet ? harness.header : harness.overlay;
+          assert.ok(view);
+          assert.match(view.render(96).join("\n"), /Test model/);
+          if (!quiet) {
+            harness.tickCountdown();
+            assert.match(view.render(96).join("\n"), /29s/);
+            view.handleInput?.("x");
+            assert.equal(harness.overlay, undefined);
+            assert.equal(harness.ctx.ui.getEditorText(), "x");
+          } else {
+            harness.type("x");
+            assert.equal(harness.header, undefined);
+          }
+          assert.equal(harness.installations, 1);
+          if (!quiet) {
+            harness.ctx.ui.setEditorText("");
+            await harness.event("session_start", "startup");
+            await harness.runStartupWork();
+            assert.ok(harness.overlay);
+            for (let second = 0; second < 30; second++) harness.tickCountdown();
+            assert.equal(harness.overlay, undefined);
+          }
+        } finally {
+          await harness.event("session_shutdown");
+          t.mock.restoreAll();
+        }
+      });
+    });
+  }
 });

--- a/welcome.ts
+++ b/welcome.ts
@@ -1,9 +1,10 @@
-import { closeSync, existsSync, openSync, readFileSync, readSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { open, opendir, realpath, stat } from "node:fs/promises";
 import { join, basename } from "node:path";
 import type { Component } from "@earendil-works/pi-tui";
 import { truncateToWidth as tuiTruncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { ansi, fgOnly, getFgAnsiCode } from "./colors.ts";
-import { getAgentPath, getAgentSessionDirs, getHomeDir } from "./paths.ts";
+import { getAgentPath, getLegacyPiPath, getHomeDir } from "./paths.ts";
 
 export interface RecentSession {
   name: string;
@@ -564,12 +565,15 @@ export function discoverLoadedCounts(): LoadedCounts {
 /**
  * Get recent sessions from the sessions directory.
  */
-function readSessionHeaderProjectName(filePath: string): string | null {
-  let fd: number | null = null;
+async function readSessionHeaderProjectName(filePath: string, signal?: AbortSignal): Promise<string | null> {
+  let file: Awaited<ReturnType<typeof open>> | undefined;
   try {
-    fd = openSync(filePath, "r");
+    signal?.throwIfAborted();
+    file = await open(filePath, "r");
+    signal?.throwIfAborted();
     const buffer = Buffer.alloc(SESSION_HEADER_READ_BYTES);
-    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+    signal?.throwIfAborted();
     const firstLine = buffer.toString("utf8", 0, bytesRead).split(/\r?\n/, 1)[0]?.trim();
     if (!firstLine) return null;
 
@@ -581,9 +585,10 @@ function readSessionHeaderProjectName(filePath: string): string | null {
 
     return basename(cwd) || cwd;
   } catch {
+    signal?.throwIfAborted();
     return null;
   } finally {
-    if (fd !== null) closeSync(fd);
+    await file?.close();
   }
 }
 
@@ -597,48 +602,63 @@ function sessionProjectNameFromDirectory(dir: string): string {
   return parts[parts.length - 1] || parentName;
 }
 
-export function getRecentSessions(maxCount: number = 3): RecentSession[] {
-  const sessionsDirs = getAgentSessionDirs();
-  
-  const sessions: { name: string; mtime: number }[] = [];
-  
-  function scanDir(dir: string) {
-    if (!existsSync(dir)) return;
+/**
+ * Collect metadata asynchronously, then read bounded headers newest-first.
+ * I/O is serial: at most one directory handle and one filesystem operation are
+ * active at a time. Abort rejects after the current operation and closes handles.
+ */
+export async function getRecentSessions(maxCount: number = 3, signal?: AbortSignal): Promise<RecentSession[]> {
+  signal?.throwIfAborted();
+  if (maxCount === 0) return [];
+  const pendingDirs = [...new Set([getAgentPath("sessions"), getLegacyPiPath("sessions")])]
+    .reverse().map(dir => ({ dir, ancestors: [] as string[] }));
+  const sessions: { filePath: string; dir: string; mtime: number }[] = [];
+
+  while (pendingDirs.length > 0) {
+    signal?.throwIfAborted();
+    const { dir, ancestors } = pendingDirs.pop()!;
     try {
-      const entries = readdirSync(dir);
-      for (const entry of entries) {
-        const entryPath = join(dir, entry);
+      const canonicalDir = await realpath(dir);
+      signal?.throwIfAborted();
+      if (ancestors.includes(canonicalDir)) continue;
+      const childAncestors = [...ancestors, canonicalDir];
+      const entries = await opendir(dir);
+      // The async iterator closes the directory on completion, error or abort.
+      for await (const entry of entries) {
+        signal?.throwIfAborted();
+        const entryPath = join(dir, entry.name);
         try {
-          const stats = statSync(entryPath);
+          const stats = await stat(entryPath);
+          signal?.throwIfAborted();
           if (stats.isDirectory()) {
-            scanDir(entryPath);
-          } else if (entry.endsWith(".jsonl")) {
-            const projectName = readSessionHeaderProjectName(entryPath) ?? sessionProjectNameFromDirectory(dir);
-            sessions.push({ name: projectName, mtime: stats.mtimeMs });
+            pendingDirs.push({ dir: entryPath, ancestors: childAncestors });
+          } else if (stats.isFile() && entry.name.endsWith(".jsonl")) {
+            sessions.push({ filePath: entryPath, dir, mtime: stats.mtimeMs });
           }
         } catch (error) {
+          signal?.throwIfAborted();
           logDiscoveryError(`Failed to inspect session entry ${entryPath}`, error);
         }
       }
     } catch (error) {
+      signal?.throwIfAborted();
       logDiscoveryError(`Failed to scan sessions dir ${dir}`, error);
     }
   }
-  
-  for (const sessionsDir of sessionsDirs) {
-    scanDir(sessionsDir);
-  }
-  
-  if (sessions.length === 0) return [];
-  
+
+  signal?.throwIfAborted();
   sessions.sort((a, b) => b.mtime - a.mtime);
-  
+
   const seen = new Set<string>();
-  const uniqueSessions: typeof sessions = [];
+  const uniqueSessions: { name: string; mtime: number }[] = [];
   for (const s of sessions) {
-    if (!seen.has(s.name)) {
-      seen.add(s.name);
-      uniqueSessions.push(s);
+    signal?.throwIfAborted();
+    const name = await readSessionHeaderProjectName(s.filePath, signal) ?? sessionProjectNameFromDirectory(s.dir);
+    signal?.throwIfAborted();
+    if (!seen.has(name)) {
+      seen.add(name);
+      uniqueSessions.push({ name, mtime: s.mtime });
+      if (maxCount > 0 && uniqueSessions.length >= maxCount) break;
     }
   }
 

--- a/welcome.ts
+++ b/welcome.ts
@@ -562,9 +562,6 @@ export function discoverLoadedCounts(): LoadedCounts {
   return { contextFiles, extensions, skills, promptTemplates };
 }
 
-/**
- * Get recent sessions from the sessions directory.
- */
 async function readSessionHeaderProjectName(filePath: string, signal?: AbortSignal): Promise<string | null> {
   let file: Awaited<ReturnType<typeof open>> | undefined;
   try {
@@ -651,15 +648,14 @@ export async function getRecentSessions(maxCount: number = 3, signal?: AbortSign
 
   const seen = new Set<string>();
   const uniqueSessions: { name: string; mtime: number }[] = [];
-  for (const s of sessions) {
+  for (const session of sessions) {
     signal?.throwIfAborted();
-    const name = await readSessionHeaderProjectName(s.filePath, signal) ?? sessionProjectNameFromDirectory(s.dir);
+    const name = await readSessionHeaderProjectName(session.filePath, signal) ?? sessionProjectNameFromDirectory(session.dir);
     signal?.throwIfAborted();
-    if (!seen.has(name)) {
-      seen.add(name);
-      uniqueSessions.push({ name, mtime: s.mtime });
-      if (maxCount > 0 && uniqueSessions.length >= maxCount) break;
-    }
+    if (seen.has(name)) continue;
+    seen.add(name);
+    uniqueSessions.push({ name, mtime: session.mtime });
+    if (maxCount > 0 && uniqueSessions.length >= maxCount) break;
   }
 
   const now = Date.now();


### PR DESCRIPTION
## Summary
- Move recent-session archive discovery off the startup completion path using serial asynchronous filesystem I/O and bounded header reads.
- Cancel pending welcome discovery on input, dismissal, session replacement, or shutdown. Late results cannot install stale header/overlay UI.
- Preserve recent-project ordering, directory-name fallback, and overlay input forwarding. Shutdown does not wait for filesystem work.

Total archive metadata traversal and sorting still scale with archive size. This removes synchronous archive discovery from startup; it does not claim a measured end-to-end speedup.

## Validation
- Retained-writer reduction, simplification, and fresh source review completed with no remaining findings.
- Full local suite: 217 tests passed before rebasing onto the separately reviewed Nerd Font fix.
- Final combined candidate: 18 welcome/icons tests and typecheck passed.
- Welcome source/tests and dependencies are unchanged by that conflict-free rebase; exact-head Ubuntu/Windows CI is required before merge.

Closes #199.
