### PR TITLE
perf: reuse inbox snapshots and skip unused footer summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - **Welcome startup** — Discover recent sessions asynchronously with bounded header reads, cancelling pending discovery when welcome is dismissed or the session changes. Fixes #199.
+- **Queue display reads** — Reuse unchanged inbox snapshots and skip footer queue summaries when the resolved layout omits or disables the queue segment (#200). Queue previews and explicit queue actions remain independent.
 - **Powerline placement** — Clarified that the primary Powerline row can be shown above or below the editor. Thanks to [@smileBeda](https://github.com/smileBeda) for #188.
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -1072,20 +1072,12 @@ function buildContentFromParts(
 function computeResponsiveLayout(
   ctx: SegmentContext,
   presetDef: ReturnType<typeof getPreset>,
+  allSegmentIds: StatusLineSegmentId[],
   availableWidth: number
 ): { topContent: string; secondaryContent: string } {
   const separatorStyle = config.separator ?? presetDef.separator;
   const separatorDef = getSeparator(separatorStyle);
   const sepWidth = visibleWidth(separatorDef.left) + 2; // separator + spaces around it
-
-  // Get all segments: primary first, then secondary
-  const mergedSegments = mergeSegmentsWithCustomItems(presetDef, config.customItems, {
-    layout: config.layout,
-    disabledSegments: config.disabledSegments,
-  });
-  const primaryIds = [...mergedSegments.leftSegments, ...mergedSegments.rightSegments];
-  const secondaryIds = mergedSegments.secondarySegments;
-  const allSegmentIds = [...primaryIds, ...secondaryIds];
 
   // Render all segments and get their widths
   const renderedSegments: { content: string; width: number }[] = [];
@@ -2656,7 +2648,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     },
   });
 
-  function buildSegmentContext(ctx: any, theme: Theme): SegmentContext {
+  function buildSegmentContext(ctx: any, theme: Theme, showQueue: boolean): SegmentContext {
     setVibeWorkingMessageTheme(theme);
     const presetDef = getPreset(config.preset);
     const colors: ColorScheme = presetDef.colors ?? getDefaultColors();
@@ -2701,7 +2693,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       : false;
 
     const thinkingLevel = currentThinkingLevel ?? thinkingLevelFromSession ?? getThinkingLevelFn?.() ?? "off";
-    const queueSummary = getQueueSummary(ctx);
+    const queueSummary: QueueSummary = showQueue ? getQueueSummary(ctx) : {
+      queueCount: 0,
+      blockedCount: 0,
+      compacting: powerlineCompacting,
+      leadingText: null,
+      leadingIntent: null,
+      leadingStatus: null,
+    };
 
     return {
       model: ctx.model,
@@ -2754,11 +2753,21 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
 
     const presetDef = getPreset(config.preset);
+    const mergedSegments = mergeSegmentsWithCustomItems(presetDef, config.customItems, {
+      layout: config.layout,
+      disabledSegments: config.disabledSegments,
+    });
+    const allSegmentIds = [
+      ...mergedSegments.leftSegments,
+      ...mergedSegments.rightSegments,
+      ...mergedSegments.secondarySegments,
+    ];
+    const showQueue = allSegmentIds.includes("queue");
     let segmentCtx: SegmentContext;
     try {
       segmentCtx = editorPerf.options.enabled
-        ? editorPerf.measure("layout.segment-context", () => buildSegmentContext(currentCtx, theme))
-        : buildSegmentContext(currentCtx, theme);
+        ? editorPerf.measure("layout.segment-context", () => buildSegmentContext(currentCtx, theme, showQueue))
+        : buildSegmentContext(currentCtx, theme, showQueue);
     } catch (error) {
       if (!isStaleExtensionContextError(error)) throw error;
       currentCtx = null;
@@ -2771,7 +2780,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
 
     lastLayoutWidth = width;
-    lastLayoutResult = computeResponsiveLayout(segmentCtx, presetDef, width);
+    lastLayoutResult = computeResponsiveLayout(segmentCtx, presetDef, allSegmentIds, width);
     lastLayoutTimestamp = now;
     layoutDirty = false;
     forceNextLayoutRecompute = false;

--- a/queue/store.ts
+++ b/queue/store.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { accessSync, constants, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import { getAgentPath } from "../paths.ts";
@@ -125,6 +125,7 @@ export function createQueueItem(input: CreateQueueItemInput): PowerlineQueueItem
 export class PowerlineQueueStore {
   private readonly inboxPath: string;
   private readonly aliasesPath: string;
+  private displaySnapshot: { fingerprint: string; items: PowerlineQueueItem[] } | undefined;
 
   constructor(inboxPath: string = getQueueStorePaths().inboxPath, aliasesPath: string = getQueueStorePaths().aliasesPath) {
     this.inboxPath = inboxPath;
@@ -195,7 +196,7 @@ export class PowerlineQueueStore {
   }
 
   summarize(context: QueueContext, compacting: boolean): QueueSummary {
-    const queueItems = this.activeItems(context);
+    const queueItems = this.displayItems().filter((item) => isActiveForContext(item, context));
     const blockedItems = queueItems.filter((item) => item.status === "blocked" || item.status === "failed");
     const leading = [...blockedItems, ...queueItems][0] ?? null;
 
@@ -207,6 +208,41 @@ export class PowerlineQueueStore {
       leadingIntent: leading?.intent ?? null,
       leadingStatus: leading?.status ?? null,
     };
+  }
+
+  // Only summaries use this snapshot; delivery and locked mutations keep fresh reads.
+  // Cached items never escape through the public item-returning methods.
+  private displayItems(): readonly PowerlineQueueItem[] {
+    try {
+      const fingerprint = this.inboxFingerprint();
+      if (fingerprint === undefined) {
+        this.displaySnapshot = undefined;
+        return [];
+      }
+      // Stat alone does not detect parent-directory or ACL permission changes.
+      accessSync(this.inboxPath, constants.R_OK);
+      if (this.displaySnapshot?.fingerprint === fingerprint) return this.displaySnapshot.items;
+
+      this.displaySnapshot = undefined;
+      const items = this.list();
+      // Do not retain a read that raced an external write or atomic replacement.
+      if (this.inboxFingerprint() === fingerprint) this.displaySnapshot = { fingerprint, items };
+      return items;
+    } catch (error) {
+      this.displaySnapshot = undefined;
+      throw error;
+    }
+  }
+
+  private inboxFingerprint(): string | undefined {
+    try {
+      const stat = statSync(this.inboxPath, { bigint: true });
+      return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeNs}:${stat.ctimeNs}:${stat.mode}:${stat.uid}:${stat.gid}`;
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error
+        && (error.code === "ENOENT" || error.code === "ENOTDIR")) return undefined;
+      throw error;
+    }
   }
 
   readAliases(): QueueAliasMap {
@@ -264,6 +300,7 @@ export class PowerlineQueueStore {
   }
 
   private writeItems(items: readonly PowerlineQueueItem[]): void {
+    this.displaySnapshot = undefined;
     mkdirSync(dirname(this.inboxPath), { recursive: true });
     const activeOrRecent = items
       .filter((item) => item.status !== "sent" || Date.now() - item.updatedAt < 24 * 60 * 60 * 1000)

--- a/tests/queue-store.test.ts
+++ b/tests/queue-store.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { PowerlineQueueStore, currentQueueContext, formatQueueDeliveryText, parseCompactQueuedPrompt } from "../queue/store.ts";
@@ -55,6 +55,64 @@ test("queue store clears items from active summary", () => withStore((store) => 
   assert.equal(store.summarize(currentQueueContext("/tmp/project"), false).queueCount, 1);
   store.clear(item.id);
   assert.equal(store.summarize(currentQueueContext("/tmp/project"), false).queueCount, 0);
+}));
+
+test("summaries follow external edits and replacement without losing writes or exposing cached items", () => withStore((store, dir) => {
+  const path = join(dir, "inbox.jsonl");
+  const context = currentQueueContext(dir);
+  const input = { source: { cwd: dir }, target: { kind: "global" } as const, intent: "follow-up" as const };
+  const first = store.add({ ...input, text: "first", now: 100 });
+  assert.equal(store.summarize(context, false).leadingText, "first");
+
+  // Same-sized in-place edit, with mtime restored: ctime must still invalidate.
+  const originalStat = statSync(path);
+  writeFileSync(path, readFileSync(path, "utf8").replace("first", "other"));
+  utimesSync(path, originalStat.atime, originalStat.mtime);
+  assert.equal(store.summarize(context, false).leadingText, "other");
+
+  const listed = store.list();
+  listed[0].text = "mutated";
+  listed.length = 0;
+  assert.equal(store.summarize(context, false).leadingText, "other");
+
+  const external = new PowerlineQueueStore(path, join(dir, "projects.json"));
+  const second = external.add({ ...input, text: "second", now: 101 });
+  // Local read-modify-write must include the external addition, even with a warm snapshot.
+  store.update(first.id, { status: "blocked" });
+  assert.equal(store.summarize(context, false).queueCount, 2);
+  external.update(second.id, { text: "external change" });
+  store.add({ ...input, text: "third", now: 102 });
+  assert.equal(store.get(second.id)?.text, "external change");
+
+  assert.equal(store.summarize(context, false).leadingText, "other");
+
+  const replacement = join(dir, "replacement.jsonl");
+  const beforeReplacement = statSync(path);
+  writeFileSync(replacement, readFileSync(path, "utf8").replace("other", "newer"));
+  utimesSync(replacement, beforeReplacement.atime, beforeReplacement.mtime);
+  renameSync(replacement, path);
+  assert.equal(store.summarize(context, false).leadingText, "newer");
+}));
+
+test("summary snapshots recover after missing files and read errors", () => withStore((store, dir) => {
+  const path = join(dir, "inbox.jsonl");
+  const context = currentQueueContext(dir);
+  store.add({ text: "visible", source: { cwd: dir }, target: { kind: "global" }, intent: "steer" });
+  const content = readFileSync(path, "utf8");
+  assert.equal(store.summarize(context, false).leadingText, "visible");
+  if (process.platform !== "win32" && process.getuid?.() !== 0) {
+    chmodSync(path, 0);
+    try {
+      assert.throws(() => store.summarize(context, false), { code: "EACCES" });
+    } finally {
+      chmodSync(path, 0o600);
+    }
+    assert.equal(store.summarize(context, false).leadingText, "visible");
+  }
+  rmSync(path);
+  assert.equal(store.summarize(context, false).queueCount, 0);
+  writeFileSync(path, content.replace("visible", "restored"));
+  assert.equal(store.summarize(context, false).leadingText, "restored");
 }));
 
 test("queue store times out instead of stealing an existing lock", () => withStore((store, dir) => {

--- a/tests/stash-shortcut.test.ts
+++ b/tests/stash-shortcut.test.ts
@@ -4,6 +4,9 @@ import { mkdtempSync, mkdirSync, readFileSync, utimesSync, writeFileSync } from 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { matchesStashShortcutInput } from "../shortcuts.ts";
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import { PowerlineQueueStore } from "../queue/store.ts";
 
 const source = readFileSync(new URL("../index.ts", import.meta.url), "utf-8");
 
@@ -57,7 +60,7 @@ interface FakeCtx {
     onTerminalInput(handler: (data: string) => unknown): () => void;
     custom(factory: CustomFactory): Promise<unknown>;
     select(): Promise<string>;
-    setWidget(): void;
+    setWidget(name: string, factory: ((tui: { requestRender(): void }, theme: FakeTheme) => { render(width: number): string[] }) | undefined): void;
     setFooter(): void;
     setHeader(): void;
     setEditorComponent(): void;
@@ -119,6 +122,7 @@ function createCtx(options: { cwd: string; text?: string; customInputs?: string[
   const statuses: Array<[string, string | undefined]> = [];
   const customTitles: string[] = [];
   const customInputs = [...(options.customInputs ?? [])];
+  const widgets = new Map<string, { render(width: number): string[] }>();
 
   const ctx: FakeCtx = {
     cwd: options.cwd,
@@ -155,7 +159,10 @@ function createCtx(options: { cwd: string; text?: string; customInputs?: string[
         }
       }),
       select: async () => "Insert",
-      setWidget() {},
+      setWidget(name, factory) {
+        if (factory) widgets.set(name, factory({ requestRender() {} }, fakeTheme()));
+        else widgets.delete(name);
+      },
       setFooter() {},
       setHeader() {},
       setEditorComponent() {},
@@ -165,6 +172,7 @@ function createCtx(options: { cwd: string; text?: string; customInputs?: string[
 
   return {
     ctx,
+    widgets,
     get text() { return text; },
     setEditorTextCalls,
     notifications,
@@ -176,6 +184,49 @@ function createCtx(options: { cwd: string; text?: string; customInputs?: string[
     },
   };
 }
+
+test("footer queue demand follows resolved layout while preview and picker stay independent", async () => {
+  for (const powerline of [
+    { preset: "full", disabledSegments: ["queue"] },
+    { layout: { left: ["model"], right: [], secondary: [] } },
+    { layout: { left: [], right: [], secondary: ["queue"] } },
+  ]) {
+    const root = mkdtempSync(join(tmpdir(), "powerline-queue-display-"));
+    writeFileSync(join(root, "settings.json"), JSON.stringify({ powerline: { welcome: false, ...powerline } }));
+    const inbox = join(root, "powerline-footer", "inbox.jsonl");
+    const store = new PowerlineQueueStore(inbox, join(root, "projects.json"));
+    store.add({ text: "independent preview", source: { cwd: root }, target: { kind: "global" }, intent: "follow-up" });
+    const { extension, restoreEnv } = await loadPowerline(root);
+    const fake = createFakePi();
+    const runtime = createCtx({ cwd: root, customInputs: [["\x1b"]] });
+    const originalRead = fs.readFileSync;
+    try {
+      extension(fake.pi);
+      await fake.handlers.get("session_start")?.({ reason: "resume" }, runtime.ctx);
+      const denied = Object.assign(new Error("inbox denied"), { code: "EACCES" });
+      fs.readFileSync = ((path, ...args) => {
+        if (path === inbox) throw denied;
+        return Reflect.apply(originalRead, fs, [path, ...args]);
+      }) as typeof fs.readFileSync;
+      syncBuiltinESMExports();
+      const renderFooter = () => runtime.widgets.get("powerline-top")!.render(120);
+      if (powerline.layout?.secondary.includes("queue")) assert.throws(renderFooter, denied);
+      else assert.doesNotThrow(renderFooter);
+      assert.throws(() => runtime.widgets.get("powerline-queue-preview")!.render(120), denied);
+      fs.readFileSync = originalRead;
+      syncBuiltinESMExports();
+      assert.match(runtime.widgets.get("powerline-queue-preview")!.render(120).join("\n"), /queued: independent preview/);
+      await fake.commands.get("queue")!.handler("", runtime.ctx);
+      assert.equal(runtime.customTitles.length, 1, "queue picker opens independently of footer layout");
+    } finally {
+      fs.readFileSync = originalRead;
+      syncBuiltinESMExports();
+      await fake.handlers.get("session_shutdown")?.({}, runtime.ctx);
+      restoreEnv();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
 
 test("stash shortcut matches Alt+S encodings without consuming literal sharp-S by default", () => {
   assert.equal(matchesStashShortcutInput("ß"), false);


### PR DESCRIPTION
## Summary
- Reuse a private parsed inbox snapshot for unchanged display summaries, with metadata/readability checks and invalidation on changes, errors, disappearance, or local writes.
- Keep delivery, item-returning APIs, and locked mutations on fresh reads.
- Skip footer summary collection when the resolved layout omits or disables the queue segment. The independent queue preview and explicit queue actions keep working.

Demand is resolved before width truncation. An active preview can still read the inbox. Cold reads remain synchronous and warm filtering remains proportional to item count; no measured end-to-end speedup is claimed.

## Validation
- 49 focused tests and typecheck passed with locked Pi 0.84.1 dependencies.
- Retained-writer challenge, simplification, and fresh review completed with no remaining findings.
- Rebased onto current main, preserving the welcome and Nerd Font fixes; worktree and diff checks clean.
- Full cross-platform suite is required on the published head before merge.

Closes #200.
