### PR TITLE
fix: deliver queued prompts after compaction becomes idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 - **Compact prompt mode** — Added `powerline.queue.compactPromptMode: "native"` so `/compact <text>` can pass `<text>` through to Pi as custom compaction instructions instead of using Powerline's post-compaction queue shorthand. Thanks to [@joshuajbrunner](https://github.com/joshuajbrunner) for #191.
 
 ### Changed
+- **Pi compatibility** — Remove the Pi peer-dependency upper bounds while retaining the `>=0.81.0` minimum.
 - **Git collection** — Reuse Pi's attached branch and collect status only for configured Git consumers, preserving explicit polling modes and dirty branch coloring (#201).
 - **Welcome startup** — Discover recent sessions asynchronously with bounded header reads, cancelling pending discovery when welcome is dismissed or the session changes. Fixes #199.
 - **Queue display reads** — Reuse unchanged inbox snapshots and skip footer queue summaries when the resolved layout omits or disables the queue segment (#200). Queue previews and explicit queue actions remain independent.
 - **Powerline placement** — Clarified that the primary Powerline row can be shown above or below the editor. Thanks to [@smileBeda](https://github.com/smileBeda) for #188.
 
 ### Fixed
+- **Post-compaction queue readiness** — Keep captured prompts queued until Pi reports idle after successful compaction, including manual completion without an agent-settled event and overflow retries (#198). Cancel pending delivery on failure or session teardown; external failure notifications require Pi 0.84.3 or newer.
 - **Git session freshness** — Keep branch, status, and remote-host icons scoped to the current session cwd, refreshing on session and branch changes (#194). Thanks to [@lengxf](https://github.com/lengxf) for the report.
 - **Terminal-name heuristic** — Fall back to `TERM` only when `TERM_PROGRAM` is unset when inferring Nerd Font support. Thanks to [@a5ehren](https://github.com/a5ehren) for #192/#195.
 - **Live thinking-level display** — Prefer the authoritative thinking-level selection event over a stale session-start context so the footer updates from `think:off` to the selected level. Thanks to [@csp256](https://github.com/csp256) for #196.

--- a/index.ts
+++ b/index.ts
@@ -1209,7 +1209,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     summary: QueueSummary;
   } | null = null;
   let powerlineCompacting = false;
-  let deliverAfterRetrySettles = false;
+  let compactionGeneration = 0;
+  let postCompactionDelivery: { generation: number; context: QueueContext } | null = null;
   let queueDeliveryTimer: ReturnType<typeof setTimeout> | null = null;
   const pendingQueueDeliveries = new Map<string, { text: string; timer: ReturnType<typeof setTimeout> }>();
 
@@ -1591,18 +1592,39 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
   }
 
-  function schedulePostCompactionDelivery(ctx: any): void {
+  function cancelPostCompactionDelivery(): void {
     if (queueDeliveryTimer) clearTimeout(queueDeliveryTimer);
-    const queueContext = getQueueContext(ctx);
-    const scheduledGeneration = sessionGeneration;
+    queueDeliveryTimer = null;
+    postCompactionDelivery = null;
+  }
+
+  function schedulePostCompactionDelivery(): void {
+    if (!postCompactionDelivery) return;
+    if (queueDeliveryTimer) clearTimeout(queueDeliveryTimer);
+    const pending = postCompactionDelivery;
     queueDeliveryTimer = setTimeout(() => {
       queueDeliveryTimer = null;
-      if (scheduledGeneration !== sessionGeneration) return;
+      if (pending !== postCompactionDelivery) return;
+      if (pending.generation !== sessionGeneration || !currentCtx) {
+        cancelPostCompactionDelivery();
+        return;
+      }
       try {
-        const item = queueStore.queuedDeliveryItems(queueContext, "post-compact")[0];
-        if (item) deliverQueueItem(ctx, item);
+        // Busy readiness checks must not read the inbox, render, or enqueue a late follow-up.
+        if (!currentCtx.isIdle()) {
+          schedulePostCompactionDelivery();
+          return;
+        }
+        const item = queueStore.queuedDeliveryItems(pending.context, "post-compact")[0];
+        if (!item) {
+          cancelPostCompactionDelivery();
+          return;
+        }
+        deliverQueueItem(currentCtx, item);
+        schedulePostCompactionDelivery();
       } catch (error) {
         if (!isStaleExtensionContextError(error)) throw error;
+        cancelPostCompactionDelivery();
         currentCtx = null;
       }
     }, 50);
@@ -1620,8 +1642,9 @@ export default function powerlineFooter(pi: ExtensionAPI) {
   }
 
   function finishFailedCompaction(ctx: any, errorMessage: string): void {
+    compactionGeneration++;
     powerlineCompacting = false;
-    deliverAfterRetrySettles = false;
+    cancelPostCompactionDelivery();
     blockPostCompactionQueue(ctx, errorMessage);
     requestQueueRender();
   }
@@ -1726,7 +1749,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     liveAssistantUsage = null;
     approximateContextUsage = event.reason === "reload" ? estimateUnknownContextUsage(ctx) : null;
     powerlineCompacting = false;
-    deliverAfterRetrySettles = false;
+    cancelPostCompactionDelivery();
     stashedEditorText = null;
 
     const settings = readSettings(ctx.cwd);
@@ -1776,13 +1799,9 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     stashShortcutInputUnsubscribe = null;
     shellSession?.dispose();
     shellSession = null;
-    if (queueDeliveryTimer) {
-      clearTimeout(queueDeliveryTimer);
-      queueDeliveryTimer = null;
-    }
+    cancelPostCompactionDelivery();
     requeuePendingQueueDeliveries("Session ended before queued message started");
     powerlineCompacting = false;
-    deliverAfterRetrySettles = false;
     bashModeActive = false;
     currentCtx = null;
     footerDataRef = null;
@@ -1920,6 +1939,8 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     liveAssistantUsage = null;
     approximateContextUsage = null;
     coreContextUsageCache.reset();
+    compactionGeneration++;
+    cancelPostCompactionDelivery();
     requestQueueRender();
   });
 
@@ -1930,20 +1951,22 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     liveAssistantUsage = null;
     approximateContextUsage = estimateUnknownContextUsage(ctx);
     coreContextUsageCache.reset();
-    if (event.willRetry) {
-      deliverAfterRetrySettles = true;
-    } else {
-      deliverAfterRetrySettles = false;
-      schedulePostCompactionDelivery(ctx);
+    compactionGeneration++;
+    cancelPostCompactionDelivery();
+    const context = getQueueContext(ctx);
+    if (queueStore.queuedDeliveryItems(context, "post-compact").length > 0) {
+      postCompactionDelivery = { generation: sessionGeneration, context };
+      schedulePostCompactionDelivery();
     }
     requestQueueRender();
   });
 
-  pi.on("agent_settled", async (_event, ctx) => {
-    if (deliverAfterRetrySettles) {
-      deliverAfterRetrySettles = false;
-      schedulePostCompactionDelivery(ctx);
-    }
+  pi.on("session_compact_failed", async (event, ctx) => {
+    finishFailedCompaction(ctx, event.errorMessage ?? "Compaction cancelled");
+  });
+
+  pi.on("agent_settled", async () => {
+    schedulePostCompactionDelivery();
   });
 
   // Also dismiss on tool calls (agent is working) + refresh vibe if rate limit allows
@@ -2272,9 +2295,7 @@ export default function powerlineFooter(pi: ExtensionAPI) {
     }
 
     requestStatusRender();
-    if (!powerlineCompacting && !deliverAfterRetrySettles) {
-      schedulePostCompactionDelivery(ctx);
-    }
+    schedulePostCompactionDelivery();
   });
 
   registerCdCommand(pi, () => currentCtx?.cwd ?? process.cwd());
@@ -3116,10 +3137,14 @@ export default function powerlineFooter(pi: ExtensionAPI) {
               capturePostCompactPrompt(ctx, compactQueuedPrompt);
             }
             powerlineCompacting = true;
-            deliverAfterRetrySettles = false;
+            cancelPostCompactionDelivery();
+            const generation = sessionGeneration;
+            const operation = ++compactionGeneration;
             requestQueueRender();
             ctx.compact({
               onError: (error: Error) => {
+                // Preparation can fail before session_before_compact increments the operation.
+                if (generation !== sessionGeneration || compactionGeneration > operation + 1 || !powerlineCompacting) return;
                 finishFailedCompaction(ctx, error.message);
                 ctx.ui.notify(error.message, "error");
               },

--- a/index.ts
+++ b/index.ts
@@ -1615,11 +1615,10 @@ export default function powerlineFooter(pi: ExtensionAPI) {
           schedulePostCompactionDelivery();
           return;
         }
-        const item = queueStore.queuedDeliveryItems(pending.context, "post-compact")[0];
-        if (!item) {
-          cancelPostCompactionDelivery();
-          return;
-        }
+        const items = queueStore.queuedDeliveryItems(pending.context, "post-compact");
+        const item = items[0];
+        if (items.length <= 1) cancelPostCompactionDelivery();
+        if (!item) return;
         deliverQueueItem(currentCtx, item);
         schedulePostCompactionDelivery();
       } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-coding-agent": "^0.84.1",
-        "@earendil-works/pi-tui": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.84.4",
+        "@earendil-works/pi-coding-agent": "^0.84.4",
+        "@earendil-works/pi-tui": "^0.84.4",
         "@types/node": "24.13.3",
         "typescript": "5.9.3"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": ">=0.81.0 <0.85.0",
-        "@earendil-works/pi-coding-agent": ">=0.81.0 <0.85.0",
-        "@earendil-works/pi-tui": ">=0.81.0 <0.85.0"
+        "@earendil-works/pi-ai": ">=0.81.0",
+        "@earendil-works/pi-coding-agent": ">=0.81.0",
+        "@earendil-works/pi-tui": ">=0.81.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -508,22 +508,20 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
-      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.4.tgz",
+      "integrity": "sha512-AClAZxf5+c4RRu44NJPS6wyQy+Nmq+Mzyyrdvm4ZVMNuixelO02RZX4G4Aq1F145Yzp43wnM5S+hLlSI7ypfVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.84.4",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -535,23 +533,22 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.1.tgz",
-      "integrity": "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.4.tgz",
+      "integrity": "sha512-jmOlrqUmvhh/siNWFRXjYLJzhKFIHNsAQaysRwzQPQFnPAaV/vhqHsLH/MBsIISA1Rjj7WTUFR3nJrpXoLx39w==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.84.1",
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-client": "^0.84.1",
-        "@earendil-works/pi-protocol": "^0.84.1",
-        "@earendil-works/pi-tui": "^0.84.1",
+        "@earendil-works/pi-agent-core": "^0.84.4",
+        "@earendil-works/pi-ai": "^0.84.4",
+        "@earendil-works/pi-client": "^0.84.4",
+        "@earendil-works/pi-protocol": "^0.84.4",
+        "@earendil-works/pi-tui": "^0.84.4",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
         "diff": "8.0.4",
-        "glob": "13.0.6",
         "grok-mermaid": "0.2.2",
         "highlight.js": "10.7.3",
         "hosted-git-info": "9.0.3",
@@ -565,7 +562,7 @@
         "yaml": "2.9.0"
       },
       "bin": {
-        "pi": "dist/cli.js"
+        "pi": "dist/bundle/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1037,13 +1034,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.84.4",
+        "@earendil-works/pi-telemetry": "^0.84.4",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -1054,21 +1051,19 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.84.4",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -1080,20 +1075,20 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-protocol": "^0.84.1"
+        "@earendil-works/pi-protocol": "^0.84.4"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1104,8 +1099,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.4.tgz",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1113,8 +1108,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.4.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1340,27 +1335,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -1373,26 +1347,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1886,24 +1840,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
       "version": "10.6.2",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
@@ -2120,16 +2056,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2178,14 +2104,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -2251,23 +2174,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
@@ -2521,30 +2427,10 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
-      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.4.tgz",
+      "integrity": "sha512-8e2CuxM+ht+hedQXTZmi5JVl6/xDK9RpSDL2+MbITevKYQhMZ/z6lJOTFgox3HQyGxO8mOZEtYGVeQNaD4OzqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2552,9 +2438,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
-      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.4.tgz",
+      "integrity": "sha512-nPUnwDkLtupPXnZQYrCwPFcuTydCDqTY6ZbFqhsL4S4kVq0AT418kPa/6uXwtaCD+MjBNBltb7ScTYX65yeE1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2586,47 +2472,6 @@
         "@modelcontextprotocol/sdk": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.42.0.tgz",
-      "integrity": "sha512-icc5xCzndZfhuJMy5oqk5AvloWquR7jtae74qzpkKkhGp8BivK+oCcEXgGnjCdTfp8hA44l+w8gE8yYJbocJJw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -3130,12 +2975,11 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.26.0",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -3268,6 +3112,7 @@
       "version": "8.20.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3282,24 +3127,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.4.3",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "test": "node --experimental-strip-types --test tests/**/*.test.ts"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": ">=0.81.0 <0.85.0",
-    "@earendil-works/pi-coding-agent": ">=0.81.0 <0.85.0",
-    "@earendil-works/pi-tui": ">=0.81.0 <0.85.0"
+    "@earendil-works/pi-ai": ">=0.81.0",
+    "@earendil-works/pi-coding-agent": ">=0.81.0",
+    "@earendil-works/pi-tui": ">=0.81.0"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.84.1",
-    "@earendil-works/pi-coding-agent": "^0.84.1",
-    "@earendil-works/pi-tui": "^0.84.1",
+    "@earendil-works/pi-ai": "^0.84.4",
+    "@earendil-works/pi-coding-agent": "^0.84.4",
+    "@earendil-works/pi-tui": "^0.84.4",
     "@types/node": "24.13.3",
     "typescript": "5.9.3"
   },

--- a/tests/bash-mode.test.ts
+++ b/tests/bash-mode.test.ts
@@ -1693,7 +1693,7 @@ test("bash editor runs copied Pi app action handlers for alt-enter", async () =>
     const { KeybindingsManager } = await import(new URL("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js", import.meta.url).href);
     const { setKittyProtocolActive } = await import(resolvePiTuiModuleUrl("dist/keys.js"));
     // Avoid loading user-level keybindings.json in this test.
-    const keybindings = new KeybindingsManager();
+    const keybindings = new KeybindingsManager({ "app.message.followUp": "alt+enter" });
     const editor = new BashModeEditor(
       { requestRender() {}, terminal: { columns: 80, rows: 24 } },
       {},

--- a/tests/post-compaction-queue.test.ts
+++ b/tests/post-compaction-queue.test.ts
@@ -40,6 +40,7 @@ async function readinessHarness(t) {
       assert.equal(options, undefined, "never leave a late Pi follow-up");
       sends.push(text);
       void emit("before_agent_start", { prompt: text });
+      idle = false;
     },
   });
   await emit("session_start", { reason: "new" });
@@ -53,11 +54,12 @@ async function readinessHarness(t) {
     else process.env.PI_CODING_AGENT_DIR = previous;
     rmSync(root, { recursive: true, force: true });
   });
-  return { emit, store, item, sends, setIdle: () => { idle = true; }, tick: async () => { t.mock.timers.tick(1000); await setImmediate(); } };
+  return { ctx, emit, store, item, sends, setIdle: () => { idle = true; }, tick: async () => { t.mock.timers.tick(1000); await setImmediate(); } };
 }
 
 test("successful retry keeps readiness through busy settlement without inbox I/O", async (t) => {
   const h = await readinessHarness(t);
+  const second = h.store.add({ ...h.item, text: "last queued prompt", now: h.item.createdAt + 1 });
   await h.emit("session_before_compact");
   await h.emit("session_compact", { willRetry: true });
   // Reject filesystem access, rather than counting private queue/cache calls.
@@ -84,6 +86,14 @@ test("successful retry keeps readiness through busy settlement without inbox I/O
   await h.tick();
   assert.deepEqual(h.sends, ["after retry"]);
   assert.equal(h.store.get(h.item.id)?.status, "sent");
+  assert.equal(h.store.get(second.id)?.status, "queued");
+  h.setIdle();
+  await h.tick();
+  assert.deepEqual(h.sends, ["after retry", "last queued prompt"]);
+  assert.equal(h.store.get(second.id)?.status, "sent");
+  t.mock.method(h.ctx, "isIdle", () => assert.fail("no readiness polling after the last queued item"));
+  await h.emit("agent_settled");
+  await h.tick();
 });
 
 test("new compaction cancellation and session replacement retire pending readiness", async (t) => {

--- a/tests/post-compaction-queue.test.ts
+++ b/tests/post-compaction-queue.test.ts
@@ -1,0 +1,220 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { setImmediate } from "node:timers/promises";
+import { PowerlineQueueStore } from "../queue/store.ts";
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+
+// Run against a supported real SDK, not a fabricated compaction lifecycle.
+// PI_COMPACTION_SDK=/path/to/pi-coding-agent/dist/index.js node --experimental-strip-types --test tests/post-compaction-queue.test.ts
+const sdkPath = process.env.PI_COMPACTION_SDK;
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => { resolve = done; });
+  return { promise, resolve };
+};
+
+async function readinessHarness(t) {
+  const root = mkdtempSync(join(tmpdir(), "powerline-readiness-"));
+  const previous = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = root;
+  writeFileSync(join(root, "settings.json"), JSON.stringify({ powerline: { welcome: false } }));
+  const { default: powerline } = await import("../index.ts");
+  const handlers = new Map();
+  const sends: string[] = [];
+  let idle = false;
+  const ctx = {
+    cwd: root, hasUI: false, isIdle: () => idle,
+    sessionManager: { getSessionId: () => "readiness", getBranch: () => [] },
+    ui: { notify() {}, setWorkingMessage() {}, setWidget() {}, setHeader() {} },
+  };
+  const emit = async (name, event = {}) => { await handlers.get(name)?.(event, ctx); };
+  powerline({
+    on: (name, handler) => handlers.set(name, handler), registerCommand() {},
+    sendUserMessage(text, options) {
+      assert.equal(idle, true, "never send while busy");
+      assert.equal(options, undefined, "never leave a late Pi follow-up");
+      sends.push(text);
+      void emit("before_agent_start", { prompt: text });
+    },
+  });
+  await emit("session_start", { reason: "new" });
+  const store = new PowerlineQueueStore();
+  const item = store.add({ text: "after retry", intent: "post-compact", source: { cwd: root, sessionId: "readiness" }, target: { kind: "current-session" } });
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  t.after(async () => {
+    await emit("session_shutdown", { reason: "quit" });
+    t.mock.timers.reset();
+    if (previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previous;
+    rmSync(root, { recursive: true, force: true });
+  });
+  return { emit, store, item, sends, setIdle: () => { idle = true; }, tick: async () => { t.mock.timers.tick(1000); await setImmediate(); } };
+}
+
+test("successful retry keeps readiness through busy settlement without inbox I/O", async (t) => {
+  const h = await readinessHarness(t);
+  await h.emit("session_before_compact");
+  await h.emit("session_compact", { willRetry: true });
+  // Reject filesystem access, rather than counting private queue/cache calls.
+  const read = fs.readFileSync;
+  const stat = fs.statSync;
+  const rejectInbox = (original) => (path, ...args) => {
+    assert.ok(!String(path).endsWith("inbox.jsonl"), "busy readiness must not inspect the inbox");
+    return original(path, ...args);
+  };
+  const readMock = t.mock.method(fs, "readFileSync", rejectInbox(read));
+  const statMock = t.mock.method(fs, "statSync", rejectInbox(stat));
+  syncBuiltinESMExports();
+  try {
+    await h.tick();
+    await h.emit("agent_settled");
+    await h.tick();
+    assert.deepEqual(h.sends, []);
+  } finally {
+    readMock.mock.restore(); statMock.mock.restore(); syncBuiltinESMExports();
+  }
+  assert.equal(h.store.get(h.item.id)?.status, "queued");
+  h.setIdle();
+  await h.tick();
+  await h.tick();
+  assert.deepEqual(h.sends, ["after retry"]);
+  assert.equal(h.store.get(h.item.id)?.status, "sent");
+});
+
+test("new compaction cancellation and session replacement retire pending readiness", async (t) => {
+  const h = await readinessHarness(t);
+  await h.emit("session_before_compact");
+  await h.emit("session_compact", { willRetry: false });
+  await h.emit("session_before_compact");
+  await h.emit("session_compact_failed", { aborted: true });
+  await h.emit("session_compact_failed", { aborted: true });
+  h.setIdle();
+  await h.tick();
+  assert.deepEqual(h.sends, []);
+  assert.equal(h.store.get(h.item.id)?.status, "blocked");
+  h.store.update(h.item.id, { status: "queued" });
+  await h.emit("session_compact", { willRetry: false });
+  await h.emit("session_shutdown", { reason: "reload" });
+  await h.emit("session_start", { reason: "reload" });
+  await h.emit("agent_settled");
+  await h.tick();
+  assert.deepEqual(h.sends, []);
+  assert.equal(h.store.get(h.item.id)?.status, "queued");
+});
+
+test("reload -> editor /compact -> captured prompt starts after delayed manual completion without agent_settled", { skip: !sdkPath, timeout: 10000 }, async (t) => {
+  const sdk = await import(pathToFileURL(sdkPath!).href);
+  const { KeybindingsManager } = await import("../node_modules/@earendil-works/pi-coding-agent/dist/core/keybindings.js");
+  const root = mkdtempSync(join(tmpdir(), "powerline-compaction-"));
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = root;
+  writeFileSync(join(root, "settings.json"), JSON.stringify({ powerline: { welcome: false }, compaction: { enabled: false, keepRecentTokens: 1 } }));
+  const { default: powerline } = await import("../index.ts");
+  const before = deferred();
+  const summarize = deferred();
+  const dispatched = deferred();
+  const finishDispatch = deferred();
+  const completed = deferred();
+  const starts: string[] = [];
+  let settlements = 0;
+  let editor;
+  const settingsManager = sdk.SettingsManager.create(root, root);
+  const loader = new sdk.DefaultResourceLoader({
+    cwd: root, agentDir: root, settingsManager,
+    noExtensions: true, noSkills: true, noPromptTemplates: true, noThemes: true, noContextFiles: true,
+    extensionFactories: [powerline, (pi) => {
+      pi.on("session_before_compact", async (event) => {
+        before.resolve();
+        await summarize.promise;
+        return { compaction: { summary: "Summary", firstKeptEntryId: event.preparation.firstKeptEntryId, tokensBefore: 100 } };
+      });
+      pi.on("session_compact", async () => {
+        dispatched.resolve();
+        await finishDispatch.promise;
+      });
+      pi.on("before_agent_start", (event) => { starts.push(event.prompt); });
+      pi.on("agent_settled", () => { settlements++; });
+    }],
+  });
+  let session;
+  try {
+    await loader.reload();
+    const manager = sdk.SessionManager.inMemory(root);
+    manager.appendMessage({ role: "user", content: "Earlier request", timestamp: Date.now() });
+    manager.appendMessage({ role: "assistant", content: [{ type: "text", text: "Earlier answer" }], api: "openai-completions", provider: "test", model: "test", usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }, stopReason: "stop", timestamp: Date.now() });
+    manager.appendMessage({ role: "user", content: "Latest request", timestamp: Date.now() });
+    const modelRuntime = await sdk.ModelRuntime.create({ authPath: join(root, "auth.json"), modelsPath: null });
+    await modelRuntime.setRuntimeApiKey("openai", "test-key");
+    const model = modelRuntime.getModels("openai")[0];
+    assert.ok(model, "runtime has built-in OpenAI model");
+    ({ session } = await sdk.createAgentSession({ cwd: root, agentDir: root, settingsManager, resourceLoader: loader, sessionManager: manager, modelRuntime, model, tools: [] }));
+    // No provider requests: compaction comes from the supported custom-summary hook;
+    // delivery is acknowledged at before_agent_start, before this local stream error.
+    session.agent.streamFunction = () => { throw new Error("probe: no network"); };
+    const tui = { requestRender() {}, terminal: { columns: 80, rows: 24 }, setFocus() {}, hasOverlay: () => false };
+    const theme = { borderColor: (s) => s, selectList: { selectedPrefix: (s) => s, selectedText: (s) => s, description: (s) => s, scrollInfo: (s) => s, noMatch: (s) => s } };
+    const ui = new Proxy({
+      theme: { fg: (_color, s) => s, bg: (_color, s) => s, bold: (s) => s },
+      setEditorComponent(factory) { if (factory) editor = factory(tui, theme, KeybindingsManager.create(root)); },
+      getEditorComponent: () => undefined,
+      onTerminalInput: () => () => {},
+      setStatus() {}, notify(message) { t.diagnostic(message); }, setWorkingMessage() {}, setWidget() {}, setFooter() {}, setHeader() {},
+      custom: async () => undefined, select: async () => undefined,
+    }, { get: (target, key) => key in target ? target[key] : () => {} });
+    await session.bindExtensions({ uiContext: ui, onError: (error) => { throw new Error(JSON.stringify(error)); } });
+    await session.reload();
+    assert.ok(editor, "reload installs the real Powerline editor");
+    session.subscribe((event) => { if (event.type === "compaction_end") completed.resolve(); });
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    editor.setText("/compact");
+    editor.handleInput("\r");
+    await before.promise;
+    editor.setText("run after manual compaction");
+    editor.handleInput("\r");
+    const store = new PowerlineQueueStore(join(root, "powerline-footer", "inbox.jsonl"), join(root, "powerline-footer", "projects.json"));
+    const context = { cwd: root, sessionId: manager.getSessionId() };
+    assert.equal(store.queuedDeliveryItems(context, "post-compact").length, 1);
+    summarize.resolve();
+    await dispatched.promise;
+    t.diagnostic(`during dispatch: idle=${session.isIdle}, queued=${store.queuedDeliveryItems(context, "post-compact").length}, pending=${session.pendingMessageCount}`);
+    // 0.84.4 reports manual dispatch idle; 0.85.0 includes compaction in isIdle.
+    const busyDispatch = !session.isIdle;
+    // Preserve the older-runtime held-dispatch failure as an explicit probe mode.
+    // Normal 0.84.4 success releases dispatch before the delivery timer runs.
+    if (busyDispatch || process.env.PI_COMPACTION_HOLD_IDLE_DISPATCH === "1") {
+      t.mock.timers.tick(1000);
+      if (busyDispatch) assert.deepEqual(starts, [], "must not enqueue into busy manual dispatch");
+      else await setImmediate();
+    }
+    assert.equal(session.pendingMessageCount, 0);
+    finishDispatch.resolve();
+    await completed.promise;
+    assert.equal(session.isIdle, true);
+    if (busyDispatch) assert.equal(settlements, 0, "manual completion provides no agent_settled wakeup");
+    t.mock.timers.tick(1000);
+    await setImmediate();
+    t.diagnostic(`after completion: idle=${session.isIdle}, status=${store.list()[0]?.status}, pending=${session.pendingMessageCount}, starts=${starts.length}, settlements=${settlements}`);
+    assert.deepEqual(starts, ["run after manual compaction"], "must start without another user action or watchdog");
+    assert.equal(store.list().find((item) => item.text === "run after manual compaction")?.status, "sent");
+    assert.equal(session.pendingMessageCount, 0);
+    t.mock.timers.tick(1000);
+    await setImmediate();
+    assert.deepEqual(starts, ["run after manual compaction"], "readiness must retire after acknowledgement");
+  } finally {
+    summarize.resolve();
+    finishDispatch.resolve();
+    if (session) {
+      await session.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+      session.dispose();
+    }
+    t.mock.timers.reset();
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/remaining-regressions.test.ts
+++ b/tests/remaining-regressions.test.ts
@@ -170,21 +170,12 @@ test("stale ctx guard handles old and new Pi messages on agent_end", () => {
   assert.match(source, /if \(!isStaleExtensionContextError\(error\)\) throw error;\r?\n\s+currentCtx = null;\r?\n\s+return;/);
 });
 
-test("post-compaction queue delivery does not read ctx.cwd from the delayed callback", () => {
-  assert.match(source, /const queueContext = getQueueContext\(ctx\);\r?\n\s+const scheduledGeneration = sessionGeneration;\r?\n\s+queueDeliveryTimer = setTimeout/);
-  assert.match(source, /if \(scheduledGeneration !== sessionGeneration\) return;\r?\n\s+try \{\r?\n\s+const item = queueStore\.queuedDeliveryItems\(queueContext, "post-compact"\)\[0\];/);
-  assert.match(source, /catch \(error\) \{\r?\n\s+if \(!isStaleExtensionContextError\(error\)\) throw error;\r?\n\s+currentCtx = null;/);
+test("queue delivery tracks acknowledgement and requeues unstarted messages on shutdown", () => {
   assert.match(source, /trackPendingQueueDelivery\(item, deliveryText\);\r?\n\s+if \(deliverAs\) \{/);
   assert.match(source, /function requeuePendingQueueDeliveries\(error: string\): void \{/);
   assert.match(source, /requeuePendingQueueDeliveries\("Session ended before queued message started"\);/);
   assert.match(source, /finishPendingQueueDelivery\(event\.prompt, ctx\);/);
   assert.match(source, /finishPendingQueueDelivery\(getPromptHistoryText\(message\.content\), ctx\);/);
-});
-
-test("agent settlement does not fail a compaction that has not emitted session_compact", () => {
-  assert.doesNotMatch(source, /pi\.on\("agent_settled", async \(_event, ctx\) => \{\r?\n\s+if \(powerlineCompacting\)/);
-  assert.match(source, /pi\.on\("session_compact", async \(event, ctx\) => \{[\s\S]*?schedulePostCompactionDelivery\(ctx\);/);
-  assert.match(source, /onError: \(error: Error\) => \{\r?\n\s+finishFailedCompaction\(ctx, error\.message\);/);
 });
 
 test("editor-adjacent widgets cache queue and last-prompt work", () => {


### PR DESCRIPTION
## Summary

Fixes #198.

- Keep one cancellable delivery check after successful compaction while eligible prompts await Pi's idle state. Manual completion no longer depends on `agent_settled`.
- Busy checks do no inbox reads, rendering, or sending. Retire the check before sending the last item; preserve ordered multi-item delivery and acknowledgement.
- Cancel on new compaction, failure, stale context, and session teardown. Retain guarded owned-compaction error callbacks.
- Keep Pi peers at `>=0.81.0` without upper bounds. Align development declarations/lockfile to 0.84.4 for typed failure events.

## Validation

- Full local suite: 223 passed, one explicit opt-in SDK test skipped; typecheck, diff check, and package dry-run passed.
- Actual Pi 0.85 reload → editor `/compact` → captured prompt: exactly one start, `sent` acknowledgement, no residual Pi message, and no manual settlement wakeup. The same probe fails against the original candidate.
- Real Pi 0.84.4 ordinary success passes. Focused regressions cover busy retry, cancellation, session replacement, two-item draining, and final-check retirement.
- Retained-writer cleanup and fresh independent review completed on `079abe95`; no blockers.

## Existing runtime limits

Pi 0.84.4 can report idle during a held `session_compact` handler while rejecting prompts until dispatch finishes. This predates the change; its failing probe remains available through `PI_COMPACTION_HOLD_IDLE_DISPATCH=1`. External failure notifications require Pi 0.84.3 or newer. No version-specific workaround, Pi core change, or synthetic continuation is introduced.
