### PR TITLE
fix: scope Git freshness and collection to the active footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 - **Compact prompt mode** — Added `powerline.queue.compactPromptMode: "native"` so `/compact <text>` can pass `<text>` through to Pi as custom compaction instructions instead of using Powerline's post-compaction queue shorthand. Thanks to [@joshuajbrunner](https://github.com/joshuajbrunner) for #191.
 
 ### Changed
+- **Git collection** — Reuse Pi's attached branch and collect status only for configured Git consumers, preserving explicit polling modes and dirty branch coloring (#201).
 - **Welcome startup** — Discover recent sessions asynchronously with bounded header reads, cancelling pending discovery when welcome is dismissed or the session changes. Fixes #199.
 - **Queue display reads** — Reuse unchanged inbox snapshots and skip footer queue summaries when the resolved layout omits or disables the queue segment (#200). Queue previews and explicit queue actions remain independent.
 - **Powerline placement** — Clarified that the primary Powerline row can be shown above or below the editor. Thanks to [@smileBeda](https://github.com/smileBeda) for #188.
 
 ### Fixed
+- **Git session freshness** — Keep branch, status, and remote-host icons scoped to the current session cwd, refreshing on session and branch changes (#194). Thanks to [@lengxf](https://github.com/lengxf) for the report.
 - **Terminal-name heuristic** — Fall back to `TERM` only when `TERM_PROGRAM` is unset when inferring Nerd Font support. Thanks to [@a5ehren](https://github.com/a5ehren) for #192/#195.
 - **Live thinking-level display** — Prefer the authoritative thinking-level selection event over a stale session-start context so the footer updates from `think:off` to the selected level. Thanks to [@csp256](https://github.com/csp256) for #196.
 

--- a/git-status.ts
+++ b/git-status.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { resolve } from "node:path";
 import type { GitStatus } from "./types.ts";
 
 interface CachedGitStatus {
@@ -34,7 +35,29 @@ let pendingFetch: Promise<void> | null = null;
 let pendingBranchFetch: Promise<void> | null = null;
 let invalidationCounter = 0; // Track invalidations to prevent stale updates
 let branchInvalidationCounter = 0;
+let currentCwd: string | null = null;
+let lastProviderBranch: string | null = null;
 const updateListeners = new Set<() => void>();
+
+// Serve-stale is only valid within one cwd. Detach old requests as well as
+// clearing their data, so they cannot publish into or block the new cwd.
+function useCwd(cwd: string): string {
+  cwd = resolve(cwd);
+  if (cwd === currentCwd) return cwd;
+
+  currentCwd = cwd;
+  invalidateGitStatus();
+  invalidateGitBranch();
+  cachedStatus = null;
+  cachedBranch = null;
+  lastProviderBranch = null;
+  return cwd;
+}
+
+/** Wait for the background reads already requested by synchronous getters. */
+export async function waitForGitUpdates(): Promise<void> {
+  await Promise.all([pendingFetch, pendingBranchFetch, pendingRemoteFetch]);
+}
 
 function notifyGitUpdate(): void {
   for (const listener of updateListeners) listener();
@@ -97,12 +120,13 @@ export function readOnlyGitEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.Pro
   return { ...env, GIT_OPTIONAL_LOCKS: "0" };
 }
 
-function runGit(args: string[], timeoutMs = 200): Promise<string | null> {
+function runGit(args: string[], cwd: string, timeoutMs = 200): Promise<string | null> {
   return new Promise((resolve) => {
     const proc = spawn("git", args, {
       stdio: ["ignore", "pipe", "pipe"],
       env: readOnlyGitEnv(),
       windowsHide: true,
+      cwd,
     });
 
     let stdout = "";
@@ -120,7 +144,7 @@ function runGit(args: string[], timeoutMs = 200): Promise<string | null> {
     });
 
     proc.on("close", (code) => {
-      finish(code === 0 ? stdout.trim() : null);
+      finish(code === 0 ? stdout.trimEnd() : null);
     });
 
     proc.on("error", () => {
@@ -138,12 +162,12 @@ function runGit(args: string[], timeoutMs = 200): Promise<string | null> {
  * Fetch current git branch asynchronously.
  * For detached HEAD, returns the short commit SHA (matches provider's "detached" behavior).
  */
-async function fetchGitBranch(): Promise<string | null> {
-  const branch = await runGit(["branch", "--show-current"]);
+async function fetchGitBranch(cwd: string): Promise<string | null> {
+  const branch = await runGit(["branch", "--show-current"], cwd);
   if (branch === null) return null;
   if (branch) return branch;
 
-  const sha = await runGit(["rev-parse", "--short", "HEAD"]);
+  const sha = await runGit(["rev-parse", "--short", "HEAD"], cwd);
   return sha ? `${sha} (detached)` : "detached";
 }
 
@@ -178,36 +202,32 @@ export function detectGitHost(remoteUrl: string | null): GitHost | null {
 }
 
 /**
- * Fetch the origin remote host asynchronously and cache the result.
- */
-async function fetchRemoteHost(): Promise<GitHost | null> {
-  const url = await runGit(["remote", "get-url", "origin"]);
-  return detectGitHost(url);
-}
-
-/**
  * Get the origin remote's hosting provider with a long TTL cache. Returns the
  * cached value immediately (or null before the first fetch completes) and
  * refreshes in the background, matching the branch/status caching pattern.
  */
-export function getGitRemoteHost(): GitHost | null {
+export function getGitRemoteHost(cwd = process.cwd()): GitHost | null {
+  cwd = useCwd(cwd);
   const now = Date.now();
   if (cachedRemoteHost && now - cachedRemoteHost.timestamp < REMOTE_TTL_MS) {
     return cachedRemoteHost.host;
   }
 
   if (!pendingRemoteFetch) {
-    pendingRemoteFetch = fetchRemoteHost()
+    const fetchId = branchInvalidationCounter;
+    pendingRemoteFetch = runGit(["remote", "get-url", "origin"], cwd).then(detectGitHost)
       .then((host) => {
+        if (fetchId !== branchInvalidationCounter) return;
         cachedRemoteHost = { host, timestamp: Date.now() };
         notifyGitUpdate();
       })
       .catch(() => {
+        if (fetchId !== branchInvalidationCounter) return;
         cachedRemoteHost = { host: null, timestamp: Date.now() };
         notifyGitUpdate();
       })
       .finally(() => {
-        pendingRemoteFetch = null;
+        if (fetchId === branchInvalidationCounter) pendingRemoteFetch = null;
       });
   }
 
@@ -217,17 +237,26 @@ export function getGitRemoteHost(): GitHost | null {
 /**
  * Fetch git status asynchronously
  */
-async function fetchGitStatus(): Promise<{ staged: number; unstaged: number; untracked: number } | null> {
-  const output = await runGit(["status", "--porcelain"], 500);
+async function fetchGitStatus(cwd: string): Promise<{ staged: number; unstaged: number; untracked: number } | null> {
+  const output = await runGit(["status", "--porcelain"], cwd, 500);
   if (output === null) return null;
   return parseGitStatusOutput(output);
 }
 
 /**
  * Get the current git branch with caching.
- * Falls back to provider branch if our cache is empty.
+ * Reuse Pi's attached branch; poll only when unavailable or detached.
+ * The provider value must belong to the supplied cwd.
  */
-export function getCurrentBranch(providerBranch: string | null): string | null {
+export function getCurrentBranch(providerBranch: string | null, cwd = process.cwd()): string | null {
+  cwd = useCwd(cwd);
+  if (providerBranch !== lastProviderBranch) {
+    invalidateGitBranch();
+    invalidateGitStatus();
+    cachedBranch = null;
+    lastProviderBranch = providerBranch;
+  }
+  if (providerBranch && providerBranch !== "detached") return providerBranch;
   const now = Date.now();
 
   // Return cached if fresh
@@ -238,7 +267,7 @@ export function getCurrentBranch(providerBranch: string | null): string | null {
   // Trigger background fetch if not already pending
   if (!pendingBranchFetch) {
     const fetchId = branchInvalidationCounter;
-    pendingBranchFetch = fetchGitBranch().then((result) => {
+    pendingBranchFetch = fetchGitBranch(cwd).then((result) => {
       // Cache result if no invalidation happened (including null for non-git dirs)
       if (fetchId === branchInvalidationCounter) {
         cachedBranch = {
@@ -247,7 +276,7 @@ export function getCurrentBranch(providerBranch: string | null): string | null {
         };
         notifyGitUpdate();
       }
-      pendingBranchFetch = null;
+      if (fetchId === branchInvalidationCounter) pendingBranchFetch = null;
     });
   }
 
@@ -261,28 +290,19 @@ export function getCurrentBranch(providerBranch: string | null): string | null {
  * This is designed for synchronous render() calls - returns last known value
  * while refreshing in background.
  */
-export function getGitStatus(providerBranch: string | null, pollingMode: GitPollingMode = "full"): GitStatus {
+export function getGitStatus(providerBranch: string | null, pollingMode: GitPollingMode = "full", cwd = process.cwd()): GitStatus {
+  cwd = useCwd(cwd);
   const now = Date.now();
-  const branch = pollingMode === "off" ? providerBranch : getCurrentBranch(providerBranch);
+  const branch = pollingMode === "off" ? providerBranch : getCurrentBranch(providerBranch, cwd);
 
   if (pollingMode !== "full") {
     return { branch, staged: 0, unstaged: 0, untracked: 0 };
   }
 
-  // Return cached if fresh
-  if (cachedStatus && now - cachedStatus.timestamp < CACHE_TTL_MS) {
-    return { 
-      branch, 
-      staged: cachedStatus.staged,
-      unstaged: cachedStatus.unstaged,
-      untracked: cachedStatus.untracked,
-    };
-  }
-
-  // Trigger background fetch if not already pending
-  if (!pendingFetch) {
+  // Refresh expired data in the background, serving the last known counts.
+  if (!pendingFetch && (!cachedStatus || now - cachedStatus.timestamp >= CACHE_TTL_MS)) {
     const fetchId = invalidationCounter; // Capture current counter
-    pendingFetch = fetchGitStatus().then((result) => {
+    pendingFetch = fetchGitStatus(cwd).then((result) => {
       // Cache result if no invalidation happened (including null for non-git dirs)
       if (fetchId === invalidationCounter) {
         cachedStatus = result
@@ -290,7 +310,7 @@ export function getGitStatus(providerBranch: string | null, pollingMode: GitPoll
           : { staged: 0, unstaged: 0, untracked: 0, timestamp: Date.now() };
         notifyGitUpdate();
       }
-      pendingFetch = null;
+      if (fetchId === invalidationCounter) pendingFetch = null;
     });
   }
 
@@ -315,6 +335,7 @@ export function getGitStatus(providerBranch: string | null, pollingMode: GitPoll
 export function invalidateGitStatus(): void {
   if (cachedStatus) cachedStatus.timestamp = 0; // expire, but keep serving the stale value
   invalidationCounter++; // Increment to invalidate any pending fetches
+  pendingFetch = null;
 }
 
 /**
@@ -324,7 +345,9 @@ export function invalidateGitStatus(): void {
 export function invalidateGitBranch(): void {
   if (cachedBranch) cachedBranch.timestamp = 0; // expire, but keep serving the stale value
   branchInvalidationCounter++;
+  pendingBranchFetch = null;
   // The origin remote is repo-scoped, so a branch/cwd change may mean a
   // different repo; drop the host cache so it re-detects.
   cachedRemoteHost = null;
+  pendingRemoteFetch = null;
 }

--- a/index.ts
+++ b/index.ts
@@ -2690,9 +2690,12 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     const showGit = allSegmentIds.includes("git") && [
       gitOptions?.showBranch, gitOptions?.showStaged, gitOptions?.showUnstaged, gitOptions?.showUntracked,
     ].some((visible) => visible !== false);
+    const gitBranch = showGit && footerDataCwd === ctx.cwd
+      ? footerDataRef?.getGitBranch() ?? null
+      : null;
     // Full mode retains counts for dirty branch coloring, even with hidden indicators.
     const gitStatus = showGit
-      ? getGitStatus(footerDataCwd === ctx.cwd ? footerDataRef?.getGitBranch() ?? null : null, gitOptions?.polling, ctx.cwd)
+      ? getGitStatus(gitBranch, gitOptions?.polling, ctx.cwd)
       : { branch: null, staged: 0, unstaged: 0, untracked: 0 };
     const extensionStatuses = footerDataRef?.getExtensionStatuses() ?? new Map();
     const customItemsById = new Map(config.customItems.map((item) => [item.id, item]));

--- a/index.ts
+++ b/index.ts
@@ -1171,6 +1171,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   let sessionGeneration = 0;
   let currentCtx: any = null;
   let footerDataRef: ReadonlyFooterDataProvider | null = null;
+  let footerDataCwd: string | null = null;
   let getThinkingLevelFn: (() => string) | null = null;
   let currentThinkingLevel: string | null = null;
   let liveAssistantUsage: SessionAssistantUsage | null = null;
@@ -1714,6 +1715,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     sessionGeneration++;
     sessionStartTime = Date.now();
     currentCtx = ctx;
+    footerDataRef = null;
+    footerDataCwd = null;
+    invalidateGitStatus();
+    invalidateGitBranch();
+    resetLayoutCache();
     customCompactionEnabled = detectCustomCompactionEnabled(ctx.cwd);
     lastUserPrompt = "";
     isStreaming = false;
@@ -2648,7 +2654,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     },
   });
 
-  function buildSegmentContext(ctx: any, theme: Theme, showQueue: boolean): SegmentContext {
+  function buildSegmentContext(ctx: any, theme: Theme, allSegmentIds: StatusLineSegmentId[]): SegmentContext {
     setVibeWorkingMessageTheme(theme);
     const presetDef = getPreset(config.preset);
     const colors: ColorScheme = presetDef.colors ?? getDefaultColors();
@@ -2680,9 +2686,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
     const segmentOptions = mergeSegmentOptions(presetDef.segmentOptions, config.segmentOptions);
 
-    // Get git status (cached)
-    const gitBranch = footerDataRef?.getGitBranch() ?? null;
-    const gitStatus = getGitStatus(gitBranch, segmentOptions.git?.polling);
+    const gitOptions = segmentOptions.git;
+    const showGit = allSegmentIds.includes("git") && [
+      gitOptions?.showBranch, gitOptions?.showStaged, gitOptions?.showUnstaged, gitOptions?.showUntracked,
+    ].some((visible) => visible !== false);
+    // Full mode retains counts for dirty branch coloring, even with hidden indicators.
+    const gitStatus = showGit
+      ? getGitStatus(footerDataCwd === ctx.cwd ? footerDataRef?.getGitBranch() ?? null : null, gitOptions?.polling, ctx.cwd)
+      : { branch: null, staged: 0, unstaged: 0, untracked: 0 };
     const extensionStatuses = footerDataRef?.getExtensionStatuses() ?? new Map();
     const customItemsById = new Map(config.customItems.map((item) => [item.id, item]));
     const hiddenExtensionStatusKeys = collectHiddenExtensionStatusKeys(config.customItems);
@@ -2693,7 +2704,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       : false;
 
     const thinkingLevel = currentThinkingLevel ?? thinkingLevelFromSession ?? getThinkingLevelFn?.() ?? "off";
-    const queueSummary: QueueSummary = showQueue ? getQueueSummary(ctx) : {
+    const queueSummary: QueueSummary = allSegmentIds.includes("queue") ? getQueueSummary(ctx) : {
       queueCount: 0,
       blockedCount: 0,
       compacting: powerlineCompacting,
@@ -2762,12 +2773,11 @@ export default function powerlineFooter(pi: ExtensionAPI) {
       ...mergedSegments.rightSegments,
       ...mergedSegments.secondarySegments,
     ];
-    const showQueue = allSegmentIds.includes("queue");
     let segmentCtx: SegmentContext;
     try {
       segmentCtx = editorPerf.options.enabled
-        ? editorPerf.measure("layout.segment-context", () => buildSegmentContext(currentCtx, theme, showQueue))
-        : buildSegmentContext(currentCtx, theme, showQueue);
+        ? editorPerf.measure("layout.segment-context", () => buildSegmentContext(currentCtx, theme, allSegmentIds))
+        : buildSegmentContext(currentCtx, theme, allSegmentIds);
     } catch (error) {
       if (!isStaleExtensionContextError(error)) throw error;
       currentCtx = null;
@@ -3247,15 +3257,24 @@ export default function powerlineFooter(pi: ExtensionAPI) {
 
     ctx.ui.setFooter((tui: any, _theme: Theme, footerData: ReadonlyFooterDataProvider) => {
       footerDataRef = footerData;
+      // Pi sets the provider cwd from sessionManager before binding session_start.
+      // Do not treat its branch as authoritative if the extension cwd differs.
+      footerDataCwd = ctx.sessionManager?.getCwd?.() ?? null;
       tuiRef = tui;
       installFooterStatusRepaintHook(footerData);
-      const unsub = footerData.onBranchChange(() => requestStatusRender());
+      const unsub = footerData.onBranchChange(() => {
+        invalidateGitStatus();
+        invalidateGitBranch();
+        requestStatusRender();
+      });
       const unsubGitUpdates = subscribeGitUpdates(() => requestStatusRender());
 
       return {
         dispose() {
           unsub();
           unsubGitUpdates();
+          footerDataRef = null;
+          footerDataCwd = null;
           restoreFooterStatusRepaintHook?.();
           restoreFooterStatusRepaintHook = null;
         },

--- a/segments.ts
+++ b/segments.ts
@@ -136,9 +136,9 @@ const pathSegment: StatusLineSegment = {
  * enabled and a remote is known, otherwise the plain branch icon. An
  * unrecognized remote falls back to the generic git logo.
  */
-function resolveBranchIcon(icons: IconSet, hostIcon: boolean): string {
+function resolveBranchIcon(icons: IconSet, hostIcon: boolean, cwd: string | undefined): string {
   if (!hostIcon) return icons.branch;
-  const host = getGitRemoteHost();
+  const host = getGitRemoteHost(cwd);
   const byHost: Record<GitHost, string> = {
     github: icons.github,
     gitlab: icons.gitlab,
@@ -168,7 +168,7 @@ const gitSegment: StatusLineSegment = {
     let content = "";
     if (showBranch && branch) {
       // Color just the branch name (icon + branch text)
-      const branchIcon = resolveBranchIcon(icons, opts.hostIcon === true);
+      const branchIcon = resolveBranchIcon(icons, opts.hostIcon === true, ctx.cwd);
       content = color(ctx, branchColor, withIcon(branchIcon, branch));
     }
 

--- a/tests/git-optional-locks.test.ts
+++ b/tests/git-optional-locks.test.ts
@@ -3,15 +3,11 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import childProcess from "node:child_process";
+import { syncBuiltinESMExports } from "node:module";
 
-import { readOnlyGitEnv } from "../git-status.ts";
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-const gitStatusSource = readFileSync(new URL("../git-status.ts", import.meta.url), "utf-8");
+import { getGitStatus, invalidateGitStatus, readOnlyGitEnv, waitForGitUpdates } from "../git-status.ts";
 const completionSource = readFileSync(new URL("../bash-mode/completion.ts", import.meta.url), "utf-8");
-
-// Background fetches spawn git with up to 500ms timeouts; give them room.
-const FETCH_SETTLE_MS = 1200;
 
 test("read-only git commands opt out of git's optional index lock", () => {
   const env = readOnlyGitEnv({ PATH: "/usr/bin" });
@@ -23,11 +19,28 @@ test("readOnlyGitEnv overrides an inherited GIT_OPTIONAL_LOCKS=1", () => {
   assert.equal(readOnlyGitEnv({ GIT_OPTIONAL_LOCKS: "1" }).GIT_OPTIONAL_LOCKS, "0");
 });
 
-test("footer git polling hides Windows child consoles while preserving read-only env", () => {
-  assert.match(
-    gitStatusSource,
-    /spawn\("git", args, \{\s*stdio: \["ignore", "pipe", "pipe"\],\s*env: readOnlyGitEnv\(\),\s*windowsHide: true,\s*\}\)/s,
-  );
+test("footer git polling hides Windows child consoles while preserving read-only env", async (t) => {
+  const spawn = childProcess.spawn;
+  const calls: Parameters<typeof spawn>[] = [];
+  t.mock.method(childProcess, "spawn", (...args: Parameters<typeof spawn>) => {
+    calls.push(args);
+    return spawn(...args);
+  });
+  syncBuiltinESMExports();
+  try {
+    invalidateGitStatus();
+    getGitStatus("main");
+    await waitForGitUpdates();
+    assert.ok(calls.length > 0);
+    for (const [, , options] of calls) {
+      assert.equal(options?.windowsHide, true);
+      assert.equal(options?.env?.GIT_OPTIONAL_LOCKS, "0");
+    }
+    t.diagnostic(`Attached full-mode process boundary: ${calls.map(([, args]) => args?.join(" ")).join(", ")}`);
+  } finally {
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
+  }
 });
 
 test("bash git completions hide Windows child consoles", () => {
@@ -58,12 +71,9 @@ test("the git process the footer spawns receives GIT_OPTIONAL_LOCKS=0", { skip: 
   // for this bug; force the opposite so we can't inherit a false pass.
   process.env.GIT_OPTIONAL_LOCKS = "1";
   try {
-    // Imported here so the module reads the shimmed PATH when it spawns.
-    const { getGitStatus, invalidateGitStatus, invalidateGitBranch } = await import("../git-status.ts");
     invalidateGitStatus();
-    invalidateGitBranch();
     getGitStatus("main");
-    await sleep(FETCH_SETTLE_MS);
+    await waitForGitUpdates();
   } finally {
     process.env.PATH = originalPath;
     if (originalOptionalLocks === undefined) delete process.env.GIT_OPTIONAL_LOCKS;

--- a/tests/git-optional-locks.test.ts
+++ b/tests/git-optional-locks.test.ts
@@ -36,7 +36,6 @@ test("footer git polling hides Windows child consoles while preserving read-only
       assert.equal(options?.windowsHide, true);
       assert.equal(options?.env?.GIT_OPTIONAL_LOCKS, "0");
     }
-    t.diagnostic(`Attached full-mode process boundary: ${calls.map(([, args]) => args?.join(" ")).join(", ")}`);
   } finally {
     t.mock.restoreAll();
     syncBuiltinESMExports();

--- a/tests/git-status.test.ts
+++ b/tests/git-status.test.ts
@@ -1,68 +1,118 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { detectGitHost, getCurrentBranch, getGitStatus, invalidateGitBranch, invalidateGitStatus, subscribeGitUpdates } from "../git-status.ts";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectGitHost, getCurrentBranch, getGitRemoteHost, getGitStatus, invalidateGitBranch, invalidateGitStatus, subscribeGitUpdates, waitForGitUpdates } from "../git-status.ts";
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-// Background fetches spawn git with up to 500ms timeouts; give them room.
-const FETCH_SETTLE_MS = 1200;
-
-test("git status supports disabling extension git polling", () => {
-  assert.deepEqual(getGitStatus("main", "off"), {
-    branch: "main",
-    staged: 0,
-    unstaged: 0,
-    untracked: 0,
+function fixture(t: test.TestContext) {
+  const root = mkdtempSync(join(tmpdir(), "powerline-git-status-"));
+  t.after(async () => {
+    await waitForGitUpdates();
+    rmSync(root, { recursive: true, force: true });
   });
-});
+  const git = (cwd: string, ...args: string[]) => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+  const repo = (name: string, host: string) => {
+    const cwd = join(root, name);
+    mkdirSync(cwd);
+    git(cwd, "init", "-q", "-b", name);
+    git(cwd, "remote", "add", "origin", `https://${host}/owner/repo`);
+    return cwd;
+  };
+  return { root, git, repo };
+}
 
-test("invalidateGitStatus serves stale counts while refreshing (no flicker to zeros)", async () => {
-  getGitStatus("provider-branch"); // kick off the initial background fetch
-  await sleep(FETCH_SETTLE_MS);
-
-  const seeded = getGitStatus("provider-branch");
-
-  invalidateGitStatus();
-  const afterInvalidate = getGitStatus("provider-branch");
-  assert.deepEqual(
-    { staged: afterInvalidate.staged, unstaged: afterInvalidate.unstaged, untracked: afterInvalidate.untracked },
-    { staged: seeded.staged, unstaged: seeded.unstaged, untracked: seeded.untracked },
-  );
-
-  // The background refresh converges to real data again (repo is unchanged).
-  await sleep(FETCH_SETTLE_MS);
-  const refreshed = getGitStatus("provider-branch");
-  assert.deepEqual(
-    { staged: refreshed.staged, unstaged: refreshed.unstaged, untracked: refreshed.untracked },
-    { staged: seeded.staged, unstaged: seeded.unstaged, untracked: seeded.untracked },
-  );
-});
-
-test("invalidateGitBranch keeps serving the last known branch while refreshing", async () => {
-  getGitStatus("provider-fallback"); // seed branch cache
-  await sleep(FETCH_SETTLE_MS);
-
-  const realBranch = getCurrentBranch("provider-fallback");
-  // Once fetched, the cached branch no longer falls back to the provider
-  // (null in non-git directories, the actual branch name inside a repo).
-  assert.notEqual(realBranch, "provider-fallback");
-
-  invalidateGitBranch();
-  assert.equal(getCurrentBranch("provider-fallback"), realBranch);
-});
-
-test("git cache completion notifies active footer subscribers", async () => {
+test("status refresh preserves dirty coloring data until new counts arrive", async (t) => {
+  const { repo, git } = fixture(t);
+  const cwd = repo("main", "github.com");
   let updates = 0;
-  const unsubscribe = subscribeGitUpdates(() => { updates += 1; });
-  try {
-    invalidateGitStatus();
-    invalidateGitBranch();
-    getGitStatus("provider-fallback");
-    await sleep(FETCH_SETTLE_MS);
-    assert.ok(updates > 0);
-  } finally {
-    unsubscribe();
-  }
+  t.after(subscribeGitUpdates(() => { updates += 1; }));
+  writeFileSync(join(cwd, "tracked"), "first");
+  git(cwd, "add", "tracked");
+  getGitStatus("main", "full", cwd);
+  await waitForGitUpdates();
+  assert.ok(updates > 0);
+  assert.deepEqual(getGitStatus("main", "full", cwd), { branch: "main", staged: 1, unstaged: 0, untracked: 0 });
+  writeFileSync(join(cwd, "tracked"), "second");
+  writeFileSync(join(cwd, "new"), "new");
+  invalidateGitStatus();
+  assert.equal(getGitStatus("main", "full", cwd).staged, 1);
+  await waitForGitUpdates();
+  assert.deepEqual(getGitStatus("main", "full", cwd), { branch: "main", staged: 1, unstaged: 1, untracked: 1 });
+  assert.deepEqual(getGitStatus("main", "branch", cwd), { branch: "main", staged: 0, unstaged: 0, untracked: 0 });
+});
+
+test("fallback branch refresh serves stale only within the same cwd", async (t) => {
+  const { repo, git } = fixture(t);
+  const cwd = repo("main", "github.com");
+  getCurrentBranch(null, cwd);
+  await waitForGitUpdates();
+  assert.equal(getCurrentBranch(null, cwd), "main");
+  git(cwd, "symbolic-ref", "HEAD", "refs/heads/feature");
+  invalidateGitBranch();
+  assert.equal(getCurrentBranch(null, cwd), "main");
+  await waitForGitUpdates();
+  assert.equal(getCurrentBranch(null, cwd), "feature");
+  assert.equal(getCurrentBranch("external", cwd), "external");
+  assert.equal(getCurrentBranch("main", cwd), "main");
+});
+
+test("cwd changes clear displayed status, branch and host, including in-flight reads", async (t) => {
+  const { repo, root } = fixture(t);
+  const a = repo("alpha", "github.com");
+  const b = repo("beta", "gitlab.com");
+  writeFileSync(join(a, "dirty"), "dirty");
+  getGitStatus(null, "full", a);
+  getGitRemoteHost(a);
+  await waitForGitUpdates();
+  assert.equal(getGitStatus(null, "full", a).untracked, 1);
+  assert.equal(getGitRemoteHost(a), "github");
+  invalidateGitBranch();
+  invalidateGitStatus();
+  getGitStatus(null, "full", a);
+  getGitRemoteHost(a);
+  const oldReads = waitForGitUpdates();
+  assert.deepEqual(getGitStatus(null, "off", b), { branch: null, staged: 0, unstaged: 0, untracked: 0 });
+  await oldReads;
+  assert.deepEqual(getGitStatus(null, "full", b), { branch: null, staged: 0, unstaged: 0, untracked: 0 });
+  assert.equal(getGitRemoteHost(b), null);
+  await waitForGitUpdates();
+  assert.deepEqual(getGitStatus(null, "full", b), { branch: "beta", staged: 0, unstaged: 0, untracked: 0 });
+  assert.equal(getGitRemoteHost(b), "gitlab");
+  assert.deepEqual(getGitStatus(null, "full", root), { branch: null, staged: 0, unstaged: 0, untracked: 0 });
+  getGitRemoteHost(root);
+  await waitForGitUpdates();
+  assert.equal(getGitRemoteHost(root), null);
+  assert.deepEqual(getGitStatus(null, "full", root), { branch: null, staged: 0, unstaged: 0, untracked: 0 });
+});
+
+test("attached, detached and worktree branch displays follow repository transitions", async (t) => {
+  const { repo, git, root } = fixture(t);
+  const cwd = repo("main", "github.com");
+  writeFileSync(join(cwd, "tracked"), "original");
+  git(cwd, "add", "tracked");
+  // A fixture-only commit supplies a real detached HEAD and linked worktree.
+  git(cwd, "-c", "user.name=Test", "-c", "user.email=test@example.com", "-c", "commit.gpgSign=false", "commit", "--allow-empty", "-qm", "fixture");
+  const sha = git(cwd, "rev-parse", "--short", "HEAD");
+  assert.equal(getCurrentBranch("main", cwd), "main");
+  git(cwd, "checkout", "-q", "--detach");
+  assert.equal(getCurrentBranch("detached", cwd), "detached");
+  await waitForGitUpdates();
+  assert.equal(getCurrentBranch("detached", cwd), `${sha} (detached)`);
+  git(cwd, "checkout", "-q", "main");
+  assert.equal(getCurrentBranch("main", cwd), "main");
+  const worktree = join(root, "linked");
+  git(cwd, "worktree", "add", "-qb", "feature", worktree);
+  assert.equal(getCurrentBranch(null, worktree), null);
+  await waitForGitUpdates();
+  assert.equal(getCurrentBranch(null, worktree), "feature");
+  writeFileSync(join(worktree, "tracked"), "modified");
+  writeFileSync(join(worktree, "dirty"), "dirty");
+  getGitStatus("feature", "full", worktree);
+  await waitForGitUpdates();
+  assert.deepEqual(getGitStatus("feature", "full", worktree), { branch: "feature", staged: 0, unstaged: 1, untracked: 1 });
+  assert.deepEqual(getGitStatus("main", "off", cwd), { branch: "main", staged: 0, unstaged: 0, untracked: 0 });
 });
 
 test("detectGitHost recognizes known hosts over SSH and HTTPS", () => {

--- a/tests/stash-shortcut.test.ts
+++ b/tests/stash-shortcut.test.ts
@@ -269,11 +269,6 @@ test("Git rendering reuses the cwd-owned provider only on demand and refreshes a
     assert.match(render(), /<warning>[^<]*branch-a<\/warning>/, "same-cwd refresh serves stale counts");
     await waitForGitUpdates();
     assert.match(render(), /<success>[^<]*branch-a<\/success>/);
-    childProcess.execFileSync("git", ["symbolic-ref", "HEAD", "refs/heads/renamed-a"], { cwd: repoA });
-    for (const notify of listeners) notify();
-    assert.match(render(), /renamed-a/);
-    await waitForGitUpdates();
-    assert.match(render(), /<success>[^<]*renamed-a<\/success>/);
 
     writeFileSync(join(repoA, "dirty"), "untracked again");
     await start({ git: { hostIcon: true } });
@@ -284,7 +279,7 @@ test("Git rendering reuses the cwd-owned provider only on demand and refreshes a
     await start({ git: { hostIcon: true } }, repoB);
     const immediate = render();
     assert.match(immediate, /branch-b/);
-    assert.doesNotMatch(immediate, /renamed-a|branch-a|<warning>/);
+    assert.doesNotMatch(immediate, /branch-a|<warning>/);
     assert.ok(!immediate.includes(NERD_ICONS.github));
     await waitForGitUpdates();
     assert.ok(render().includes(NERD_ICONS.gitlab));

--- a/tests/stash-shortcut.test.ts
+++ b/tests/stash-shortcut.test.ts
@@ -336,6 +336,7 @@ test("footer queue demand follows resolved layout while preview and picker stay 
       fs.readFileSync = originalRead;
       syncBuiltinESMExports();
       await fake.handlers.get("session_shutdown")?.({}, runtime.ctx);
+      await waitForGitUpdates();
       restoreEnv();
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/tests/stash-shortcut.test.ts
+++ b/tests/stash-shortcut.test.ts
@@ -7,6 +7,10 @@ import { matchesStashShortcutInput } from "../shortcuts.ts";
 import fs from "node:fs";
 import { syncBuiltinESMExports } from "node:module";
 import { PowerlineQueueStore } from "../queue/store.ts";
+import childProcess from "node:child_process";
+import type { ReadonlyFooterDataProvider } from "@earendil-works/pi-coding-agent";
+import { waitForGitUpdates } from "../git-status.ts";
+import { NERD_ICONS } from "../icons.ts";
 
 const source = readFileSync(new URL("../index.ts", import.meta.url), "utf-8");
 
@@ -48,6 +52,7 @@ type CustomFactory = (
 ) => FakeComponent;
 interface FakeCtx {
   cwd: string;
+  sessionManager?: { getCwd(): string };
   hasUI: boolean;
   model: { name: string; provider: string };
   modelRegistry: Record<string, never>;
@@ -61,7 +66,7 @@ interface FakeCtx {
     custom(factory: CustomFactory): Promise<unknown>;
     select(): Promise<string>;
     setWidget(name: string, factory: ((tui: { requestRender(): void }, theme: FakeTheme) => { render(width: number): string[] }) | undefined): void;
-    setFooter(): void;
+    setFooter(factory?: (tui: { requestRender(): void }, theme: FakeTheme, provider: ReadonlyFooterDataProvider) => { dispose(): void }): void;
     setHeader(): void;
     setEditorComponent(): void;
     getEditorComponent(): undefined;
@@ -114,7 +119,7 @@ function createFakePi() {
   };
 }
 
-function createCtx(options: { cwd: string; text?: string; customInputs?: string[][] } = { cwd: process.cwd() }) {
+function createCtx(options: { cwd: string; text?: string; customInputs?: string[][]; footerData?: ReadonlyFooterDataProvider; theme?: FakeTheme } = { cwd: process.cwd() }) {
   let text = options.text ?? "";
   let terminalInput: ((data: string) => unknown) | null = null;
   const setEditorTextCalls: string[] = [];
@@ -123,9 +128,11 @@ function createCtx(options: { cwd: string; text?: string; customInputs?: string[
   const customTitles: string[] = [];
   const customInputs = [...(options.customInputs ?? [])];
   const widgets = new Map<string, { render(width: number): string[] }>();
+  let footer: { dispose(): void } | undefined;
 
   const ctx: FakeCtx = {
     cwd: options.cwd,
+    sessionManager: { getCwd: () => options.cwd },
     hasUI: true,
     model: { name: "test", provider: "test" },
     modelRegistry: {},
@@ -160,10 +167,13 @@ function createCtx(options: { cwd: string; text?: string; customInputs?: string[
       }),
       select: async () => "Insert",
       setWidget(name, factory) {
-        if (factory) widgets.set(name, factory({ requestRender() {} }, fakeTheme()));
+        if (factory) widgets.set(name, factory({ requestRender() {} }, options.theme ?? fakeTheme()));
         else widgets.delete(name);
       },
-      setFooter() {},
+      setFooter(factory) {
+        footer?.dispose();
+        footer = factory && options.footerData ? factory({ requestRender() {} }, fakeTheme(), options.footerData) : undefined;
+      },
       setHeader() {},
       setEditorComponent() {},
       getEditorComponent: () => undefined,
@@ -173,6 +183,7 @@ function createCtx(options: { cwd: string; text?: string; customInputs?: string[
   return {
     ctx,
     widgets,
+    disposeFooter: () => ctx.ui.setFooter(undefined),
     get text() { return text; },
     setEditorTextCalls,
     notifications,
@@ -184,6 +195,114 @@ function createCtx(options: { cwd: string; text?: string; customInputs?: string[
     },
   };
 }
+
+test("Git rendering reuses the cwd-owned provider only on demand and refreshes across sessions", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "powerline-git-display-"));
+  const repoA = join(root, "repo-a");
+  const repoB = join(root, "repo-b");
+  for (const [cwd, branch, host] of [[repoA, "branch-a", "github.com"], [repoB, "branch-b", "gitlab.com"]]) {
+    mkdirSync(cwd);
+    childProcess.execFileSync("git", ["init", "-q", "-b", branch], { cwd });
+    childProcess.execFileSync("git", ["remote", "add", "origin", `https://${host}/owner/repo`], { cwd });
+  }
+  writeFileSync(join(repoA, "dirty"), "untracked");
+  const oldFonts = process.env.POWERLINE_NERD_FONTS;
+  process.env.POWERLINE_NERD_FONTS = "1";
+  const { extension, restoreEnv } = await loadPowerline(root);
+  const fake = createFakePi();
+  let providerCwd = repoA;
+  let allowBranchRead = false;
+  const listeners = new Set<() => void>();
+  const footerData: ReadonlyFooterDataProvider = {
+    getGitBranch() {
+      assert.ok(allowBranchRead, "unused Git must not read Pi's branch getter");
+      return readFileSync(join(providerCwd, ".git", "HEAD"), "utf8").trim().replace("ref: refs/heads/", "");
+    },
+    getExtensionStatuses: () => new Map(),
+    getAvailableProviderCount: () => 0,
+    onBranchChange(callback) { listeners.add(callback); return () => { listeners.delete(callback); }; },
+  };
+  const spawn = childProcess.spawn;
+  const calls: Parameters<typeof spawn>[] = [];
+  t.mock.method(childProcess, "spawn", (...args: Parameters<typeof spawn>) => {
+    calls.push(args);
+    return spawn(...args);
+  });
+  syncBuiltinESMExports();
+  let runtime: ReturnType<typeof createCtx> | undefined;
+  const layout = { left: ["git"], right: [], secondary: [] };
+  const hiddenCounts = { showStaged: false, showUnstaged: false, showUntracked: false };
+  const start = async (powerline: Record<string, unknown>, cwd = repoA) => {
+    runtime?.disposeFooter();
+    // Mirror Pi's applyRuntimeSettings -> bindExtensions -> session_start ordering.
+    providerCwd = cwd;
+    writeFileSync(join(root, "settings.json"), JSON.stringify({ powerline: { welcome: false, layout, ...powerline } }));
+    runtime = createCtx({ cwd, footerData, theme: { ...fakeTheme(), fg: (color, text) => `<${color}>${text}</${color}>` } });
+    await fake.handlers.get("session_start")?.({ reason: "resume" }, runtime.ctx);
+    calls.length = 0;
+  };
+  const render = () => runtime!.widgets.get("powerline-top")!.render(240).join("\n");
+  try {
+    extension(fake.pi);
+    for (const settings of [
+      { preset: "full", layout: undefined, disabledSegments: ["git"] },
+      { layout: { left: ["model"], right: [], secondary: [] } },
+      { git: { ...hiddenCounts, showBranch: false, hostIcon: true } },
+    ]) {
+      await start(settings);
+      render();
+      await waitForGitUpdates();
+      assert.deepEqual(calls, [], "no Git process for absent, disabled, or wholly hidden Git");
+    }
+    t.diagnostic("Unused Git: provider getter forbidden; no Git subprocesses in disabled/omitted/hidden layouts");
+    allowBranchRead = true;
+    for (const polling of ["off", "branch", "full"]) {
+      await start({ git: { ...hiddenCounts, polling } });
+      assert.match(render(), /branch-a/);
+      await waitForGitUpdates();
+      assert.deepEqual(calls.map(([, args]) => args), polling === "full" ? [["status", "--porcelain"]] : []);
+      t.diagnostic(`Attached ${polling}: ${calls.map(([, args]) => args?.join(" ")).join(", ") || "no subprocesses"}`);
+    }
+    assert.match(render(), /<warning>[^<]*branch-a<\/warning>/, "full mode keeps dirty coloring with hidden counts");
+    fs.unlinkSync(join(repoA, "dirty"));
+    for (const notify of listeners) notify();
+    assert.match(render(), /<warning>[^<]*branch-a<\/warning>/, "same-cwd refresh serves stale counts");
+    await waitForGitUpdates();
+    assert.match(render(), /<success>[^<]*branch-a<\/success>/);
+    childProcess.execFileSync("git", ["symbolic-ref", "HEAD", "refs/heads/renamed-a"], { cwd: repoA });
+    for (const notify of listeners) notify();
+    assert.match(render(), /renamed-a/);
+    await waitForGitUpdates();
+    assert.match(render(), /<success>[^<]*renamed-a<\/success>/);
+
+    writeFileSync(join(repoA, "dirty"), "untracked again");
+    await start({ git: { hostIcon: true } });
+    render();
+    await waitForGitUpdates();
+    assert.ok(render().includes(NERD_ICONS.github));
+    assert.match(render(), /<warning>/);
+    await start({ git: { hostIcon: true } }, repoB);
+    const immediate = render();
+    assert.match(immediate, /branch-b/);
+    assert.doesNotMatch(immediate, /renamed-a|branch-a|<warning>/);
+    assert.ok(!immediate.includes(NERD_ICONS.github));
+    await waitForGitUpdates();
+    assert.ok(render().includes(NERD_ICONS.gitlab));
+    assert.ok(calls.every(([, , options]) => options?.cwd === repoB), "status and host reads use ctx.cwd, not ambient cwd");
+    runtime!.disposeFooter();
+    assert.equal(listeners.size, 0, "footer disposal unsubscribes branch notifications");
+  } finally {
+    await waitForGitUpdates();
+    runtime?.disposeFooter();
+    if (runtime) await fake.handlers.get("session_shutdown")?.({}, runtime.ctx);
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
+    if (oldFonts === undefined) delete process.env.POWERLINE_NERD_FONTS;
+    else process.env.POWERLINE_NERD_FONTS = oldFonts;
+    restoreEnv();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("footer queue demand follows resolved layout while preview and picker stay independent", async () => {
   for (const powerline of [


### PR DESCRIPTION
## Summary
- Scope branch, status, remote-host data and pending reads to the active cwd. Old repository results cannot appear after a session switch.
- Reuse Pi's cwd-owned attached branch and skip collection when the resolved layout has no visible Git consumer.
- Preserve explicit polling modes, dirty branch coloring with hidden counts, same-cwd refresh behavior, and detached/unavailable-provider fallback.
- Use existing notifications and subscriptions; no new watchers or timers.

Thanks to [@lengxf](https://github.com/lengxf) for reporting #194. Linked credit is included in the changelog.

## Validation
- 20 focused Git/module/caller tests and typecheck passed with locked Pi 0.84.1.
- Public tests cover cwd transitions, old in-flight results, remote icons, modes, dirty coloring and unused layouts.
- Process-boundary diagnostics: attached branch/off modes launch no Git subprocesses with host icons disabled; full mode launches status only. These are Powerline diagnostics, not whole-Pi latency claims.
- Retained-writer deletion pass, simplification and fresh read-only review completed; no remaining findings. Parent verified the final seven-file diff and clean candidate.
- Full Ubuntu/Windows suite is required on the published head before merge. No live interactive runtime smoke was run; provider ownership was checked against locked Pi lifecycle source.

Closes #194.
Closes #201.
